### PR TITLE
Package module

### DIFF
--- a/conf/config.template.php
+++ b/conf/config.template.php
@@ -35,6 +35,9 @@ $vars['default_module_status'] = 0;
 // Enable the readline-based console interface to the bot?
 $vars['enable_console_client'] = 1;
 
+// Enable the module to install other modules from within the bot
+$vars['enable_package_module'] = 1;
+
 // Use AO Chat Proxy? 1 for enabled, 0 for disabled.
 $vars['use_proxy']    = 0;
 $vars['proxy_server'] = "127.0.0.1";

--- a/src/Core/Modules/CONSOLE/ConsoleCommandReply.php
+++ b/src/Core/Modules/CONSOLE/ConsoleCommandReply.php
@@ -43,13 +43,15 @@ class ConsoleCommandReply implements CommandReply {
 			"<myname>" => $this->chatBot->vars["name"],
 			"<myguild>" => $this->chatBot->vars["my_guild"],
 			"<tab>" => "    ",
-			"<end>" => "\e[0m",
+			"<end>" => "\e[22;24m",
 			"<u>" => "\e[4m",
 			"</u>" => "\e[24m",
 			"<i>" => "\e[3m",
 			"</i>" => "\e[23m",
 			"<symbol>" => "",
-			"<br>" => "\n"
+			"<br>" => "\n",
+			"<br/>" => "\n",
+			"<br />" => "\n"
 		];
 
 		$message = preg_replace_callback(

--- a/src/Modules/PACKAGE_MODULE/Package.php
+++ b/src/Modules/PACKAGE_MODULE/Package.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\PACKAGE_MODULE;
+
+class Package {
+	public string $name;
+	public string $description;
+	public string $short_description;
+	public string $version;
+	public string $author;
+	public string $bot_type;
+	public string $bot_version;
+
+	public bool $compatible = false;
+	public int $state = 0;
+}

--- a/src/Modules/PACKAGE_MODULE/PackageAction.php
+++ b/src/Modules/PACKAGE_MODULE/PackageAction.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\PACKAGE_MODULE;
+
+use Nadybot\Core\CommandReply;
+
+class PackageAction {
+	public const INSTALL = 1;
+	public const UPGRADE = 2;
+
+	public int $action = self::INSTALL;
+
+	public string $package;
+
+	public ?SemanticVersion $oldVersion;
+
+	public ?SemanticVersion $version;
+
+	public string $sender;
+
+	public CommandReply $sendto;
+
+	public function __construct(string $module, int $action) {
+		$this->package = $module;
+		$this->action = $action;
+	}
+}

--- a/src/Modules/PACKAGE_MODULE/PackageController.php
+++ b/src/Modules/PACKAGE_MODULE/PackageController.php
@@ -260,16 +260,16 @@ class PackageController {
 			if (isset($pGroup->highest_supported) && $package->state !== static::BUILT_INT) {
 				if ($pGroup->highest_supported && ($installedVersion??"") !== "") {
 					if (SemanticVersion::compareUsing($installedVersion, $pGroup->highest_supported->version, '<')) {
-						$installLink = $this->text->makeChatcmd(
+						$installLink = "[" . $this->text->makeChatcmd(
 							"update",
 							"/tell <myname> package update {$pGroup->highest_supported->name} {$pGroup->highest_supported->version}"
-						);
+						) . "]";
 					}
 				} else {
-					$installLink = $this->text->makeChatcmd(
+					$installLink = "[" . $this->text->makeChatcmd(
 						"install",
 						"/tell <myname> package install {$pGroup->highest_supported->name} {$pGroup->highest_supported->version}"
-					);
+					) . "]";
 				}
 			} elseif ($package->state === static::BUILT_INT) {
 				$installLink = "<i>Included in Nadybot now</i>";

--- a/src/Modules/PACKAGE_MODULE/PackageController.php
+++ b/src/Modules/PACKAGE_MODULE/PackageController.php
@@ -473,6 +473,14 @@ class PackageController {
 	 * @Matches("/^packages?\s+install\s+([a-z_0-9-]+)\s+(.+)$/i")
 	 */
 	public function packageInstallCommand(string $message, string $channel, string $sender, CommandReply $sendto, array $args): void {
+		if (($this->chatBot->vars['enable_package_module']??0) != 1) {
+			$sendto->reply(
+				"In order to be allowed to install modules from within Nadybot, ".
+				"you have to set <highlight>\$vars['enable_package_module'] = 1;<end> in your ".
+				"bot's config file."
+			);
+			return;
+		}
 		$cmd = new PackageAction($args[1], PackageAction::INSTALL);
 		$cmd->version = $args[2] ? new SemanticVersion($args[2]) : null;
 		$cmd->sender = $sender;
@@ -486,6 +494,14 @@ class PackageController {
 	 * @Matches("/^packages?\s+update\s+([a-z_0-9-]+)\s+(.+)$/i")
 	 */
 	public function packageUpdateCommand(string $message, string $channel, string $sender, CommandReply $sendto, array $args): void {
+		if (($this->chatBot->vars['enable_package_module']??0) != 1) {
+			$sendto->reply(
+				"In order to be allowed to update modules from within Nadybot, ".
+				"you have to set <highlight>\$vars['enable_package_module'] = 1;<end> in your ".
+				"bot's config file."
+			);
+			return;
+		}
 		$cmd = new PackageAction($args[1], PackageAction::UPGRADE);
 		$cmd->version = $args[2] ? new SemanticVersion($args[2]) : null;
 		$cmd->sender = $sender;

--- a/src/Modules/PACKAGE_MODULE/PackageController.php
+++ b/src/Modules/PACKAGE_MODULE/PackageController.php
@@ -88,6 +88,9 @@ class PackageController {
 		}
 		if ($dh = opendir($targetDir)) {
 			while (($dir = readdir($dh)) !== false) {
+				if (in_array($dir, [".", ".."], true)) {
+					continue;
+				}
 				$this->scanExtraModule($targetDir, $dir);
 			}
 			closedir($dh);
@@ -259,6 +262,7 @@ class PackageController {
 			$package = $pGroup->highest;
 			$infoLink = $this->text->makeChatcmd("details", "/tell <myname> package info {$package->name}");
 			$installLink = "";
+			$installedVersion = null;
 			if ($package->state === static::EXTRA) {
 				$res = $this->db->queryRow(
 					"SELECT MAX(`version`) AS `cur` FROM `package_files_<myname>` ".

--- a/src/Modules/PACKAGE_MODULE/PackageController.php
+++ b/src/Modules/PACKAGE_MODULE/PackageController.php
@@ -514,6 +514,14 @@ class PackageController {
 	 * @Matches("/^packages?\s+(?:uninstall|delete|remove|erase|del|rm)\s+(.+)$/i")
 	 */
 	public function packageUninstallCommand(string $message, string $channel, string $sender, CommandReply $sendto, array $args): void {
+		if (($this->chatBot->vars['enable_package_module']??0) != 1) {
+			$sendto->reply(
+				"In order to be allowed to uninstall modules from within Nadybot, ".
+				"you have to set <highlight>\$vars['enable_package_module'] = 1;<end> in your ".
+				"bot's config file."
+			);
+			return;
+		}
 		$module = strtoupper($args[1]);
 		$instType = $this->getInstalledModuleType($module);
 		if ($instType === static::UNINST) {

--- a/src/Modules/PACKAGE_MODULE/PackageController.php
+++ b/src/Modules/PACKAGE_MODULE/PackageController.php
@@ -1,0 +1,761 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\PACKAGE_MODULE;
+
+use Nadybot\Core\{
+	BotRunner,
+	CacheManager,
+	CacheResult,
+	CommandAlias,
+	CommandReply,
+	DB,
+	Http,
+	HttpResponse,
+	LoggerWrapper,
+	Nadybot,
+	Text,
+};
+use Nadybot\Modules\WEBSERVER_MODULE\JsonImporter;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Throwable;
+use ZipArchive;
+
+/**
+ * @author Nadyita (RK5)
+ *
+ * @Instance
+ *
+ * Commands this controller contains:
+ *	@DefineCommand(
+ *		command     = 'package',
+ *		accessLevel = 'admin',
+ *		description = 'Install or update external packages',
+ *		help        = 'package.txt'
+ *	)
+ */
+class PackageController {
+	public const EXTRA = 2;
+	public const BUILT_INT = 1;
+	public const UNINST = 0;
+	public const API = "https://pkg.aobots.org/api";
+
+	/**
+	 * Name of the module.
+	 * Set automatically by module loader.
+	 */
+	public string $moduleName;
+
+	/** @Inject */
+	public DB $db;
+
+	/** @Inject */
+	public Nadybot $chatBot;
+
+	/** @Inject */
+	public Text $text;
+
+	/** @Inject */
+	public Http $http;
+
+	/** @Inject */
+	public CommandAlias $commandAlias;
+
+	/** @Inject */
+	public CacheManager $cacheManager;
+
+	/** @Logger */
+	public LoggerWrapper $logger;
+
+	/** @Setup */
+	public function setup(): void {
+		$this->db->loadSQLFile($this->moduleName, "package_files");
+		$this->scanForUnregisteredExtraModules();
+		$this->commandAlias->register($this->moduleName, "package", "packages");
+		$this->commandAlias->register($this->moduleName, "package", "modules");
+		$this->commandAlias->register($this->moduleName, "package", "module");
+	}
+
+	/**
+	 * Scan for and add all unregistered extra modules into the database
+	 */
+	protected function scanForUnregisteredExtraModules(): void {
+		$targetDir = $this->getExtraModulesDir();
+		if ($targetDir === null) {
+			return;
+		}
+		if ($dh = opendir($targetDir)) {
+			while (($dir = readdir($dh)) !== false) {
+				$this->scanExtraModule($targetDir, $dir);
+			}
+			closedir($dh);
+		}
+	}
+
+	/** Return if a module id extra (2) built-in (1) or not installed (0) */
+	public function getInstalledModuleType(string $module): int {
+		$path = $this->chatBot->runner->classLoader->registeredModules[$module] ?? null;
+		if (!isset($path)) {
+			return static::UNINST;
+		}
+		if (realpath(dirname($path)) === realpath(dirname(__DIR__))) {
+			return static::BUILT_INT;
+		}
+		return static::EXTRA;
+	}
+
+	/**
+	 * Scan for and add all files of $module into the database
+	 */
+	protected function scanExtraModule(string $targetDir, string $module): void {
+		$res = $this->db->queryRow(
+			"SELECT COUNT(*) AS `num` FROM `package_files_<myname>` ".
+			"WHERE `module`=?",
+			$module
+		);
+		if ($res->num > 0) {
+			return;
+		}
+
+		$version = $this->getInstalledVersion($module, $targetDir);
+		$dirIterator = new RecursiveDirectoryIterator("{$targetDir}/{$module}", RecursiveDirectoryIterator::SKIP_DOTS);
+		$iterator = new RecursiveIteratorIterator($dirIterator, RecursiveIteratorIterator::SELF_FIRST);
+
+		foreach ($iterator as $file) {
+			/** @var SplFileInfo $file */
+			if (in_array($file->getFilename(), [".", ".."], true)) {
+				continue;
+			}
+			if (preg_match("/(^|\/)\.git(\/|$)/", $file->getPathname())) {
+				continue;
+			}
+			$relPath = substr($file->getPathname(), strlen($targetDir) + 1);
+			if (substr($relPath, 0, 1) === ".") {
+				continue;
+			}
+			$this->db->exec(
+				"INSERT INTO `package_files_<myname>`(`module`, `version`, `file`) VALUES".
+				"(?, ?, ?)",
+				$module,
+				$version ?? "",
+				$relPath
+			);
+		}
+	}
+
+	public function isValidJSON(?string $data): bool {
+		try {
+			$data = json_decode($data, false, 512, JSON_THROW_ON_ERROR);
+		} catch (Throwable $e) {
+			return false;
+		}
+		return true;
+	}
+
+	/** Download and parse the full package index */
+	public function getPackages(callable $callback, ...$args): void {
+		$this->cacheManager->asyncLookup(
+			static::API . "/packages",
+			"PACKAGE_MODULE",
+			"packages",
+			[$this, "isValidJSON"],
+			3600,
+			false,
+			[$this, "parsePackages"], $callback, ...$args
+		);
+	}
+
+	/** Download and parse the package index for $package */
+	public function getPackage(string $package, callable $callback, ...$args): void {
+		$this->cacheManager->asyncLookup(
+			static::API . "/packages/{$package}",
+			"PACKAGE_MODULE",
+			"package_" . md5($package),
+			[$this, "isValidJSON"],
+			3600,
+			false,
+			[$this, "parsePackages"], $callback, ...$args
+		);
+	}
+
+	public function parsePackages(CacheResult $response, callable $callback, ...$args): void {
+		if ($response->data === null) {
+			$callback(null, ...$args);
+			return;
+		}
+		try {
+			$data = json_decode($response->data, false, 512, JSON_THROW_ON_ERROR);
+		} catch (Throwable $e) {
+			$callback(null, ...$args);
+			return;
+		}
+		if (!is_array($data)) {
+			$callback(null, ...$args);
+			return;
+		}
+		$packages = [];
+		foreach ($data as $pack) {
+			$packages []= JsonImporter::convert(Package::class, $pack);
+		}
+		$packages = array_values(array_filter(
+			$packages,
+			function(Package $package): bool {
+				return $package->bot_type === "Nadybot";
+			}
+		));
+		foreach ($packages as $package) {
+			$package->compatible = $this->isVersionCompatible($package->bot_version);
+			$package->state = $this->getInstalledModuleType($package->name);
+		}
+		$callback($packages, ...$args);
+	}
+
+	/**
+	 * @HandlesCommand("package")
+	 * @Matches("/^packages?\s+list$/i")
+	 */
+	public function listPackagesCommand(string $message, string $channel, string $sender, CommandReply $sendto, array $args): void {
+		$this->getPackages([$this, "displayPackages"], $sender, $sendto);
+	}
+
+	public function displayPackages(?array $packages, string $sender, CommandReply $sendto): void {
+		if (!isset($packages)) {
+			$sendto->reply("There was an error retrieving the list of available packages.");
+			return;
+		}
+		/** @var array<string,PackageGroup> */
+		$groupedPackages = [];
+		/** @var Package[] $packages */
+		if (!count($packages)) {
+			$sendto->reply("There are currently no packages available for Nadybot.");
+			return;
+		}
+		foreach ($packages as $package) {
+			$pGroup = $groupedPackages[$package->name] ?? null;
+			if (!isset($pGroup)) {
+				$pGroup = new PackageGroup();
+				$pGroup->name = $package->name;
+				$groupedPackages[$package->name] = $pGroup;
+			}
+			$pGroup->highest ??= $package;
+			if ($package->compatible) {
+				$pGroup->highest_supported = $package;
+			}
+		}
+		$blobs = [];
+		foreach ($groupedPackages as $pName => $pGroup) {
+			$package = $pGroup->highest;
+			$infoLink = $this->text->makeChatcmd("details", "/tell <myname> package info {$package->name}");
+			$installLink = "";
+			if ($package->state === static::EXTRA) {
+				$res = $this->db->queryRow(
+					"SELECT MAX(`version`) AS `cur` FROM `package_files_<myname>` ".
+					"WHERE `module`=?",
+					$package->name
+				);
+				$installedVersion = $res->cur;
+			}
+			if (isset($pGroup->highest_supported) && $package->state !== static::BUILT_INT) {
+				if ($pGroup->highest_supported && ($installedVersion??"") !== "") {
+					if (SemanticVersion::compareUsing($installedVersion, $pGroup->highest_supported->version, '<')) {
+						$installLink = $this->text->makeChatcmd(
+							"update",
+							"/tell <myname> package update {$pGroup->highest_supported->name} {$pGroup->highest_supported->version}"
+						);
+					}
+				} else {
+					$installLink = $this->text->makeChatcmd(
+						"install",
+						"/tell <myname> package install {$pGroup->highest_supported->name} {$pGroup->highest_supported->version}"
+					);
+				}
+			} elseif ($package->state === static::BUILT_INT) {
+				$installLink = "<i>Included in Nadybot now</i>";
+			}
+			$blob = "<pagebreak><header2>{$package->name}<end>\n".
+				"<tab>Description: <highlight>{$package->short_description}<end>\n".
+				"<tab>Author: <highlight>{$package->author}<end>\n".
+				"<tab>Newest version: <highlight>{$package->version}<end> [{$infoLink}]\n";
+			if (isset($installedVersion)) {
+				$blob .= "<tab>Installed: <highlight>".
+					($installedVersion ?: "unknown version").
+					"<end>\n";
+			}
+			$blob .= "<tab>Highest compatible version: ".
+				($pGroup->highest_supported
+					? "<highlight>{$pGroup->highest_supported->version}"
+					: "<red>none (needs Nadybot " . htmlspecialchars($pGroup->highest->bot_version) . ")"
+				).
+				"<end> {$installLink}";
+			$blobs []= $blob;
+		}
+		$msg = $this->text->makeBlob(
+			"Available Packages (" . count($groupedPackages) . ")",
+			join("\n\n", $blobs)
+		);
+		$sendto->reply($msg);
+	}
+
+	/**
+	 * @HandlesCommand("package")
+	 * @Matches("/^packages?\s+info\s+(.+)$/i")
+	 */
+	public function packageInfoCommand(string $message, string $channel, string $sender, CommandReply $sendto, array $args): void {
+		$this->getPackage($args[1], [$this, "displayPackageDetail"], $args[1], $sender, $sendto);
+	}
+
+	/**
+	 * @param Package[]|null $packages
+	 */
+	public function displayPackageDetail(?array $packages, string $packageName, string $sender, CommandReply $sendto): void {
+		if (!isset($packages)) {
+			$sendto->reply("There was an error retrieving information about {$packageName}.");
+			return;
+		}
+		if (!count($packages)) {
+			$sendto->reply("{$packageName} is not compatible with Nadybot.");
+			return;
+		}
+		if ($packages[0]->state === static::EXTRA) {
+			$res = $this->db->queryRow(
+				"SELECT MAX(`version`) AS `cur` FROM `package_files_<myname>` ".
+				"WHERE `module`=?",
+				$packages[0]->name
+			);
+			$installedVersion = $res->cur;
+		}
+		$blob = trim($this->renderHTML($packages[0]->description));
+		$blob .= "\n\n<header2>Details<end>\n".
+			"<tab>Name: <highlight>{$packages[0]->name}<end>\n".
+			"<tab>Author: <highlight>{$packages[0]->author}<end>\n";
+		if ($packages[0]->state === static::BUILT_INT) {
+			$blob .= "<tab>Status: <highlight>Included in Nadybot now<end>\n";
+		} elseif (isset($installedVersion)) {
+			$blob .= "<tab>Installed: <highlight>".
+				($installedVersion !== "" ? $installedVersion : "yes, unknown version").
+				"<end>\n";
+		}
+		$blob .= "\n<header2>Available versions<end>\n";
+		foreach ($packages as $package) {
+			$blob .= "<tab><highlight>{$package->version}<end>";
+			if (1 || $package->compatible) {
+				if ($package->state === static::EXTRA) {
+					$installLink = $this->text->makeChatcmd(
+						"install",
+						"/tell <myname> package install {$package->name} {$package->version}"
+					);
+					$updateLink = $this->text->makeChatcmd(
+						"update",
+						"/tell <myname> package update {$package->name} {$package->version}"
+					);
+					if (($installedVersion??"") !== "" && SemanticVersion::compareUsing($installedVersion, $package->version, "<")) {
+						$blob .= " [{$updateLink}]";
+					} elseif (($installedVersion??"") !== "" && SemanticVersion::compareUsing($installedVersion, $package->version, "==")) {
+						$blob .= " <i>Installed</i>";
+					} elseif ($installedVersion === "") {
+						$blob .= " [{$installLink}]";
+					}
+				}
+				$blob .= "\n";
+			} else {
+				$blob .= " <i>incompatible with your version</i>\n";
+			}
+		}
+		$msg = $this->text->makeBlob("Details for {$packageName}", $blob);
+		$sendto->reply($msg);
+	}
+
+	/** Try to render the API's HTML into AOML */
+	public function renderHTML(string $html): string {
+		$html = preg_replace("/\n/", "", $html);
+		$html = preg_replace("/<h1.*?>/", "<header2>", $html);
+		$html = preg_replace("/<\/h1>/", "<end>\n", $html);
+		$html = preg_replace("/<h2.*?>/", "\n<u>", $html);
+		$html = preg_replace("/<\/h2>/", "</u>\n", $html);
+		$html = preg_replace("/<p>/", "<tab>", $html);
+		$html = preg_replace("/<\/p>/", "\n", $html);
+		$html = preg_replace("/<code>/", "<highlight>", $html);
+		$html = preg_replace("/<\/code>/", "<end>", $html);
+		return $html;
+	}
+
+	/**
+	 * Parse a version-requirement string (>=5.0.0, <6.0.0)
+	 * against our bot's version
+	 * @param string $version
+	 * @return bool true if we match, false if not
+	 */
+	public function isVersionCompatible(string $version): bool {
+		$parts = preg_split("/\s*,\s*/", $version);
+		$ourVersion = BotRunner::getVersion();
+
+		foreach ($parts as $part) {
+			if (!preg_match("/^([!=<>]+)(.+)$/", $part, $matches)) {
+				return false;
+			}
+			if (!SemanticVersion::compareUsing($ourVersion, $matches[2], $matches[1])) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * @HandlesCommand("package")
+	 * @Matches("/^packages?\s+install\s+([a-z_0-9-]+)\s+(.+)$/i")
+	 */
+	public function packageInstallCommand(string $message, string $channel, string $sender, CommandReply $sendto, array $args): void {
+		$cmd = new PackageAction($args[1], PackageAction::INSTALL);
+		$cmd->version = new SemanticVersion($args[2]);
+		$cmd->sender = $sender;
+		$cmd->sendto = $sendto;
+		$this->getPackage($args[1], [$this, "checkAndInstall"], $cmd);
+	}
+
+	/**
+	 * @HandlesCommand("package")
+	 * @Matches("/^packages?\s+update\s+([a-z_0-9-]+)$/i")
+	 * @Matches("/^packages?\s+update\s+([a-z_0-9-]+)\s+(.+)$/i")
+	 */
+	public function packageUpdateCommand(string $message, string $channel, string $sender, CommandReply $sendto, array $args): void {
+		$cmd = new PackageAction($args[1], PackageAction::UPGRADE);
+		$cmd->version = $args[2] ? new SemanticVersion($args[2]) : null;
+		$cmd->sender = $sender;
+		$cmd->sendto = $sendto;
+		$this->getPackage($args[1], [$this, "checkAndInstall"], $cmd);
+	}
+
+	/**
+	 * Check if the package is compatible with Bot type and version and install/update if so
+	 *
+	 * @param Package[]|null $packages
+	 */
+	public function checkAndInstall(?array $packages, PackageAction $cmd): void {
+		if (!isset($packages)) {
+			$cmd->sendto->reply(
+				"There was an error retrieving information about ".
+				"<highlight>{$cmd->package}<end>."
+			);
+			return;
+		}
+		if (!count($packages)) {
+			$cmd->sendto->reply("{$cmd->package} is not compatible with Nadybot.");
+			return;
+		}
+		if ($packages[0]->state === static::BUILT_INT) {
+			$cmd->sendto->reply(
+				"<highlight>{$cmd->package}<end> is a built-in module in ".
+				"Nadybot " . BotRunner::getVersion() ." and cannot be managed ".
+				"with this command."
+			);
+			return;
+		}
+		if (isset($cmd->version)) {
+			$packages = array_values(
+				array_filter(
+					$packages,
+					function(Package $package) use ($cmd): bool {
+						return $cmd->version->cmpStr($package->version) === 0;
+					}
+				)
+			);
+			/** @var Package[] $packages */
+			if (!count($packages)) {
+				$cmd->sendto->reply(
+					"<highlight>{$cmd->package}<end> does not exist in ".
+					"version <highlight>{$cmd->version}<end>."
+				);
+				return;
+			}
+			if (!$packages[0]->compatible) {
+				$cmd->sendto->reply(
+					"<highlight>{$cmd->package} {$cmd->version}<end> ".
+					" is not compatible with Nadybot " . BotRunner::getVersion()
+				);
+				return;
+			}
+		} else {
+			$packages = array_values(
+				array_filter(
+					$packages,
+					function(Package $package): bool {
+						return $package->compatible;
+					}
+				)
+			);
+			$newestPackage = end($packages);
+			if ($newestPackage === false) {
+				$cmd->sendto->reply(
+					"No version of <highlight>{$cmd->package}<end> found that ".
+					"is compatible with Nadybot " . BotRunner::getVersion() . "."
+				);
+				return;
+			}
+			$cmd->version = new SemanticVersion($newestPackage->version);
+		}
+		$this->http->get(static::API . "/packages/{$cmd->package}/{$cmd->version}/download")
+			->withTimeout(10)
+			->withCallback([$this, "installPackage"], $cmd);
+	}
+
+	/**
+	 * Get the latest installed version of $package
+	 *
+	 * @return string null if uninstalled, "" if unknown version, "x.y.z" otherwise
+	 */
+	public function getInstalledVersion(string $package, ?string $moduleDir): ?string {
+		$moduleDir ??= $this->getExtraModulesDir();
+		if (!isset($moduleDir)) {
+			return null;
+		}
+		if (!@file_exists("{$moduleDir}/{$package}")) {
+			return null;
+		}
+		if (!@file_exists("{$moduleDir}/{$package}/aopkg.toml")) {
+			return "";
+		}
+		$content = file_get_contents("{$moduleDir}/{$package}/aopkg.toml");
+		if ($content === false) {
+			return "";
+		}
+		if (!preg_match("/^\s*version\s*=\s*\"(.*?)\"/m", $content, $matches)) {
+			return "";
+		}
+		return $matches[1];
+	}
+
+	/** Try to get a ZipArchive from a HttpResponse */
+	protected function getResponseZip(HttpResponse $response, PackageAction $cmd): ?ZipArchive {
+		if ($response->body === null || $response->error) {
+			$cmd->sendto->reply("Error downloading {$cmd->package} {$cmd->version}.");
+			return null;
+		}
+		if ($response->headers["status-code"] === "404") {
+			$cmd->sendto->reply(
+				"<highlight>{$cmd->package} {$cmd->version}<end> does not exist."
+			);
+			return null;
+		}
+		if ($response->headers["status-code"] !== "200"
+			|| $response->headers["content-type"] !== "application/zip") {
+			$cmd->sendto->reply("Error downloading {$cmd->package} {$cmd->version}.");
+			return null;
+		}
+		$temp = tempnam(sys_get_temp_dir(), "nadybot-module");
+		if (@file_put_contents($temp, $response->body) === false) {
+			$cmd->sendto->reply(
+				"Error writing to temporary file: " . error_get_last()["message"]
+			);
+			return null;
+		}
+		$zip = new ZipArchive();
+		$openResult = $zip->open($temp);
+		@unlink($temp);
+		if ($openResult !== true) {
+			$cmd->sendto->reply("The downloaded file was corrupt.");
+			return null;
+		}
+		if ($zip->numFiles < 1) {
+			$cmd->sendto->reply("The package didn't contain any data.");
+			return null;
+		}
+		return $zip;
+	}
+
+	/** Install a requested package that comes as a callback */
+	public function installPackage(HttpResponse $response, PackageAction $cmd): void {
+		$zip = $this->getResponseZip($response, $cmd);
+		if (!isset($zip)) {
+			return;
+		}
+		$targetDir = $this->getExtraModulesDir();
+
+		if ($targetDir === null) {
+			$cmd->sendto->reply(
+				"Your Bot configuration does not have an extra modules dir defined. ".
+				"If you want to be able to install additional, user-provided modules, ".
+				"please add one."
+			);
+			return;
+		}
+		$oldVersion = $this->getInstalledVersion($cmd->package, $targetDir);
+		$cmd->oldVersion = isset($oldVersion) ? new SemanticVersion($oldVersion) : $oldVersion;
+		if (!$this->canInstallVersion($cmd)) {
+			return;
+		}
+
+		$this->logger->log("INFO", "Installing module {$cmd->package} into {$targetDir}/{$cmd->package}");
+		if (!@file_exists("{$targetDir}/{$cmd->package}/")) {
+			if (!@mkdir("{$targetDir}/{$cmd->package}", 0700, true)) {
+				$cmd->sendto->reply(
+					"There was an error creating ".
+					"<highlight>{$targetDir}/{$cmd->package}<end>."
+				);
+				$this->logger->log("ERROR", "Error on mkdir of {$targetDir}/{$cmd->package}: " .
+					error_get_last()["message"]);
+				return;
+			}
+		}
+		if ($cmd->action === $cmd::UPGRADE) {
+			$this->removePackageInstallation($cmd, $targetDir);
+		}
+
+		if (!$this->installAndRegisterZip($zip, $cmd, $targetDir)) {
+			return;
+		}
+
+		if ($cmd->action === $cmd::INSTALL) {
+			$cmd->sendto->reply(
+				"<highlight>{$cmd->package} {$cmd->version}<end> installed successfully. ".
+				"Restart the bot for the changes to take effect."
+			);
+		} else {
+			$cmd->sendto->reply(
+				"<highlight>{$cmd->package}<end> successfully upgraded ".
+				($cmd->oldVersion ? "from {$cmd->oldVersion} " : "").
+				"to {$cmd->version}. ".
+				"Restart the bot for the changes to take effect."
+			);
+		}
+	}
+
+	/**
+	 * Remove all files from the old version in the filesystem, excluding
+	 * the module directory itself
+	 */
+	public function removePackageInstallation(PackageAction $cmd, string $targetDir): bool {
+		/** @var PackageFile[] */
+		$oldFiles = $this->db->fetchAll(
+			PackageFile::class,
+			"SELECT * FROM `package_files_<myname>` ".
+			"WHERE `module`=? ORDER BY LENGTH(`file`) DESC",
+			$cmd->package
+		);
+		foreach ($oldFiles as $oldFile) {
+			$fullFilename = "{$targetDir}/{$oldFile->file}";
+			if (!@file_exists($fullFilename)) {
+				continue;
+			}
+			if (@is_dir($fullFilename)) {
+				$this->logger->log("INFO", "rmdir {$fullFilename}");
+				@rmdir($fullFilename);
+			} else {
+				$this->logger->log("INFO", "del {$fullFilename}");
+				@unlink($fullFilename);
+			}
+		}
+		$this->db->exec(
+			"DELETE FROM `package_files_<myname>` WHERE module=?",
+			$cmd->package
+		);
+		return true;
+	}
+
+	/**
+	 * Extract all files from the zip file according to spec
+	 * and register them in the database for update
+	 */
+	public function installAndRegisterZip(ZipArchive $zip, PackageAction $cmd, string $targetDir): bool {
+		$subDir = $this->getSubdir($zip);
+		for ($i = 0; $i < $zip->numFiles; $i++) {
+			$targetFile = "{$targetDir}/{$cmd->package}/".
+				substr($zip->getNameIndex($i), strlen($subDir));
+			if (substr($targetFile, -1, 1) === "/") {
+				if (@mkdir($targetFile, 0700, true) === false) {
+					$cmd->sendto->reply(
+						"There was an error creating <highlight>{$targetFile}<end>."
+					);
+					$this->logger->log("ERROR", "Error on mkdir of {$targetFile}: ".
+						error_get_last()["message"]);
+					return false;
+				}
+			} else {
+				$success = @file_put_contents($targetFile, $zip->getFromIndex($i));
+				if ($success === false) {
+					$cmd->sendto->reply(
+						"There was an error extracting <highlight>{$targetFile}<end>."
+					);
+					$this->logger->log("ERROR", "Error on extraction of {$targetFile}: ".
+						error_get_last()["message"]);
+					return false;
+				}
+			}
+			$this->logger->log("INFO", "unzip -> {$targetFile}");
+			$this->db->exec(
+				"INSERT INTO `package_files_<myname>`(`module`, `version`, `file`) VALUES".
+				"(?, ?, ?)",
+				$cmd->package,
+				$cmd->version,
+				"{$cmd->package}/" . substr($zip->getNameIndex($i), strlen($subDir))
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Check if the action in $cmd can be done version-wise
+	 */
+	public function canInstallVersion(PackageAction $cmd): bool {
+		if (!isset($cmd->oldVersion) && $cmd->action === $cmd::UPGRADE) {
+			$cmd->sendto->reply("<highlight>{$cmd->package}<end> is not installed, nothing to upgrade.");
+			return false;
+		}
+		if (!isset($cmd->oldVersion)) {
+			return true;
+		}
+		if ((string)$cmd->oldVersion === "") {
+			$cmd->sendto->reply("<highlight>{$cmd->package}<end> is already installed.");
+			return false;
+		}
+		$cmp = $cmd->oldVersion->cmp($cmd->version);
+		if ($cmp < 0 && $cmd->action !== $cmd::UPGRADE) {
+			$cmd->sendto->reply(
+				"You have <highlight>{$cmd->package} {$cmd->oldVersion}<end> ".
+				"installed. Use <highlight><symbol>package update {$cmd->package} {$cmd->version}<end> ".
+				"to update this installation."
+			);
+			return false;
+		} elseif ($cmp === 0) {
+			$cmd->sendto->reply(
+				"<highlight>{$cmd->package} {$cmd->oldVersion}<end> is already installed."
+			);
+			return false;
+		} elseif ($cmp > 0) {
+			$cmd->sendto->reply(
+				"You cannot downgrade to <highlight>{$cmd->package} {$cmd->version}<end>."
+			);
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Try to find out if all files in the ZIP are in a base
+	 * directory (the module dir) or directly in /
+	 */
+	protected function getSubdir(ZipArchive $zip): string {
+		$subdir = "";
+		for ($i = 0; $i < $zip->numFiles; $i++ ) {
+			$name = $zip->getNameIndex($i);
+			$slashPos = strpos($name, "/");
+			if ($slashPos === false) {
+				return "";
+			}
+			$subdir = substr($name, 0, $slashPos+1);
+		}
+		return $subdir;
+	}
+
+	/** Try to determine the directory where custom modules shall be installed */
+	public function getExtraModulesDir(): ?string {
+		$moduleDirs = array_map("realpath", $this->chatBot->vars["module_load_paths"]);
+		$moduleDirs = array_diff($moduleDirs, [realpath("./src/Modules")]);
+		$extraDir = end($moduleDirs);
+		if ($extraDir === false) {
+			return null;
+		}
+		return $extraDir;
+	}
+}

--- a/src/Modules/PACKAGE_MODULE/PackageFile.php
+++ b/src/Modules/PACKAGE_MODULE/PackageFile.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\PACKAGE_MODULE;
+
+use Nadybot\Core\DBRow;
+
+class PackageFile extends DBRow {
+	/** From which module/package is that file */
+	public string $module;
+	/** From which module/package version is that file */
+	public string $version;
+	/** Filename relative to extra module basedir */
+	public string $file;
+}

--- a/src/Modules/PACKAGE_MODULE/PackageGroup.php
+++ b/src/Modules/PACKAGE_MODULE/PackageGroup.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\PACKAGE_MODULE;
+
+class PackageGroup {
+	public string $name;
+
+	public ?Package $highest_supported = null;
+	public ?Package $highest = null;
+}

--- a/src/Modules/PACKAGE_MODULE/README.txt
+++ b/src/Modules/PACKAGE_MODULE/README.txt
@@ -1,0 +1,3 @@
+This module allows you to install, update and uninstall
+extra modules from https://pkg.aobots.org directly from
+the bot.

--- a/src/Modules/PACKAGE_MODULE/SemanticVersion.php
+++ b/src/Modules/PACKAGE_MODULE/SemanticVersion.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\PACKAGE_MODULE;
+
+class SemanticVersion {
+	protected string $version;
+
+	public function __construct(string $version) {
+		$this->version = $this->normalizeVersion($version);
+	}
+
+	public function __toString(): string {
+		return $this->version;
+	}
+
+	public function cmp(SemanticVersion $version2): int {
+		return static::compare($this->version, (string)$version2);
+	}
+
+	public function cmpStr(string $version2): int {
+		return static::compare($this->version, $version2);
+	}
+
+	public static function normalizeVersion(string $version): string {
+		$version = preg_replace("/@.+$/", "", $version);
+		if (preg_match("/[^\d]$/", $version)) {
+			$version .= "1";
+		}
+		$version = preg_replace("/[^a-z0-9.]+/i", ".", $version);
+		$version = preg_replace("/([a-z]+)(?!\.|$)/i", "$1.", $version);
+		$version = preg_replace("/^(\d+)\.(?!\d)/", "$1.0.0.", $version);
+		$version = preg_replace("/^(\d+\.\d+)\.(?!\d)/", "$1.0.", $version);
+		return $version;
+	}
+
+	public static function compare(string $version1, string $version2): int {
+		$v1 = explode(".", static::normalizeVersion($version1));
+		$v2 = explode(".", static::normalizeVersion($version2));
+
+		for ($i = 0; $i < max(count($v1), count($v2)); $i++) {
+			$t1 = $v1[$i] ?? "0";
+			$t2 = $v2[$i] ?? "0";
+			if (!ctype_digit($t1) && !ctype_digit($t2)) {
+				$t1 = ord(substr($t1, 0, 1));
+				$t2 = ord(substr($t2, 0, 1));
+			} elseif (!ctype_digit($t1)) {
+				return -1;
+			} elseif (!ctype_digit($t2)) {
+				return 1;
+			}
+			if (($cmp = ($t1 <=> $t2)) === 0) {
+				continue;
+			}
+			return $cmp;
+		}
+		return 0;
+	}
+
+	public static function compareUsing(string $version1, string $version2, string $operator): bool {
+		$cmp = static::compare($version1, $version2);
+		switch ($operator) {
+			case "<>":
+			case "!=":
+				return $cmp !== 0;
+			case "=":
+			case "==":
+				return $cmp === 0;
+			case "<":
+				return $cmp < 0;
+			case "<=":
+				return $cmp <= 0;
+			case ">":
+				return $cmp > 0;
+			case ">=":
+				return $cmp >= 0;
+		}
+		return false;
+	}
+}

--- a/src/Modules/PACKAGE_MODULE/SemanticVersion.php
+++ b/src/Modules/PACKAGE_MODULE/SemanticVersion.php
@@ -22,7 +22,7 @@ class SemanticVersion {
 	}
 
 	public static function normalizeVersion(string $version): string {
-		$version = preg_replace("/@.+$/", "", $version);
+		$version = preg_replace("/@.+$/", "", strtolower($version));
 		if (preg_match("/[^\d]$/", $version)) {
 			$version .= "1";
 		}

--- a/src/Modules/PACKAGE_MODULE/package.txt
+++ b/src/Modules/PACKAGE_MODULE/package.txt
@@ -5,6 +5,9 @@ To get information about a specific package, use
 <tab><highlight><symbol>package info 'package'<end>
 
 To install a package, use:
+<tab><highlight><symbol>package install 'package'<end>
+
+To install a package in a specific version, use:
 <tab><highlight><symbol>package install 'package' 'version'<end>
 
 To update an already installed package to a specific version, use:
@@ -12,3 +15,6 @@ To update an already installed package to a specific version, use:
 
 To update an already installed package to the latest version, use:
 <tab><highlight><symbol>package update 'package'<end>
+
+To uninstall a package, use:
+<tab><highlight><symbol>package uninstall 'package'<end>

--- a/src/Modules/PACKAGE_MODULE/package.txt
+++ b/src/Modules/PACKAGE_MODULE/package.txt
@@ -1,0 +1,14 @@
+In order to get a full list of all available packages, use
+<tab><highlight><symbol>packages list<end>
+
+To get information about a specific package, use
+<tab><highlight><symbol>package info 'package'<end>
+
+To install a package, use:
+<tab><highlight><symbol>package install 'package' 'version'<end>
+
+To update an already installed package to a specific version, use:
+<tab><highlight><symbol>package update 'package' 'version'<end>
+
+To update an already installed package to the latest version, use:
+<tab><highlight><symbol>package update 'package'<end>

--- a/src/Modules/PACKAGE_MODULE/package_files.sql
+++ b/src/Modules/PACKAGE_MODULE/package_files.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS `package_files_<myname>`(
+	`module` VARCHAR(25) NOT NULL,
+	`version` VARCHAR(50) NOT NULL,
+	`file` TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS `package_files_<myname>_module_idx` on `package_files_<myname>`(`module`);
+CREATE INDEX IF NOT EXISTS `package_files_<myname>_version_idx` on `package_files_<myname>`(`version`);


### PR DESCRIPTION
Introduce the `PACKAGE_MODULE` to Nadybot

The idea is to be able to install modules from a central database https://pkg.aobots.org via the bot itself, without the need to manually download and install things.

Because this is a security risk for bot-hosters, the install, update and uninstall option need to be explicitely enabled in the bot configuration file.

Closes #91 