### PR TITLE
Replace last await-calls with callbacks

### DIFF
--- a/src/Core/CacheResult.php
+++ b/src/Core/CacheResult.php
@@ -33,5 +33,5 @@ class CacheResult {
 	/**
 	 * The cached data as retrieved from the URL's body
 	 */
-	public ?string $data;
+	public ?string $data = null;
 }

--- a/src/Core/Modules/LIMITS/LimitsController.php
+++ b/src/Core/Modules/LIMITS/LimitsController.php
@@ -17,8 +17,8 @@ use Nadybot\Core\Modules\BAN\BanController;
 use Nadybot\Core\Modules\CONFIG\ConfigController;
 use Nadybot\Core\Modules\PLAYER_LOOKUP\{
 	PlayerHistory,
-    PlayerHistoryData,
-    PlayerHistoryManager,
+	PlayerHistoryData,
+	PlayerHistoryManager,
 	PlayerManager,
 };
 use PhpAmqpLib\Exception\AMQPConnectionClosedException;

--- a/src/Core/Modules/LIMITS/LimitsController.php
+++ b/src/Core/Modules/LIMITS/LimitsController.php
@@ -12,10 +12,13 @@ use Nadybot\Core\{
 	Timer,
 	Util,
 };
+use Nadybot\Core\DBSchema\Player;
 use Nadybot\Core\Modules\BAN\BanController;
 use Nadybot\Core\Modules\CONFIG\ConfigController;
 use Nadybot\Core\Modules\PLAYER_LOOKUP\{
-	PlayerHistoryManager,
+	PlayerHistory,
+    PlayerHistoryData,
+    PlayerHistoryManager,
 	PlayerManager,
 };
 use PhpAmqpLib\Exception\AMQPConnectionClosedException;
@@ -180,18 +183,28 @@ class LimitsController {
 	/**
 	 * Check if $sender is allowed to send $message
 	 */
-	public function check(string $sender, string $message): bool {
+	public function checkAndExecute(string $sender, string $message, callable $callback, ...$args): void {
 		if (
 			preg_match("/^about$/i", $message)
 			|| $this->rateIgnoreController->check($sender)
 			|| $sender === ucfirst(strtolower($this->settingManager->get("relaybot")))
 			// if access level is at least member, skip checks
 			|| $this->accessManager->checkAccess($sender, 'member')
-			|| ($msg = $this->getAccessErrorMessage($sender)) === null
 		) {
-			return true;
+			$callback(...$args);
+			return;
 		}
+		$this->checkAccessError(
+			$sender,
+			function(string $msg) use ($sender, $message): void {
+				$this->handleAccessError($sender, $message, $msg);
+			},
+			$callback,
+			...$args
+		);
+	}
 	
+	public function handleAccessError(string $sender, string $message, string $msg): void {
 		$this->logger->log('Info', "$sender denied access to bot due to: $msg");
 
 		$this->handleLimitCheckFail($msg, $sender);
@@ -205,8 +218,6 @@ class LimitsController {
 		if ($this->settingManager->getBool('access_denied_notify_priv')) {
 			$this->chatBot->sendPrivate("Player <highlight>$sender<end> was denied access to command <highlight>$cmd<end> due to limit checks.", true);
 		}
-
-		return false;
 	}
 	
 	/**
@@ -220,59 +231,97 @@ class LimitsController {
 			$this->chatBot->sendTell($msg, $sender);
 		}
 	}
+	
+	protected function handleLevelAndFactionRequirements(?Player $whois, callable $errorHandler, callable $successHandler, ...$args): void {
+		if ($whois === null) {
+			$errorHandler("Error! Unable to get your character info for limit checks. Please try again later.");
+			return;
+		}
+		$tellReqFaction = $this->settingManager->get('tell_req_faction');
+		$tellReqLevel = $this->settingManager->getInt('tell_req_lvl');
+
+		// check minlvl
+		if ($tellReqLevel > 0 && $tellReqLevel > $whois->level) {
+			$errorHandler("Error! You must be at least level <highlight>$tellReqLevel<end>.");
+			return;
+		}
+
+		// check faction limit
+		if (
+			in_array($tellReqFaction, ["Omni", "Clan", "Neutral"])
+			&& $tellReqFaction !== $whois->faction
+		) {
+			$errorHandler("Error! You must be <".strtolower($tellReqFaction).">$tellReqFaction<end>.");
+			return;
+		}
+		if (in_array($tellReqFaction, ["not Omni", "not Clan", "not Neutral"])) {
+			$tmp = explode(" ", $tellReqFaction);
+			if ($tmp[1] === $whois->faction) {
+				$errorHandler("Error! You must not be <".strtolower($tmp[1]).">{$tmp[1]}<end>.");
+				return;
+			}
+		}
+		$successHandler(...$args);
+	}
 
 	/**
 	 * Check if $sender is allowed to run commands on the bot
 	 */
-	public function getAccessErrorMessage(string $sender): ?string {
+	public function checkAccessError(string $sender, callable $errorHandler, callable $successHandler, ...$args): void {
+		$minAgeCheck = function() use ($sender, $errorHandler, $successHandler, $args): void {
+			if ($this->settingManager->getInt("tell_min_player_age") <= 1) {
+				$successHandler(...$args);
+				return;
+			}
+			$this->playerHistoryManager->asyncLookup(
+				$sender,
+				(int)$this->chatBot->vars['dimension'],
+				function(?PlayerHistory $history, callable $errorHandler, callable $successHandler, ...$args): void {
+					$this->handleMinAgeRequirements($history, $errorHandler, $successHandler, ...$args);
+				},
+				$errorHandler,
+				$successHandler,
+				...$args
+			);
+		};
 		$tellReqFaction = $this->settingManager->get('tell_req_faction');
 		$tellReqLevel = $this->settingManager->getInt('tell_req_lvl');
 		if ($tellReqLevel > 0 || $tellReqFaction !== "all") {
 			// get player info which is needed for following checks
-			$whois = $this->playerManager->getByName($sender);
-			if ($whois === null) {
-				return "Error! Unable to get your character info for limit checks. Please try again later.";
-			}
-
-			// check minlvl
-			if ($tellReqLevel > 0 && $tellReqLevel > $whois->level) {
-				return "Error! You must be at least level <highlight>$tellReqLevel<end>.";
-			}
-
-			// check faction limit
-			if (
-				in_array($tellReqFaction, ["Omni", "Clan", "Neutral"])
-				&& $tellReqFaction !== $whois->faction
-			) {
-				return "Error! You must be <".strtolower($tellReqFaction).">$tellReqFaction<end>.";
-			}
-			if (in_array($tellReqFaction, ["not Omni", "not Clan", "not Neutral"])) {
-				$tmp = explode(" ", $tellReqFaction);
-				if ($tmp[1] === $whois->faction) {
-					return "Error! You must not be <".strtolower($tmp[1]).">{$tmp[1]}<end>.";
-				}
-			}
+			$this->playerManager->getByNameAsync(
+				function(?Player $player) use ($errorHandler, $minAgeCheck): void {
+					$this->handleLevelAndFactionRequirements(
+						$player,
+						$errorHandler,
+						$minAgeCheck
+					);
+				},
+				$sender
+			);
+			return;
 		}
-		
-		// check player age
-		if ($this->settingManager->getInt("tell_min_player_age") > 1) {
-			$history = $this->playerHistoryManager->lookup($sender, (int)$this->chatBot->vars['dimension']);
-			if ($history === null) {
-				return "Error! Unable to get your character history for limit checks. Please try again later.";
-			}
-			$minAge = time() - $this->settingManager->getInt("tell_min_player_age");
-			$entry = array_pop($history->data);
-			// TODO check for rename
-
-			if ($entry->last_changed > $minAge) {
-				$timeString = $this->util->unixtimeToReadable($this->settingManager->getInt("tell_min_player_age"));
-				return "Error! You must be at least <highlight>$timeString<end> old.";
-			}
-		}
-		
-		return null;
+		$minAgeCheck();
 	}
 
+	protected function handleMinAgeRequirements(?PlayerHistory $history, callable $errorHandler, callable $successHandler, ...$args): void {
+		if ($history === null) {
+			$errorHandler("Error! Unable to get your character history for limit checks. Please try again later.");
+			return;
+		}
+		$minAge = time() - $this->settingManager->getInt("tell_min_player_age");
+		/** @var PlayerHistoryData */
+		$entry = array_pop($history->data);
+		// TODO check for rename
+
+		if ($entry->last_changed->getTimestamp() > $minAge) {
+			$timeString = $this->util->unixtimeToReadable($this->settingManager->getInt("tell_min_player_age"));
+			$errorHandler("Error! You must be at least <highlight>$timeString<end> old.");
+			return;
+		}
+		
+		$successHandler(...$args);
+	}
+		
 	/**
 	 * @Event("command(*)")
 	 * @Description("Enforce rate limits")

--- a/src/Core/Modules/PLAYER_LOOKUP/GuildManager.php
+++ b/src/Core/Modules/PLAYER_LOOKUP/GuildManager.php
@@ -2,10 +2,12 @@
 
 namespace Nadybot\Core\Modules\PLAYER_LOOKUP;
 
+use Closure;
 use JsonException;
 use Nadybot\Core\{
 	AOChatPacket,
 	CacheManager,
+	CacheResult,
 	DB,
 	Nadybot,
 };
@@ -29,6 +31,48 @@ class GuildManager {
 	/** @Inject */
 	public PlayerManager $playerManager;
 
+	protected function getJsonValidator(): Closure {
+		return function($data): bool {
+			try {
+				if ($data === null) {
+					return false;
+				}
+				$result = json_decode($data, false, 512, JSON_THROW_ON_ERROR);
+				return $result !== null;
+			} catch (JsonException $e) {
+				return false;
+			}
+		};
+	}
+
+	public function getByIdAsync(int $guildID, ?int $dimension, bool $forceUpdate, callable $callback, ...$args): void {
+		// if no server number is specified use the one on which the bot is logged in
+		$dimension ??= (int)$this->chatBot->vars["dimension"];
+		
+		$url = "http://people.anarchy-online.com/org/stats/d/$dimension/name/$guildID/basicstats.xml?data_type=json";
+		$maxCacheAge = 86400;
+		if (
+			isset($this->chatBot->vars["my_guild_id"])
+			&& $this->chatBot->vars["my_guild_id"] === $guildID
+		) {
+			$maxCacheAge = 21600;
+		}
+
+		$this->cacheManager->asyncLookup(
+			$url,
+			"guild_roster",
+			"$guildID.$dimension.json",
+			$this->getJsonValidator(),
+			$maxCacheAge,
+			$forceUpdate,
+			[$this, "handleGuildLookup"],
+			$guildID,
+			$dimension,
+			$callback,
+			...$args
+		);
+	}
+
 	public function getById(int $guildID, int $dimension=null, bool $forceUpdate=false): ?Guild {
 		// if no server number is specified use the one on which the bot is logged in
 		$dimension ??= (int)$this->chatBot->vars["dimension"];
@@ -43,36 +87,41 @@ class GuildManager {
 		) {
 			$maxCacheAge = 21600;
 		}
-		$cb = function($data) {
-			try {
-				if ($data === null) {
-					return false;
-				}
-				$result = json_decode($data, false, 512, JSON_THROW_ON_ERROR);
-				return $result !== null;
-			} catch (JsonException $e) {
-				return false;
-			}
-		};
+		$cb = $this->getJsonValidator();
 
 		$cacheResult = $this->cacheManager->lookup($url, $groupName, $filename, $cb, $maxCacheAge, $forceUpdate);
+		$result = null;
+		$this->handleGuildLookup(
+			$cacheResult,
+			$guildID,
+			$dimension,
+			function(?Guild $guild) use (&$result): void {
+				$result = $guild;
+			}
+		);
+		return $result;
+	}
+
+	public function handleGuildLookup(CacheResult $cacheResult, int $guildID, int $dimension, callable $callback, ...$args): void {
 
 		// if there is still no valid data available give an error back
 		if ($cacheResult->success !== true) {
-			return null;
+			$callback(null, ...$args);
+			return;
 		}
 		
 		[$orgInfo, $members, $lastUpdated] = json_decode($cacheResult->data);
 		
-		$guild = new Guild();
-		$guild->guild_id = $guildID;
 		if ($orgInfo->NAME === null) {
-			return $guild;
+			$callback(null, ...$args);
+			return;
 		}
 
 		// parsing of the member data
-		$guild->orgname	= $orgInfo->NAME;
-		$guild->orgside	= $orgInfo->SIDE_NAME;
+		$guild = new Guild();
+		$guild->guild_id = $guildID;
+		$guild->orgname = $orgInfo->NAME;
+		$guild->orgside = $orgInfo->SIDE_NAME;
 
 		// pre-fetch the charids...this speeds things up immensely
 		foreach ($members as $member) {
@@ -86,34 +135,34 @@ class GuildManager {
 
 		foreach ($members as $member) {
 			$name = $member->NAME;
-			$charid = $this->chatBot->get_uid($name);
+			$charid = $member->CHAR_INSTANCE ?? $this->chatBot->get_uid($name);
 			if ($charid === null || $charid === false) {
 				$charid = 0;
 			}
 
-			$guild->members[$name]                 = new Player();
-			$guild->members[$name]->charid         = $charid;
-			$guild->members[$name]->firstname      = trim($member->FIRSTNAME);
-			$guild->members[$name]->name           = $name;
-			$guild->members[$name]->lastname       = trim($member->LASTNAME);
-			$guild->members[$name]->level          = $member->LEVELX;
-			$guild->members[$name]->breed          = $member->BREED;
-			$guild->members[$name]->gender         = $member->SEX;
-			$guild->members[$name]->faction        = $guild->orgside;
-			$guild->members[$name]->profession     = $member->PROF;
-			$guild->members[$name]->prof_title     = $member->PROF_TITLE;
-			$guild->members[$name]->ai_rank        = $member->DEFENDER_RANK_TITLE;
-			$guild->members[$name]->ai_level       = $member->ALIENLEVEL;
-			$guild->members[$name]->guild_id       = $guild->guild_id;
-			$guild->members[$name]->guild          = $guild->orgname;
-			$guild->members[$name]->guild_rank     = $member->RANK_TITLE;
-			$guild->members[$name]->guild_rank_id  = $member->RANK;
-			$guild->members[$name]->dimension      = $dimension;
-			$guild->members[$name]->source         = 'org_roster';
+			$guild->members[$name]                = new Player();
+			$guild->members[$name]->charid        = $charid;
+			$guild->members[$name]->firstname     = trim($member->FIRSTNAME);
+			$guild->members[$name]->name          = $name;
+			$guild->members[$name]->lastname      = trim($member->LASTNAME);
+			$guild->members[$name]->level         = $member->LEVELX;
+			$guild->members[$name]->breed         = $member->BREED;
+			$guild->members[$name]->gender        = $member->SEX;
+			$guild->members[$name]->faction       = $guild->orgside;
+			$guild->members[$name]->profession    = $member->PROF;
+			$guild->members[$name]->prof_title    = $member->PROF_TITLE;
+			$guild->members[$name]->ai_rank       = $member->DEFENDER_RANK_TITLE;
+			$guild->members[$name]->ai_level      = $member->ALIENLEVEL;
+			$guild->members[$name]->guild_id      = $guild->guild_id;
+			$guild->members[$name]->guild         = $guild->orgname;
+			$guild->members[$name]->guild_rank    = $member->RANK_TITLE;
+			$guild->members[$name]->guild_rank_id = $member->RANK;
+			$guild->members[$name]->dimension     = $dimension;
+			$guild->members[$name]->source        = 'org_roster';
 			
-			$guild->members[$name]->head_id        = $member->HEADID;
-			$guild->members[$name]->pvp_rating     = $member->PVPRATING;
-			$guild->members[$name]->pvp_title      = $member->PVPTITLE;
+			$guild->members[$name]->head_id       = $member->HEADID;
+			$guild->members[$name]->pvp_rating    = $member->PVPRATING;
+			$guild->members[$name]->pvp_title     = $member->PVPTITLE;
 		}
 
 		// this is done separately from the loop above to prevent nested transaction errors from occurring
@@ -131,6 +180,6 @@ class GuildManager {
 			$this->db->commit();
 		}
 
-		return $guild;
+		$callback($guild, ...$args);
 	}
 }

--- a/src/Core/Modules/PLAYER_LOOKUP/PlayerHistoryManager.php
+++ b/src/Core/Modules/PLAYER_LOOKUP/PlayerHistoryManager.php
@@ -3,6 +3,7 @@
 namespace Nadybot\Core\Modules\PLAYER_LOOKUP;
 
 use Nadybot\Core\CacheManager;
+use Nadybot\Core\CacheResult;
 use Throwable;
 
 /**
@@ -13,6 +14,30 @@ class PlayerHistoryManager {
 	/** @Inject */
 	public CacheManager $cacheManager;
 	
+	public function asyncLookup(string $name, int $dimension, callable $callback, ...$args): void {
+		$name = ucfirst(strtolower($name));
+		$url = "http://pork.budabot.jkbff.com/pork/history.php?server=$dimension&name=$name";
+		$groupName = "player_history";
+		$filename = "$name.$dimension.history.json";
+		$maxCacheAge = 86400;
+		$cb = function($data) {
+			return isset($data) && $data !== "[]";
+		};
+		
+		$this->cacheManager->asyncLookup(
+			$url,
+			$groupName,
+			$filename,
+			$cb,
+			$maxCacheAge,
+			false,
+			[$this, "handleCacheResult"],
+			$name,
+			$callback,
+			...$args
+		);
+	}
+
 	public function lookup(string $name, int $dimension): ?PlayerHistory {
 		$name = ucfirst(strtolower($name));
 		$url = "http://pork.budabot.jkbff.com/pork/history.php?server=$dimension&name=$name";
@@ -24,9 +49,22 @@ class PlayerHistoryManager {
 		};
 		
 		$cacheResult = $this->cacheManager->lookup($url, $groupName, $filename, $cb, $maxCacheAge);
+		$playerHistory = null;
+		$this->handleCacheResult(
+			$cacheResult,
+			$name,
+			function(?PlayerHistory $obj) use (&$playerHistory): void {
+				$playerHistory = $obj;
+			}
+		);
+		return $playerHistory;
+	}
+
+	public function handleCacheResult(?CacheResult $cacheResult, string $name, callable $callback, ...$args): void {
 		
 		if ($cacheResult->success !== true) {
-			return null;
+			$callback(null, ...$args);
+			return;
 		}
 		$obj = new PlayerHistory();
 		$obj->name = $name;
@@ -34,13 +72,14 @@ class PlayerHistoryManager {
 		try {
 			$history = json_decode($cacheResult->data, false, 512, JSON_THROW_ON_ERROR);
 		} catch (Throwable $e) {
-			return null;
+			$callback(null, ...$args);
+			return;
 		}
 		foreach ($history as $entry) {
 			$historyEntry = new PlayerHistoryData();
 			$historyEntry->fromJSON($entry);
 			$obj->data []= $historyEntry;
 		}
-		return $obj;
+		$callback($obj, ...$args);
 	}
 }

--- a/src/Core/Modules/PLAYER_LOOKUP/PlayerManager.php
+++ b/src/Core/Modules/PLAYER_LOOKUP/PlayerManager.php
@@ -174,7 +174,7 @@ class PlayerManager {
 		if (!isset($response) || $response->headers["status-code"] !== "200") {
 			return null;
 		}
-		if ($response->body === "null") {
+		if (!isset($response->body) || $response->body === "null") {
 			return null;
 		}
 		[$char, $org] = json_decode($response->body);

--- a/src/Core/Modules/PLAYER_LOOKUP/PlayerManager.php
+++ b/src/Core/Modules/PLAYER_LOOKUP/PlayerManager.php
@@ -191,7 +191,7 @@ class PlayerManager {
 		$obj->faction        = $char->SIDE;
 		$obj->profession     = $char->PROF;
 		$obj->prof_title     = $char->PROFNAME;
-		$obj->ai_rank        = $char->RANK_name;
+		$obj->ai_rank        = $char->RANK_name ?? '';
 		$obj->ai_level       = $char->ALIENLEVEL;
 		$obj->guild_id       = $org->ORG_INSTANCE;
 		$obj->guild          = $org->NAME ?? '';

--- a/src/Core/Nadybot.php
+++ b/src/Core/Nadybot.php
@@ -807,12 +807,14 @@ class Nadybot extends AOChat {
 		}
 
 		// check tell limits
-		if (!$this->limitsController->check($sender, $message)) {
-			return;
-		}
-
-		$sendto = new PrivateMessageCommandReply($this, $sender);
-		$this->commandManager->process($type, $message, $sender, $sendto);
+		$this->limitsController->checkAndExecute(
+			$sender,
+			$message,
+			function() use ($sender, $type, $message): void {
+				$sendto = new PrivateMessageCommandReply($this, $sender);
+				$this->commandManager->process($type, $message, $sender, $sendto);
+			}
+		);
 	}
 
 	/**

--- a/src/Core/Util.php
+++ b/src/Core/Util.php
@@ -39,6 +39,7 @@ class Util {
 		}
 
 		$units = [
+			"year" => 31536000,
 			"day" => 86400,
 			"hr" => 3600,
 			"min" => 60,

--- a/src/Modules/ORGLIST_MODULE/OrgMembersController.php
+++ b/src/Modules/ORGLIST_MODULE/OrgMembersController.php
@@ -68,14 +68,14 @@ class OrgMembersController {
 		foreach ($players as $player) {
 			if ($currentLetter !== $player->name[0]) {
 				$currentLetter = $player->name[0];
-				$blob .= "\n\n<header2>$currentLetter<end>\n";
+				$blob .= "\n\n<pagebreak><header2>$currentLetter<end>\n";
 			}
 
-			$blob .= "<tab><highlight>{$player->name}<end>, {$player->guild_rank} (Level {$player->level}";
+			$blob .= "<tab><highlight>{$player->name}<end> ({$player->level}";
 			if ($player->ai_level > 0) {
-				$blob .= "<green>/{$player->ai_level}<end>";
+				$blob .= "/<green>{$player->ai_level}<end>";
 			}
-			$blob .= ", {$player->gender} {$player->breed} {$player->profession})\n";
+			$blob .= ", {$player->gender} {$player->breed} <highlight>{$player->profession}<end>, {$player->guild_rank})\n";
 		}
 
 		$msg = $this->text->makeBlob("Org members for '$org->orgname' ($numrows)", $blob);

--- a/src/Modules/ORGLIST_MODULE/OrgMembersController.php
+++ b/src/Modules/ORGLIST_MODULE/OrgMembersController.php
@@ -5,6 +5,7 @@ namespace Nadybot\Modules\ORGLIST_MODULE;
 use Nadybot\Core\CommandReply;
 use Nadybot\Core\DB;
 use Nadybot\Core\DBSchema\Player;
+use Nadybot\Core\Modules\PLAYER_LOOKUP\Guild;
 use Nadybot\Core\Modules\PLAYER_LOOKUP\GuildManager;
 use Nadybot\Core\Text;
 
@@ -45,16 +46,17 @@ class OrgMembersController {
 	public function orgmembers2Command(string $message, string $channel, string $sender, CommandReply $sendto, array $args): void {
 		$guildId = (int)$args[1];
 
-		$msg = "Getting org info...";
-		$sendto->reply($msg);
+		$sendto->reply("Getting org info...");
 
-		$org = $this->guildManager->getById($guildId);
+		$this->guildManager->getByIdAsync($guildId, null, false, [$this, "showOrglist"], $guildId, $sendto);
+	}
+
+	public function showOrglist(?Guild $org, int $guildId, CommandReply $sendto): void {
 		if ($org === null) {
 			$msg = "Error in getting the org info. Either org does not exist or AO's server was too slow to respond.";
 			$sendto->reply($msg);
 			return;
 		}
-
 		$sql = "SELECT * FROM players WHERE guild_id = ? AND dimension = '<dim>' ORDER BY name ASC";
 		/** @var Player[] */
 		$players = $this->db->fetchAll(Player::class, $sql, $guildId);

--- a/src/Modules/ORGLIST_MODULE/OrglistController.php
+++ b/src/Modules/ORGLIST_MODULE/OrglistController.php
@@ -14,6 +14,7 @@ use Nadybot\Core\{
 use Nadybot\Core\Modules\PLAYER_LOOKUP\GuildManager;
 use Nadybot\Core\Modules\PLAYER_LOOKUP\PlayerManager;
 use Nadybot\Core\DBSchema\Player;
+use Nadybot\Core\Modules\PLAYER_LOOKUP\Guild;
 
 /**
  * @author Tyrence (RK2)
@@ -163,8 +164,10 @@ class OrglistController {
 
 		$sendto->reply("Downloading org roster for org id $orgid...");
 
-		$org = $this->guildManager->getById($orgid);
+		$this->guildManager->getByIdAsync($orgid, null, false, [$this, "checkOrg"], $sendto);
+	}
 
+	public function checkOrg(?Guild $org, CommandReply $sendto): void {
 		if ($org === null) {
 			$msg = "Error in getting the Org info. Either org does not exist or AO's server was too slow to respond.";
 			$sendto->reply($msg);

--- a/src/Modules/ORGLIST_MODULE/WhoisOrgController.php
+++ b/src/Modules/ORGLIST_MODULE/WhoisOrgController.php
@@ -11,6 +11,7 @@ use Nadybot\Core\Modules\PLAYER_LOOKUP\PlayerManager;
 use Nadybot\Core\Nadybot;
 use Nadybot\Core\Text;
 use Nadybot\Core\Util;
+use Nadybot\Modules\ONLINE_MODULE\OnlineController;
 
 /**
  * @author Tyrence (RK2)
@@ -50,6 +51,9 @@ class WhoisOrgController {
 	
 	/** @Inject */
 	public GuildManager $guildManager;
+
+	/** @Inject */
+	public OnlineController $onlineController;
 	
 	/**
 	 * @HandlesCommand("whoisorg")
@@ -129,7 +133,7 @@ class WhoisOrgController {
 		$averageLevel = round($sumLevels/$numMembers);
 
 		$link = "<header2>General Info<end>\n";
-		$link .= "<tab>Faction: <highlight>$leader->faction<end>\n";
+		$link .= "<tab>Faction: <" . strtolower($leader->faction) . ">$leader->faction<end>\n";
 		$link .= "<tab>Lowest lvl: <highlight>$minLevel<end>\n";
 		$link .= "<tab>Highest lvl: <highlight>$maxLevel<end>\n";
 		$link .= "<tab>Average lvl: <highlight>$averageLevel<end>\n\n";
@@ -144,6 +148,7 @@ class WhoisOrgController {
 		ksort($countProfs);
 		$link .= "<header2>Members ($numMembers)<end>\n";
 		foreach ($countProfs as $prof => $profMembers) {
+			$profIcon = "<img src=tdb://id:GFX_GUI_ICON_PROFESSION_".$this->onlineController->getProfessionId($prof).">";
 			$link .= "<tab>".
 				$this->text->alignNumber($profMembers, 3, "highlight").
 				"  (".
@@ -151,7 +156,7 @@ class WhoisOrgController {
 					(int)round(($profMembers*100)/$numMembers, 1),
 					(count($countProfs) > 1 ) ? 2 : 3
 				).
-				"%)  $prof\n";
+				"%)  $profIcon $prof\n";
 		}
 		$msg = $this->text->makeBlob("Org Info for $org->orgname", $link);
 

--- a/src/Modules/ORGLIST_MODULE/WhoisOrgController.php
+++ b/src/Modules/ORGLIST_MODULE/WhoisOrgController.php
@@ -5,6 +5,7 @@ namespace Nadybot\Modules\ORGLIST_MODULE;
 use Nadybot\Core\CommandReply;
 use Nadybot\Core\DB;
 use Nadybot\Core\DBSchema\Player;
+use Nadybot\Core\Modules\PLAYER_LOOKUP\Guild;
 use Nadybot\Core\Modules\PLAYER_LOOKUP\GuildManager;
 use Nadybot\Core\Modules\PLAYER_LOOKUP\PlayerManager;
 use Nadybot\Core\Nadybot;
@@ -63,7 +64,7 @@ class WhoisOrgController {
 		
 		if (preg_match("/^\d+$/", $args[1])) {
 			$orgId = (int)$args[1];
-			$this->sendOrgInfo($orgId, $sendto, $dimension);
+			$this->sendOrgIdInfo($orgId, $sendto, $dimension);
 			return;
 		}
 		// Someone's name.  Doing a whois to get an orgID.
@@ -79,18 +80,21 @@ class WhoisOrgController {
 					$sendto->reply($msg);
 					return;
 				}
-				$this->sendOrgInfo($whois->guild_id, $sendto, $dimension);
+				$this->sendOrgIdInfo($whois->guild_id, $sendto, $dimension);
 			},
 			$name,
 			$dimension
 		);
 	}
 
-	protected function sendOrgInfo(int $orgId, CommandReply $sendto, int $dimension): void {
+	protected function sendOrgIdInfo(int $orgId, CommandReply $sendto, int $dimension): void {
 		$msg = "Getting org info...";
 		$sendto->reply($msg);
 
-		$org = $this->guildManager->getById($orgId, $dimension);
+		$this->guildManager->getByIdAsync($orgId, $dimension, false, [$this, "sendOrgInfo"], $sendto);
+	}
+
+	public function sendOrgInfo(?Guild $org, CommandReply $sendto): void {
 		if ($org === null) {
 			$msg = "Error in getting the org info. ".
 				"Either the org does not exist or AO's server ".

--- a/src/Modules/WHOIS_MODULE/PlayerHistoryController.php
+++ b/src/Modules/WHOIS_MODULE/PlayerHistoryController.php
@@ -3,6 +3,7 @@
 namespace Nadybot\Modules\WHOIS_MODULE;
 
 use Nadybot\Core\CommandReply;
+use Nadybot\Core\Modules\PLAYER_LOOKUP\PlayerHistory;
 use Nadybot\Core\Modules\PLAYER_LOOKUP\PlayerHistoryManager;
 use Nadybot\Core\Nadybot;
 use Nadybot\Core\Text;
@@ -49,7 +50,10 @@ class PlayerHistoryController {
 			$dimension = (int)$args[2];
 		}
 
-		$history = $this->playerHistoryManager->lookup($name, $dimension);
+		$this->playerHistoryManager->asyncLookup($name, $dimension, [$this, "servePlayerHistory"], $name, $dimension, $sendto);
+	}
+
+	public function servePlayerHistory(?PlayerHistory $history, string $name, int $dimension, CommandReply $sendto): void {
 		if ($history === null) {
 			$msg = "Could not get History of $name on RK$dimension.";
 			$sendto->reply($msg);


### PR DESCRIPTION
The await-model causes issues on Windows and slows down the bot in some scenarios.
All usage of await-loops was replaced with callbacks while leaving the old API in place for other (old) modules.