### PR TITLE
Colorize item matches

### DIFF
--- a/src/Modules/ITEMS_MODULE/ItemsController.php
+++ b/src/Modules/ITEMS_MODULE/ItemsController.php
@@ -592,6 +592,16 @@ class ItemsController {
 			}
 			unset($nameMatches);
 		}
+		$list = preg_replace_callback(
+			"/^([^<]+?)<red>\[<end>(.+)<red>\]<end>$/m",
+			function(array $matches): string {
+				if (strpos($matches[2], "<red>") !== false) {
+					return $matches[0];
+				}
+				return $matches[1].$matches[2];
+			},
+			$list
+		);
 		return $list;
 	}
 

--- a/src/Modules/ITEMS_MODULE/ItemsController.php
+++ b/src/Modules/ITEMS_MODULE/ItemsController.php
@@ -330,7 +330,8 @@ class ItemsController {
 		$data = $this->findItemsFromLocal($search, $ql);
 
 		$aoiaPlusLink = $this->text->makeChatcmd("AOIA+", "/start https://sourceforge.net/projects/aoiaplus");
-		$footer = "Item DB rips created using the $aoiaPlusLink tool.";
+		$footer = "QLs between <red>[<end>brackets<red>]<end> denote items matching your name search\n".
+			"Item DB rips created using the $aoiaPlusLink tool.";
 
 		$msg = $this->createItemsBlob($data, $search, $ql, $this->settingManager->get('aodb_db_version'), 'local', $footer);
 
@@ -419,7 +420,7 @@ class ItemsController {
 			}
 			return $msg;
 		} elseif ($groups < 4) {
-			return trim($this->formatSearchResults($data, $ql, false));
+			return trim($this->formatSearchResults($data, $ql, false, $search));
 		}
 		$blob = "Version: <highlight>$version<end>\n";
 		if ($ql !== null) {
@@ -432,7 +433,7 @@ class ItemsController {
 			$blob .= "Time: <highlight>" . round($elapsed, 2) . "s<end>\n";
 		}
 		$blob .= "\n";
-		$blob .= $this->formatSearchResults($data, $ql, true);
+		$blob .= $this->formatSearchResults($data, $ql, true, $search);
 		if ($numItems === $this->settingManager->getInt('maxitems')) {
 			$blob .= "\n\n<highlight>*Results have been limited to the first " . $this->settingManager->get("maxitems") . " results.<end>";
 		}
@@ -487,11 +488,12 @@ class ItemsController {
 	 * @param bool $showImages
 	 * @return string
 	 */
-	public function formatSearchResults(array $data, ?int $ql, bool $showImages) {
+	public function formatSearchResults(array $data, ?int $ql, bool $showImages, ?string $search=null) {
 		$list = '';
 		$oldGroup = null;
 		for ($itemNum = 0; $itemNum < count($data); $itemNum++) {
 			$row = $data[$itemNum];
+			$row->origName = $row->name;
 			$newGroup = false;
 			if (!isset($row->group_id) && $ql && $ql !== $row->ql) {
 				continue;
@@ -500,6 +502,14 @@ class ItemsController {
 				$lastQL = null;
 				$newGroup = true;
 				// If this is a group of items, name them by their longest common name
+				if (isset($nameMatches)) {
+					if (substr($list, -2, 2) === ", ") {
+						$list = substr($list, 0, strlen($list) - 2) . "<red>]<end>, ";
+					} else {
+						$list .= "<red>]<end>";
+					}
+					unset($nameMatches);
+				}
 				if (isset($row->group_id)) {
 					$itemNames = [];
 					for ($j=$itemNum; $j < count($data); $j++) {
@@ -542,6 +552,19 @@ class ItemsController {
 				} else {
 					$list .= ", ";
 				}
+				if (isset($search) && $this->itemNameMatchesSearch($row->origName, $search)) {
+					if (!isset($nameMatches)) {
+						$list .= "<red>[<end>";
+						$nameMatches = true;
+					}
+				} elseif (isset($nameMatches)) {
+					if (substr($list, -2, 2) === ", ") {
+						$list = substr($list, 0, strlen($list) - 2) . "<red>]<end>, ";
+					} else {
+						$list .= "<red>]<end>";
+					}
+					unset($nameMatches);
+				}
 				$item = $this->text->makeItem($row->lowid, $row->highid, $row->ql, (string)$row->ql);
 				if ($ql === $row->ql) {
 					$list .= "<yellow>[<end>$item<yellow>]<end>";
@@ -561,7 +584,28 @@ class ItemsController {
 				$lastQL = $row->ql;
 			}
 		}
+		if (isset($nameMatches)) {
+			if (substr($list, -2, 2) === ", ") {
+				$list = substr($list, 0, strlen($list) - 2) . "<red>]<end>, ";
+			} else {
+				$list .= "<red>]<end>";
+			}
+			unset($nameMatches);
+		}
 		return $list;
+	}
+
+	public function itemNameMatchesSearch(string $itemName, ?string $search): bool {
+		if (!isset($search)) {
+			return false;
+		}
+		$tokens = preg_split("/\s+/", $search);
+		foreach ($tokens as $token) {
+			if (stripos($itemName, $token) === false) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	public function findByName(string $name, ?int $ql=null): ?AODBEntry {

--- a/src/Modules/ITEMS_MODULE/ItemsController.php
+++ b/src/Modules/ITEMS_MODULE/ItemsController.php
@@ -601,7 +601,12 @@ class ItemsController {
 		}
 		$tokens = preg_split("/\s+/", $search);
 		foreach ($tokens as $token) {
-			if (stripos($itemName, $token) === false) {
+			if (substr($token, 0, 1) === "-"
+				&& stripos($itemName, substr($token, 1)) !== false) {
+				return false;
+			}
+			if (substr($token, 0, 1) !== "-"
+				&& stripos($itemName, $token) === false) {
 				return false;
 			}
 		}

--- a/src/Modules/ITEMS_MODULE/items.txt
+++ b/src/Modules/ITEMS_MODULE/items.txt
@@ -4,13 +4,13 @@ To search for an item using the local database:
 To search for a specific QL of an item:
 <highlight><tab><symbol>items 'QL' 'item name'<end>
 
-To search for an item by id:
-<highlight><tab><symbol>itemid 'id'<end>
-
-Note: to not include results that match a certain search term, precede term with a minus ('-').
-
 To search for item IDs by name:
 <highlight><tab><symbol>id 'name'<end>
+
+<i>Note: to not include results that match a certain search term, precede term with a minus ('-').</i>
+
+To search for an item by id:
+<highlight><tab><symbol>itemid 'id'<end>
 
 <header2>Examples:<end>
 
@@ -25,3 +25,6 @@ Shows results with 'panther' but not 'ofab' in the name
 
 Shows Burden of Competence
 <highlight><tab><symbol>itemid 244718<end>
+
+Search for the item id of 'Burden of Competence'
+<highlight><tab><symbol>id burden competence<end>


### PR DESCRIPTION
An item search for something like "beyer" will show all the Galahad weapons, leaving the user clueless which QLs actually matched the word "beyer". In fact, only 2 do.
To enhance the search results, the QLs matching the search term will be enclosed in red brackets in addition to the optional yellow brackets for QL matches. Because this is not immediately obvious, an additional footnote was added to explain the red brackets.

Searches to try:

- `!items beyer`
- `!items chiroptera -crispy`

Closes #99
Closes #101 