### PR TITLE
Fix Discord module and update to API v8

### DIFF
--- a/src/Core/Modules/DISCORD/DiscordAPIClient.php
+++ b/src/Core/Modules/DISCORD/DiscordAPIClient.php
@@ -31,7 +31,7 @@ class DiscordAPIClient {
 	protected $guildMemberCache = [];
 	protected $userCache = [];
 
-	public const DISCORD_API = "https://discord.com/api";
+	public const DISCORD_API = "https://discord.com/api/v8";
 
 	public function get(string $uri): AsyncHttp {
 		$botToken = $this->settingManager->getString('discord_bot_token');

--- a/src/Core/WebsocketCallback.php
+++ b/src/Core/WebsocketCallback.php
@@ -3,7 +3,7 @@
 namespace Nadybot\Core;
 
 class WebsocketCallback {
-	public WebsocketServer $websocket;
+	public WebsocketBase $websocket;
 	public string $eventName;
 	public ?string $data = null;
 	public ?int $code = null;

--- a/src/Core/WebsocketClient.php
+++ b/src/Core/WebsocketClient.php
@@ -233,6 +233,7 @@ class WebsocketClient extends WebsocketBase {
 			return false;
 		}
 		$this->logger->log("DEBUG", "connection upgraded to websocket on {$this->uri}");
+		unset($this->notifier);
 		$this->listenForRead();
 		$event = $this->getEvent("connect");
 		$this->fireEvent(static::ON_CONNECT, $event);

--- a/src/Modules/DISCORD_GATEWAY_MODULE/DiscordGatewayCommandHandler.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/DiscordGatewayCommandHandler.php
@@ -237,7 +237,7 @@ class DiscordGatewayCommandHandler {
 		Registry::injectDependencies($sendto);
 		$discordUserId = $event->discord_message->author->id;
 		$this->commandManager->process(
-			"priv",
+			"msg",
 			$event->message,
 			$this->getNameForDiscordId($discordUserId) ?? $discordUserId,
 			$sendto

--- a/src/Modules/DISCORD_GATEWAY_MODULE/DiscordGatewayController.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/DiscordGatewayController.php
@@ -161,7 +161,7 @@ class DiscordGatewayController {
 			return;
 		}
 		$this->client = $this->websocket->createClient()
-			->withURI("wss://gateway.discord.gg/?v=7&encoding=json")
+			->withURI("wss://gateway.discord.gg/?v=8&encoding=json")
 			->withTimeout(30)
 			->on(WebsocketClient::ON_CLOSE, [$this, "processWebsocketClose"])
 			->on(WebsocketClient::ON_TEXT, [$this, "processWebsocketMessage"])
@@ -267,9 +267,11 @@ class DiscordGatewayController {
 		if ($payload->t === null) {
 			return;
 		}
-		$event->type = strtolower("discord({$payload->t})");
+		$newEvent = new DiscordGatewayEvent();
+		$newEvent->payload = $payload;
+		$newEvent->type = strtolower("discord({$payload->t})");
 		$this->logger->log("DEBUG", "New event: discord({$payload->t})");
-		$this->eventManager->fireEvent($event);
+		$this->eventManager->fireEvent($newEvent);
 	}
 
 	/**

--- a/src/Modules/DISCORD_GATEWAY_MODULE/Model/Guild.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/Model/Guild.php
@@ -31,10 +31,6 @@ class Guild extends JSONDataModel {
 	public ?string $afk_channel_id;
 	/** afk timeout in seconds */
 	public int $afk_timeout;
-	/** true if the server widget is enabled (deprecated, replaced with widget_enabled) */
-	public bool $embed_enabled;
-	/** the channel id that the widget will generate an invite to, or null if set to no invite (deprecated, replaced with widget_channel_id) */
-	public ?string $embed_channel_id;
 	/** verification level required for the guild */
 	public int $verification_level;
 	/** default message notifications level */

--- a/src/Modules/DISCORD_GATEWAY_MODULE/Model/Role.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/Model/Role.php
@@ -12,10 +12,8 @@ class Role extends JSONDataModel {
 	/** if this role is pinned in the user listing */
 	public bool $hoist;
 	public int $position;
-	/** legacy permission bit set */
-	public int $permissions;
 	/** permission bit set */
-	public string $permissions_new;
+	public int $permissions;
 	/** whether this role is managed by an integration */
 	public bool $managed;
 	/** whether this role is mentionable */

--- a/src/Modules/DISCORD_GATEWAY_MODULE/Model/UpdateStatus.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/Model/UpdateStatus.php
@@ -10,17 +10,22 @@ class UpdateStatus extends JSONDataModel {
 	public const STATUS_IDLE = "idle";
 	public const STATUS_INVISIBLE = "invisible";
 	public const STATUS_OFFLINE = "offline";
-	
+
 	/**
 	 * unix time (in milliseconds) of when the client went idle,
 	 * or null if the client is not idle
 	 */
 	public ?int $since;
-	public ?Activity $game;
+	/**
+	 * list of activities the client is playing
+	 * @var Activity[]
+	 */
+	public ?array $activities;
 	public string $status = self::STATUS_ONLINE;
 	public bool $afk = false;
 
 	public function __construct() {
-		$this->game = new Activity();
+		$activity = new Activity();
+		$this->activities = [$activity];
 	}
 }


### PR DESCRIPTION
This fixes all the Discord module and gateway stuff and updates models and URls to use the gateway and http api v8 instead of v6 and v7.

Relay and linking works fine.