### PR TITLE
Alias parameters

### DIFF
--- a/src/Core/CommandAlias.php
+++ b/src/Core/CommandAlias.php
@@ -111,12 +111,10 @@ class CommandAlias {
 		// count number of parameters and don't split more than that so that the
 		// last parameter will have whatever is left
 
-		// TODO: figure out highest numbered parameter and use that as $numMatches
-		// otherwise this will break if the parameters do not include every number
-		// from 1 to MAX -Tyrence
-		preg_match_all("/\{\\d+(:.*?)?\}/", $cmd, $matches);
-		$numMatches = count(array_unique($matches[0]));
-		if ($numMatches === 0) {
+		preg_match_all("/\{(\\d+)(:.*?)?\}/", $cmd, $matches);
+		$values = array_map("intval", $matches[1]);
+		$numMatches = max([0, ...$values]);
+		if ($numMatches === 0 && !count($values)) {
 			$cmd .= " {0}";
 		}
 

--- a/src/Core/CommandAlias.php
+++ b/src/Core/CommandAlias.php
@@ -108,20 +108,19 @@ class CommandAlias {
 		$this->logger->log('DEBUG', "Command alias found command: '{$row->cmd}' alias: '{$row->alias}'");
 		$cmd = $row->cmd;
 
-		// count number of parameters and don't split more than that so that the
+		// Determine highest placeholder and don't split more than that so that the
 		// last parameter will have whatever is left
-
 		preg_match_all("/\{(\\d+)(:.*?)?\}/", $cmd, $matches);
-		$values = array_map("intval", $matches[1]);
-		$numMatches = max([0, ...$values]);
+		$placeholders = array_map("intval", $matches[1]);
+		$highestPlaceholder = max([0, ...$placeholders]);
 		// If there aren't any defined parameters, but player gave arguments, process them:
-		if ($numMatches === 0 && !count($values) && $params !== "") {
+		if ($highestPlaceholder === 0 && !count($placeholders) && $params !== "") {
 			$cmd .= " {0}";
 		}
 
 		$aliasParams = [];
 		if ($params !== "") {
-			$aliasParams = explode(' ', $params, $numMatches);
+			$aliasParams = explode(' ', $params, $highestPlaceholder);
 			// add the entire param string as the {0} parameter
 			array_unshift($aliasParams, $params);
 		}

--- a/src/Core/CommandAlias.php
+++ b/src/Core/CommandAlias.php
@@ -114,16 +114,19 @@ class CommandAlias {
 		preg_match_all("/\{(\\d+)(:.*?)?\}/", $cmd, $matches);
 		$values = array_map("intval", $matches[1]);
 		$numMatches = max([0, ...$values]);
+		// If there aren't any defined parameters, but player gave arguments, process them:
 		if ($numMatches === 0 && !count($values) && $params !== "") {
 			$cmd .= " {0}";
 		}
 
-		$aliasParams = $params === "" ? [] : explode(' ', $params, $numMatches);
+		$aliasParams = [];
+		if ($params !== "") {
+			$aliasParams = explode(' ', $params, $numMatches);
+			// add the entire param string as the {0} parameter
+			array_unshift($aliasParams, $params);
+		}
 
-		// add the entire param string as the {0} parameter
-		array_unshift($aliasParams, $params);
-
-		// replace parameter placeholders with their values
+		// replace parameter placeholders with their values or the default
 		$cmd = preg_replace_callback(
 			"/\{(\d+)(:.*?)?\}/",
 			function (array $matches) use ($aliasParams): string {

--- a/src/Core/CommandAlias.php
+++ b/src/Core/CommandAlias.php
@@ -114,7 +114,7 @@ class CommandAlias {
 		preg_match_all("/\{(\\d+)(:.*?)?\}/", $cmd, $matches);
 		$values = array_map("intval", $matches[1]);
 		$numMatches = max([0, ...$values]);
-		if ($numMatches === 0 && !count($values)) {
+		if ($numMatches === 0 && !count($values) && $params !== "") {
 			$cmd .= " {0}";
 		}
 

--- a/src/Core/Modules/CONFIG/AliasController.php
+++ b/src/Core/Modules/CONFIG/AliasController.php
@@ -37,6 +37,8 @@ class AliasController {
 	 * This command handler add a command alias.
 	 *
 	 * @HandlesCommand("alias")
+	 * @Matches('/^alias add "([a-z 0-9]+?)" (.+)/si')
+	 * @Matches("/^alias add '([a-z 0-9]+?)' (.+)/si")
 	 * @Matches("/^alias add ([a-z0-9]+) (.+)/si")
 	 */
 	public function aliasAddCommand(string $message, string $channel, string $sender, CommandReply $sendto, array $args): void {
@@ -113,7 +115,7 @@ class AliasController {
 	 * This command handler remove a command alias.
 	 *
 	 * @HandlesCommand("alias")
-	 * @Matches("/^alias rem ([a-z0-9]+)/i")
+	 * @Matches("/^alias rem ([a-z 0-9]+)/i")
 	 */
 	public function aliasRemCommand(string $message, string $channel, string $sender, CommandReply $sendto, array $args): void {
 		$alias = strtolower($args[1]);

--- a/src/Core/Modules/CONFIG/alias.txt
+++ b/src/Core/Modules/CONFIG/alias.txt
@@ -1,15 +1,25 @@
+<header2>Syntax<end>
+
 To show a list of the current aliases:
 <highlight><tab><symbol>alias list<end>
 
 To create an alias:
-<highlight><tab><symbol>alias add <i>alias_name</i> <i>command_name</i><end>
+<highlight><tab><symbol>alias add <i>alias_name</i> <i>command to execue</i><end>
+
+To create an alias consisting of more than 1 word, enclose it in single or double quotes:
+<highlight><tab><symbol>alias add <i>"alias name"</i> <i>command to execute</i><end>
+
+You can refer to the parameters of your command with a numeric placeholder {1} to whatever
+you want to go. The alias will throw an error, though, when you do not give enough
+arguments to the alias. If an alias defines a placeholder {4}, then you have to give
+at least 4 parameters. The highest parameter will always get all remaining parameters
+given to the alias and you can define default values like {3:Default value} if the
+parameter is not given. The placeholder {0} always contains all arguments as one.
 
 To remove an alias:
 <highlight><tab><symbol>alias rem <i>alias_name</i><end>
 
-Note that while <i>command_name</i> can have multiple words, the <i>alias_name</i> parameter can only be a single word.  The first word is interpreted as the alias name and all subsequent words are interpreted as the command name.
-
-<header2> ::: Examples ::: <end>
+<header2>Examples<end>
 
 Create an alias for a single-worded command:
 <highlight><tab><symbol>alias add o online<end>
@@ -18,3 +28,9 @@ This will let you use <highlight><symbol>o<end> instead of <highlight><symbol>on
 Create an alias for a multi-worded command:
 <highlight><tab><symbol>alias add orgwins victory org <myguild><end>
 This will let you use <highlight><symbol>orgwins<end> instead of <highlight><symbol>victory org <myguild><end> to see recent tower victories of your org.
+
+Create an alias to encapsulate your commands into exclamation marks:
+<highlight><tab><symbol>alias add c cmd !!! {0} !!!<end>
+
+Same, but with a default text
+<highlight><tab><symbol>alias add c cmd !!! {0:Party on guys} !!!<end>

--- a/src/Core/Modules/CONFIG/alias.txt
+++ b/src/Core/Modules/CONFIG/alias.txt
@@ -4,7 +4,7 @@ To show a list of the current aliases:
 <highlight><tab><symbol>alias list<end>
 
 To create an alias:
-<highlight><tab><symbol>alias add <i>alias_name</i> <i>command to execue</i><end>
+<highlight><tab><symbol>alias add <i>alias_name</i> <i>command to execute</i><end>
 
 To create an alias consisting of more than 1 word, enclose it in single or double quotes:
 <highlight><tab><symbol>alias add <i>"alias name"</i> <i>command to execute</i><end>


### PR DESCRIPTION
* Support creation of aliases with more than one word: `!alias add "kos add" comment add {1} kos`
* Support default values for alias parameters: `!alias add "kos add" comment add {1} kos {2:Kill on sight}`