### PR TITLE
Fix SQL error in !config cmd disable/enable command

### DIFF
--- a/src/Core/Modules/CONFIG/ConfigController.php
+++ b/src/Core/Modules/CONFIG/ConfigController.php
@@ -159,8 +159,10 @@ class ConfigController {
 			 $confirmString = "all " . $args[2];
 		}
 	
-		$sql = "SELECT `type`, `file`, `cmd`, `admin` FROM `cmdcfg_<myname>` WHERE `cmdevent` = 'cmd' AND ($typeSql)";
-		$data = $this->db->fetchAll(CmdCfg::class, $sql);
+		$sql = "SELECT `type`, `file`, `cmd`, `admin` ".
+			"FROM `cmdcfg_<myname>` ".
+			"WHERE `cmdevent` = 'cmd' AND ($typeSql)";
+		$data = $this->db->fetchAll(CmdCfg::class, $sql, ...$sqlArgs);
 		foreach ($data as $row) {
 			if (!$this->accessManager->checkAccess($sender, $row->admin)) {
 				continue;
@@ -173,7 +175,7 @@ class ConfigController {
 		}
 	
 		$sql = "UPDATE `cmdcfg_<myname>` SET `status` = ? WHERE (`cmdevent` = 'cmd' OR `cmdevent` = 'subcmd') AND ($typeSql)";
-		$sqlArgs []= $status;
+		$sqlArgs = [$status, ...$sqlArgs];
 		$this->db->exec($sql, ...$sqlArgs);
 	
 		$msg = "Successfully <highlight>" . ($status === 1 ? "enabled" : "disabled") . "<end> $confirmString commands.";


### PR DESCRIPTION
```
2020-11-18 23:03:25.792 INFO  [Inc. Msg.] Beefcheeks: config cmd disable guild
2020-11-18 23:03:25.793 ERROR Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '?)' at line 1
Query: SELECT `type`, `file`, `cmd`, `admin` FROM `cmdcfg_testclap` WHERE `cmdevent` = 'cmd' AND (`type` = ?)
Params: []
2020-11-18 23:03:25.793 INFO  [Out. Msg.] Beefcheeks: There was an SQL error executing your command.
```