### PR TITLE
Issue 32: tracker improvement

### DIFF
--- a/src/Core/Util.php
+++ b/src/Core/Util.php
@@ -566,4 +566,27 @@ class Util {
 	public function isInteger($input): bool {
 		return(ctype_digit(strval($input)));
 	}
+
+	/** Calculate the title level from the player's level */
+	public function levelToTL(int $level): int {
+		if ($level < 15) {
+			return 1;
+		}
+		if ($level < 50) {
+			return 2;
+		}
+		if ($level < 100) {
+			return 3;
+		}
+		if ($level < 150) {
+			return 4;
+		}
+		if ($level < 190) {
+			return 5;
+		}
+		if ($level < 205) {
+			return 6;
+		}
+		return 7;
+	}
 }


### PR DESCRIPTION
This add the ability to customize how tracked players are reported and also adds a new command `!track online` showing all currently online tracked players either ungrouped, grouped by profession or grouped by title level.

Closes #32 