### PR TITLE
Add new raffle features

### DIFF
--- a/src/Modules/RAFFLE_MODULE/Raffle.php
+++ b/src/Modules/RAFFLE_MODULE/Raffle.php
@@ -7,10 +7,17 @@ use Nadybot\Core\CommandReply;
 class Raffle {
 	/** @var RaffleSlot[] */
 	public array $slots = [];
+	/** Timestamp when the raffle was started*/
 	public int $start;
+	/** Where to send annoucements, etc. to */
 	public CommandReply $sendto;
+	/** Name of the character giving away items */
 	public string $raffler;
+	/** If set, this is the unix timestamp when the raffle will end */
 	public ?int $end = null;
+	/** Interval (in second) between 2 announcements */
+	public ?int $announceInterval = null;
+	/** Unix timestamp when the raffle was announced the last time */
 	public ?int $lastAnnounce = null;
 
 	public function __construct() {
@@ -21,7 +28,7 @@ class Raffle {
 		$list = $this->toList();
 		$items = [];
 		for ($i = 0; $i < count($list); $i++) {
-			$items []= "Item " . ($i + 1) . ": <highlight>{$list[$i]}<end>";
+			$items []= ((count($list) > 1) ? "Item " . ($i + 1) . ": " : "") . "<highlight>{$list[$i]}<end>";
 		}
 		return $prefix . join("\n$prefix", $items);
 	}

--- a/src/Modules/RAFFLE_MODULE/raffle.txt
+++ b/src/Modules/RAFFLE_MODULE/raffle.txt
@@ -1,23 +1,43 @@
-To start a raffle:
-<highlight><tab><symbol>raffle start (count) 'item'<end>
+<header2>Commands for the raffler<end>
+<tab>To start a raffle for a single item:
+<tab><highlight><tab><symbol>raffle start 'item'<end>
 
-To start a raffle for two separate things:
-<highlight><tab><symbol>raffle start 'item1','item2'<end>
+<tab>To start a raffle for two separate things, separate them with commas:
+<tab><highlight><tab><symbol>raffle start 'item1','item2'<end>
 
-To start a raffle for a 9 pairs of Alpha and Beta Boxes and also something else
-<highlight><tab><symbol>raffle start 9xAlpha Box+Beta Box,Something else<end>
+<tab>To start a raffle for a 9 pairs of Alpha and Beta Boxes and also something else
+<tab><highlight><tab><symbol>raffle start 9xAlpha Box+Beta Box,Something else<end>
 
-To start a raffle for 6 Libra Activation codes:
-<highlight><tab><symbol>raffle start 6xLibra activation codes<end>
+<tab>To start a raffle for 6 Libra Activation codes:
+<tab><highlight><tab><symbol>raffle start 6xLibra activation codes<end>
 
-To cancel the raffle immediately:
-<highlight><tab><symbol>raffle cancel<end>
+<tab>To start a raffle with a custom timer of 30s:
+<tab><highlight><tab><symbol>raffle start 30s 'item'<end>
 
-To end the raffle immediately and post the result:
-<highlight><tab><symbol>raffle end<end>
+<tab>To cancel the raffle immediately:
+<tab><highlight><tab><symbol>raffle cancel<end>
 
-To join the raffle:
-<highlight><tab><symbol>raffle join<end>
+<tab>To end the raffle immediately and post the result:
+<tab><highlight><tab><symbol>raffle end<end>
 
-To leave the raffle:
-<highlight><tab><symbol>raffle leave<end>
+<tab>To set or modify the raffle timer:
+<tab><highlight><tab><symbol>raffle timer 'time'<end>
+
+<tab>To announce the raffle
+<tab><highlight><tab><symbol>raffle announce<end>
+
+<tab>To announce the raffle with an extra announcement
+<tab><highlight><tab><symbol>raffle announce The raffle will be closing soon!<end>
+
+<header2>Commands for the rafflees<end>
+<tab>To enter the raffle:
+<tab><highlight><tab><symbol>raffle enter<end>
+
+<tab>To enter the raffle for the item in slot 2:
+<tab><highlight><tab><symbol>raffle enter 2<end>
+
+<tab>To leave the raffle for all slots:
+<tab><highlight><tab><symbol>raffle leave<end>
+
+<tab>To leave the raffle for only slot 3:
+<tab><highlight><tab><symbol>raffle leave 3<end>


### PR DESCRIPTION
* Add an option `raffle_ends_automatically` for raffles not to have a timer by default
* Made `raffle_announce_participants` an actual bool setting
* Do not show which item someone entered a raffle for - if there is only on anyway
* Do not show `Item 1:` in front of the raffled item if there is only 1 item raffled
* Show the winner of a multi-item raffle where only 1 person entered the same way as a single-item raffle
* Add command `!raffle announce [<text>]` to announce a raffle with an optional message to display on top
* Add command `!raffle timer <time>` to start or change the timer for a raffle
* Upon starting a new raffle,send the raffler a tell with an admin-popup to control the raffle
* Some typos fixed
* Improved documentation to showcase new commands and optional raffle timer `!rafle start [<timer>] <item(s)>`

Closes #81 