### PR TITLE
Implement raid rank promition distance

### DIFF
--- a/src/Modules/RAID_MODULE/RaidRankController.php
+++ b/src/Modules/RAID_MODULE/RaidRankController.php
@@ -95,7 +95,7 @@ class RaidRankController {
 		$this->settingManager->add(
 			$this->moduleName,
 			'raid_rank_promotion_distance',
-			'Number of raid ranks below your own you can promote to',
+			'Number of raid ranks below your own you can manage',
 			'edit',
 			'number',
 			'1'


### PR DESCRIPTION
This allows limiting up to which raid rank below your own,
raid admins/leaders are allowed to make changes.
This includes promoting as well as demoting.

Close #137