### PR TITLE
Fix typo in OnlinePlayers JSON

### DIFF
--- a/html/api.json
+++ b/html/api.json
@@ -141,7 +141,7 @@
 							"$ref": "#/components/schemas/OnlinePlayer"
 						}
 					},
-					"private_chanel": {
+					"private_channel": {
 						"type": "array",
 						"description": "All players online in the private channel",
 						"items": {

--- a/src/Modules/ONLINE_MODULE/OnlinePlayers.php
+++ b/src/Modules/ONLINE_MODULE/OnlinePlayers.php
@@ -19,5 +19,5 @@ class OnlinePlayers {
 	 * All players online in the private channel
 	 * @var OnlinePlayer[]
 	 */
-	public array $private_chanel = [];
+	public array $private_channel = [];
 }


### PR DESCRIPTION
This fixes a typo that led to wrong API specifications and duplicate JSON keys being sent in the API response for the online list.