### PR TITLE
Make sure we don't have dups in players

### DIFF
--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -675,6 +675,26 @@ class DB {
 		)->exists > 0;
 	}
 
+	public function columnUnique(string $table, string $column): bool {
+		if ($this->getType() === static::SQLITE) {
+			$indexes = $this->query("PRAGMA index_list(`{$table}`)");
+			foreach ($indexes as $index) {
+				if (!$index->unique) {
+					continue;
+				}
+				$indexColumns = $this->query("PRAGMA index_info(`{$index->name}`)");
+				foreach ($indexColumns as $indexColumn) {
+					if ($column !== $indexColumn->name) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+		$indexes = $this->queryRow("SHOW INDEXES FROM `{$table}` WHERE Column_name=? AND NOT Non_Unique", $column);
+		return isset($indexes);
+	}
+
 	/**
 	 * Insert a DBRow $row into the database table $table
 	 */

--- a/src/Core/Modules/PLAYER_LOOKUP/PlayerLookupController.php
+++ b/src/Core/Modules/PLAYER_LOOKUP/PlayerLookupController.php
@@ -3,6 +3,7 @@
 namespace Nadybot\Core\Modules\PLAYER_LOOKUP;
 
 use Nadybot\Core\DB;
+use Nadybot\Core\LoggerWrapper;
 
 /**
  * @author Tyrence (RK2)
@@ -20,6 +21,9 @@ class PlayerLookupController {
 	/** @Inject */
 	public DB $db;
 
+	/** @Logger */
+	public LoggerWrapper $logger;
+
 	/**
 	 * @Setup
 	 * This handler is called on bot startup.
@@ -27,7 +31,57 @@ class PlayerLookupController {
 	public function setup() {
 		$this->db->loadSQLFile($this->moduleName, 'players');
 		if ($this->db->getType() === $this->db::MYSQL) {
-			$this->db->exec("ALTER TABLE players change `prof_title` `prof_title` VARCHAR(40)");
+			$this->db->exec("ALTER TABLE `players` CHANGE `prof_title` `prof_title` VARCHAR(40)");
+		}
+		$this->upgradeToUniqueNameDim();
+	}
+
+	/**
+	 * Ensure that name and dimension are a unique tuple
+	 * @return void
+	 */
+	protected function upgradeToUniqueNameDim() {
+		if ($this->db->columnUnique("players", "name")) {
+			return;
+		}
+		if ($this->db->getType() === $this->db::MYSQL) {
+			$this->logger->log('INFO', "Upgrading schema for table players");
+			$doublePlayers = $this->db->query(
+				"SELECT `name`, `dimension`, COUNT(*) AS `amount` ".
+				"FROM `players` ".
+				"GROUP BY `name`, `dimension` ".
+				"HAVING COUNT(*) > 1"
+			);
+			$this->logger->log('INFO', "* Deleting " . count($doublePlayers) . " duplicates");
+			foreach ($doublePlayers as $duplicate) {
+				$this->db->exec(
+					"DELETE FROM `players` WHERE `name`=? AND `dimension`=? LIMIT ?",
+					$duplicate->name,
+					$duplicate->dimension,
+					$duplicate->amount - 1
+				);
+			}
+			$this->logger->log('INFO', "* Adding UNIQUE index");
+			$this->db->exec(
+				"ALTER TABLE `players` ".
+				"ADD CONSTRAINT `UC_players_name_dim` UNIQUE (`name`, `dimension`)"
+			);
+			$this->logger->log('INFO', "* DONE");
+		} elseif ($this->db->getType() === $this->db::SQLITE) {
+			$this->logger->log('INFO', "Upgrading schema for table players");
+			$this->logger->log('INFO', "* Deleting duplicates");
+			$this->db->exec(
+				"DELETE FROM `players` ".
+				"WHERE rowid NOT IN ( ".
+					"SELECT MIN(rowid) FROM `players` GROUP BY `name`, `dimension`".
+				")"
+			);
+			$this->logger->log('INFO', "* Adding UNIQUE index");
+			$this->db->exec(
+				"CREATE UNIQUE INDEX `players_name_dim_idx` ".
+				"ON `players`(`name`, `dimension`)"
+			);
+			$this->logger->log('INFO', "* DONE");
 		}
 	}
 }

--- a/src/Core/Modules/PLAYER_LOOKUP/PlayerManager.php
+++ b/src/Core/Modules/PLAYER_LOOKUP/PlayerManager.php
@@ -209,9 +209,6 @@ class PlayerManager {
 	}
 
 	public function update(Player $char): void {
-		$sql = "DELETE FROM players WHERE `name` = ? AND `dimension` = ?";
-		$this->db->exec($sql, $char->name, $char->dimension);
-
 		$char->guild_id ??= 0;
 
 		if ($char->guild_rank_id === '') {
@@ -219,7 +216,7 @@ class PlayerManager {
 		}
 
 		$sql = "
-			INSERT INTO players (
+			REPLACE INTO players (
 				`charid`,
 				`firstname`,
 				`name`,

--- a/src/Core/Modules/PLAYER_LOOKUP/players.sql
+++ b/src/Core/Modules/PLAYER_LOOKUP/players.sql
@@ -20,7 +20,8 @@ CREATE TABLE IF NOT EXISTS players(
 	`pvp_rating`    SMALLINT DEFAULT NULL,
 	`pvp_title`     VARCHAR (20) DEFAULT NULL,
 	`source`        VARCHAR (50) NOT NULL DEFAULT '',
-	`last_update`   INT     
+	`last_update`   INT,
+	UNIQUE(`name`, `dimension`)
 );
-CREATE INDEX IF NOT EXISTS players_name ON players(name);
-CREATE INDEX IF NOT EXISTS players_charid ON players(charid);
+CREATE INDEX IF NOT EXISTS `players_name` ON `players`(`name`);
+CREATE INDEX IF NOT EXISTS `players_charid` ON `players`(`charid`);


### PR DESCRIPTION
If 2 bots share the same database, then it can
happen that both insert player data at the same
time, leading to totally stupid things like
players appearing multiple times in the online
list or on the tracker list.
This commit ensures that it doesn't happen again
and also removes all already existing dupes from
the players table.