### PR TITLE
First tower module overhaul

### DIFF
--- a/createMigration.php
+++ b/createMigration.php
@@ -15,13 +15,13 @@ class CreateMigration {
 		$className = basename($migration, ".shared");
 		$namespace = "Unknown";
 		if (preg_match("/Core\/Modules\/(.+)$/", $path, $matches)) {
-			$namespace = "Nadybot\\Core\\Modules\\" . rtrim(str_replace("/", "\\", $matches[1]), "/");
+			$namespace = "Nadybot\\Core\\Modules\\" . rtrim(str_replace("/", "\\", $matches[1]), "\\");
 		} elseif (preg_match("/Core\/Migrations/", $path)) {
 			$namespace = "Nadybot\\Core\\Migrations";
 		} elseif (preg_match("/src\/Modules\/(.+)$/", $path, $matches)) {
-			$namespace = "Nadybot\\Modules\\" . rtrim(str_replace("/", "\\", $matches[1]), "/");
+			$namespace = "Nadybot\\Modules\\" . rtrim(str_replace("/", "\\", $matches[1]), "\\");
 		} elseif (preg_match("/extras\/(.+)$/", $path, $matches)) {
-			$namespace = "Nadybot\\User\\Modules\\" . rtrim(str_replace("/", "\\", $matches[1]), "/");
+			$namespace = "Nadybot\\User\\Modules\\" . rtrim(str_replace("/", "\\", $matches[1]), "\\");
 		}
 		$fileName = sprintf(
 			"%s/%d_%s.php",

--- a/src/Core/Modules/CONSOLE/ConsoleCommandReply.php
+++ b/src/Core/Modules/CONSOLE/ConsoleCommandReply.php
@@ -223,19 +223,19 @@ class ConsoleCommandReply implements CommandReply {
 		$message = preg_replace("/<img\s+src=['\"]?tdb:\/\/id:[A-Z0-9_]+['\"]?>/s", "", $message);
 		$message = preg_replace("/<img\s+src=['\"]?rdb:\/\/\d+['\"]?>/s", "", $message);
 		$message = preg_replace("/\n\[item:<link><\/link>]\n/s", "\n", $message);
+		$message = str_replace("\n", "\n ", $this->handleColors($message, true));
 		$parts = [];
 		$message = html_entity_decode(
 			preg_replace_callback(
 				"/<a\s+href\s*=\s*([\"'])text:\/\/(.+?)\\1\s*>(.*?)<\/a>/s",
 				function (array $matches) use (&$parts): string {
-					$parts[] = $this->handleColors(html_entity_decode($matches[2], ENT_QUOTES), true);
+					$parts[] = html_entity_decode($this->handleColors($matches[2], true), ENT_QUOTES);
 					return $this->handleColors("<link>{$matches[3]}</link>", false);
 				},
 				$message
 			),
 			ENT_QUOTES
 		);
-		$message = str_replace("\n", "\n ", $this->handleColors($message, true));
 		if (count($parts)) {
 			$message .= "\n\n" . join("\n" . str_repeat("-", 75) . "\n", $parts);
 		}

--- a/src/Modules/TOWER_MODULE/HotInfo.php
+++ b/src/Modules/TOWER_MODULE/HotInfo.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\TOWER_MODULE;
+
+class HotInfo {
+	public ?int $ct_ql;
+	public ?string $guild_name;
+	public ?string $faction;
+	public ?int $close_time;
+}

--- a/src/Modules/TOWER_MODULE/HotSite.php
+++ b/src/Modules/TOWER_MODULE/HotSite.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\TOWER_MODULE;
+
+class HotSite extends SiteInfo {
+	public HotInfo $info;
+}

--- a/src/Modules/TOWER_MODULE/Migrations/20210705033831_AddTimingColumn.php
+++ b/src/Modules/TOWER_MODULE/Migrations/20210705033831_AddTimingColumn.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\TOWER_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\DB;
+use Nadybot\Core\LoggerWrapper;
+use Nadybot\Core\SchemaMigration;
+
+class AddTimingColumn implements SchemaMigration {
+	public function migrate(LoggerWrapper $logger, DB $db): void {
+		$table = "tower_site";
+		$db->schema()->table($table, function(Blueprint $table) {
+			$table->unsignedSmallInteger("timing")->default(0);
+		});
+	}
+}

--- a/src/Modules/TOWER_MODULE/TowerController.php
+++ b/src/Modules/TOWER_MODULE/TowerController.php
@@ -516,7 +516,7 @@ class TowerController {
 					$currentGuildName = $row->guild_name;
 				}
 				$gasInfo = $this->getGasLevel((int)$row->close_time);
-				$gasChangeString = "{$gasInfo->color} {$gasInfo->gas_level} - ".
+				$gasChangeString = "{$gasInfo->color}{$gasInfo->gas_level}<end> - ".
 					"{$gasInfo->next_state} in <highlight>".
 					$this->util->unixtimeToReadable($gasInfo->gas_change).
 					"<end>";

--- a/src/Modules/TOWER_MODULE/TowerController.php
+++ b/src/Modules/TOWER_MODULE/TowerController.php
@@ -96,6 +96,10 @@ class TowerController {
 
 	public const DB_TOWER_ATTACK = "tower_attack_<myname>";
 	public const DB_TOWER_VICTORY = "tower_victory_<myname>";
+	public const FIXED_TIMES = [
+		1 => [4, 22, 3],
+		2 => [20, 14, 19],
+	];
 
 	/**
 	 * Name of the module.

--- a/src/Modules/TOWER_MODULE/TowerController.php
+++ b/src/Modules/TOWER_MODULE/TowerController.php
@@ -159,6 +159,7 @@ class TowerController {
 	/** @var AttackListener[] */
 	protected array $attackListeners = [];
 
+	/** @var array<string,array<int,?string>> */
 	protected array $lcOwningFactions = [];
 
 	/**

--- a/src/Modules/TOWER_MODULE/TowerController.php
+++ b/src/Modules/TOWER_MODULE/TowerController.php
@@ -81,6 +81,7 @@ use Throwable;
  *	)
  *	@DefineCommand(
  *		command     = 'needsscout',
+ *		alias       = 'needscout',
  *		accessLevel = 'guild',
  *		description = 'Check which tower sites need scouting',
  *		help        = 'scout.txt'
@@ -838,8 +839,7 @@ class TowerController {
 
 	/**
 	 * @HandlesCommand("scout")
-	 * @Matches("/^scout ([0-9a-z]+[a-z])\s*(\d+)\s+(\d{1,2}:\d{2}:\d{2}) (\d+) ([a-z]+) (.*)$/i")
-	 * @Matches("/^scout ([0-9a-z]+[a-z])\s*(\d+)\s+(.*)$/i")
+	 * @Matches("/^scout ([0-9a-z]+[a-z])\s*(\d+)\s+(.*)$/is")
 	 */
 	public function scoutCommand(string $message, string $channel, string $sender, CommandReply $sendto, array $args): void {
 		$this->scoutInputHandler($sender, $sendto, $args);

--- a/src/Modules/TOWER_MODULE/TowerSite.php
+++ b/src/Modules/TOWER_MODULE/TowerSite.php
@@ -12,4 +12,9 @@ class TowerSite extends DBRow {
 	public int $x_coord;
 	public int $y_coord;
 	public string $site_name;
+
+	/**
+	 * Is this legacy (0), EU-friendly (1) or US-friendly (2)
+	 */
+	public int $timing;
 }

--- a/src/Modules/TOWER_MODULE/hot.txt
+++ b/src/Modules/TOWER_MODULE/hot.txt
@@ -1,0 +1,10 @@
+See which sites are currently hot:
+<tab><highlight><symbol>hot<end>
+
+See which sites of a specific faction are currently hot:
+<tab><highlight><symbol>hot clan<end>
+<tab><highlight><symbol>hot omni<end>
+
+See which sites in a specific playfield are currently hot:
+<tab><highlight><symbol>hot pw<end>
+<tab><highlight><symbol>hot pw omni<end>

--- a/src/Modules/TOWER_MODULE/scout.txt
+++ b/src/Modules/TOWER_MODULE/scout.txt
@@ -1,18 +1,17 @@
 To scout a tower site:
-<highlight><tab><symbol>scout 'playfield' 'site number' 'closing time' 'ct ql' 'faction' 'guild name'<end>
 <highlight><tab><symbol>scout 'playfield' 'site number' 'paste ct blob info'<end>
 
 For instance:
-<highlight><tab><symbol>scout PW 4 12:34:56 190 clan Dark Ninjas<end>
--OR-
 <highlight><tab><symbol>scout PW 4 Control Tower - Clan Level: 190 Danger level: Killing it poses no danger. Might attack you on sight. Alignment: clan  Organization: Dark Ninjas Created at UTC: 2014-05-19 12:34:56<end>
 
 Note that the closing time is the "Created at" time, but only the time part, not the date part.
-
-Note that you can use <highlight><symbol>forcescout<end> to bypass some of the integrity checks if they are enabled but this should only be used if you understand the implications.
 
 To remove a scouted tower site:
 <highlight><tab><symbol>remscout 'playfield' 'site number'<end>
 
 To show info on the list of scouted bases:
 <highlight><tab><symbol>opentimes<end>
+
+To show a list of sites that need scouting:
+<highlight><tab><symbol>needsscout<end>
+<highlight><tab><symbol>needsscout pw<end>

--- a/src/Modules/TOWER_MODULE/tower_site.csv
+++ b/src/Modules/TOWER_MODULE/tower_site.csv
@@ -1,264 +1,264 @@
-playfield_id,site_number,min_ql,max_ql,x_coord,y_coord,site_name
-505,1,60,90,2740,4260,"Griffon Frontier"
-505,2,80,110,540,4180,Draught
-505,3,70,95,1740,3460,"Dreadfire Volcano"
-505,4,80,120,2780,3420,"Northeast Barren Lands"
-505,5,60,90,580,3140,"Western Desert"
-505,6,50,75,2420,1900,"Waylander Mines"
-505,7,70,100,1860,1700,"North of Main Omni Base"
-505,8,61,82,460,1380,"Dome Ore"
-505,9,100,150,2700,620,"Crystal Forge Volcano"
-505,10,100,150,660,460,"SW Low Plateau"
-550,1,10,20,2660,2020,"Sifter Beach"
-550,2,20,30,1780,1780,"Academy Ore"
-550,3,15,25,1980,1340,"Athen Fault"
-550,4,10,20,2660,820,Grindmoore
-550,5,15,23,1380,380,"Gladius Grove"
-551,1,40,90,1700,3700,"Styx Magma"
-551,2,35,50,2220,3340,"Carbon Grove"
-551,3,26,50,980,3140,"Between the Craters"
-551,4,25,35,340,2420,"Powdered Dunes"
-551,5,32,45,2540,2060,"Dust Bank"
-551,6,20,30,580,1740,"Charred Groove"
-551,7,12,45,940,1540,"West of Perdition"
-551,8,15,30,660,900,"North of Yuttos"
-560,1,100,170,1500,3420,"Terraform Edge"
-560,2,170,250,3060,3020,"West Spirals"
-560,3,170,250,3500,2980,"East Spirals"
-560,4,130,170,1220,2220,"Middle Mort Desert"
-560,5,1,100,900,1460,"Green Crater"
-560,6,110,160,3100,1460,"Oasis Ore"
-560,7,150,200,2740,700,"South East Craterwall"
-560,8,100,150,540,540,"South West Craterwall"
-560,9,160,210,2780,540,Stormshelter
-565,1,25,40,2940,2900,"Rich Desert Ridge"
-565,2,30,45,1980,2580,"East of Meetmedere"
-565,3,50,75,540,2020,"Middle of Western Desert"
-565,4,40,60,2580,1940,"North of Rhino Village"
-565,5,40,60,2700,1260,"South of Rhino Village"
-567,1,12,20,1220,1060,"In the Newland Desert"
-567,2,15,25,540,460,"West of Newland Lake"
-570,1,200,300,3220,3020,"North of Cyborg Hideout"
-570,2,191,250,3780,2540,"Middle of Liberty"
-570,3,120,180,980,2060,"South of Sabulum"
-570,4,190,230,3940,2060,"Cyborg Border"
-570,5,200,300,2820,1820,"Middle of Perpetual Wastelands"
-570,6,200,300,3740,1700,"South of Cyborg Hideout"
-570,7,100,150,1500,1340,"Lower Plateu Zone"
-570,8,100,150,2100,1380,"The Mid Canyon Crossing"
-570,9,120,180,3020,1220,"Plains of dust"
-570,10,100,150,900,1060,"West of Canyon"
-570,11,100,150,3180,940,"The Canyon Mines"
-570,12,190,230,2300,780,"South of Canyon"
-585,1,40,60,1220,2740,"Northern Wastelands"
-585,2,11,16,2180,2580,"West Wastelands"
-585,3,40,55,1020,2460,"Mid Wastelands"
-585,4,30,45,2140,1660,"Giant Green River Bank North"
-585,5,11,16,1180,1340,"West of the Dead Forest"
-585,6,30,45,2100,1340,"Giant Green River Bank South"
-585,7,15,22,1420,1020,"Canyon East"
-585,8,25,35,820,780,"Canyon South"
-585,9,35,50,900,460,"By the River"
-590,1,140,200,1740,3100,"By the Fisher Village"
-590,2,140,200,2100,3060,"Fisher Village Approach"
-590,3,100,170,2900,2820,"North Forest"
-590,4,90,130,3340,2700,"North-east Forest"
-590,5,130,170,860,1220,"North-west of Lava Ditches"
-590,6,100,150,3100,980,"Mid Clutching Forest"
-590,7,130,170,860,780,"South-west of Lava Ditches"
-590,8,100,150,3180,620,"South Clutching Forest"
-595,1,100,150,1140,3380,"Old ruins"
-595,2,100,150,3180,2900,"Plains of defense"
-595,3,130,180,1740,2300,"The haunted forest outskirt"
-595,4,130,180,900,2220,"Forest of Xzawkaz"
-595,5,200,300,2260,1860,"In the Swamp of Horrors"
-595,6,130,180,1420,1500,"Island of Control"
-595,7,130,180,1340,1140,"The swamp of hope"
-595,8,200,300,2900,1100,"South of the Medusa"
-595,9,140,210,2140,780,"Middle of the Foul Forest"
-595,10,200,300,540,540,"Southern Forest of Xzawkaz"
-600,1,30,45,2420,2980,"By the Rivers Edge"
-600,2,50,75,620,2900,"North Forest Road"
-600,3,25,50,1300,2660,"Along the Rivers Edge"
-600,4,30,45,3740,2500,"East Forest"
-600,5,25,50,3140,2020,"Rhino Hills"
-600,6,50,75,580,1700,"West Forest"
-600,7,60,90,1940,1620,Crossroads
-600,8,60,90,1140,1500,Forestdawn
-600,9,50,75,3220,1140,"East of Crater"
-605,1,160,200,2940,2820,"Forest Waters"
-605,2,110,120,1100,2620,"Muddy Pools"
-605,3,100,150,1700,2300,"West of Wine"
-605,4,120,180,2940,2260,"East of Wine"
-605,5,130,195,1900,1740,"Central Belial Forest"
-605,6,130,190,2500,1660,"River Delta"
-605,7,160,200,2540,1220,"Junction Forest"
-605,8,100,150,2340,860,Borderline
-605,9,120,180,2020,420,"Southern belial Mine"
-605,10,140,200,620,380,"Southwest Belial Mining District"
-610,1,60,90,1380,2780,"Tetlies Land control area"
-610,2,80,120,2900,2660,"East of the Great Marsh"
-610,3,60,90,660,2460,"West of outpost 10-3"
-610,4,100,150,2300,2020,"Defense of Geholva"
-610,5,106,143,2740,1180,"South of Forest of Geholva"
-610,6,120,180,860,900,"Avid Crater"
-610,7,120,180,1540,900,"East of Avid Crater"
-610,8,100,150,2460,540,"Bendelham forest Defense"
-615,1,60,100,1900,3020,"North of Lenne"
-615,2,100,150,860,2820,"Little Hawaii Defense"
-615,3,90,120,2620,2660,"Defense of Zoto"
-615,4,60,100,900,2100,"By the Ocean"
-615,5,61,100,2300,1180,Birm
-615,6,120,180,2700,660,"SFH Defense"
-615,7,100,150,1860,500,"South in Nightplain"
-620,1,150,200,2700,3860,"Krud the Lost Valley Defense"
-620,2,150,225,1900,3180,Pranade
-620,3,120,180,620,2980,"Plains of Jarga Defense"
-620,4,200,300,2460,2260,"Old Plains"
-620,5,200,300,1540,1780,"Middle of Easter Fouls Plains"
-620,6,130,200,1540,1140,"Clefre Defense"
-620,7,100,150,2020,860,"Central Sharewood"
-620,8,200,300,820,540,Pegradul
-625,1,90,130,1460,1940,"The Resilient Forest - North"
-625,2,90,120,1900,1540,"The Resilient Forest - East"
-625,3,125,170,2780,1380,"Central Prowler Waste"
-625,4,100,125,1380,1180,"Central Resilient Forest"
-625,5,125,170,2860,1020,"Southern Prowler Waste"
-625,6,100,150,4020,980,"The Barren Hills"
-625,7,100,125,1740,860,"The Resilient Forest - South"
-625,8,50,75,2460,540,"The Silent Woods - East"
-630,1,40,60,1540,2660,"Pleasant Range Offense Hill"
-630,2,60,90,2380,2500,"Central Pleasant Range"
-630,3,50,75,580,2420,"West of 20K"
-630,4,30,70,3220,2220,"Pleasant Range Defense"
-630,5,60,90,3220,1980,"Pleasant River Defense"
-630,6,60,90,3260,1500,"Pleasant River Offense"
-630,7,40,60,2260,1140,"Central Pleasant Plains"
-630,8,30,70,3020,1020,"East Pleasant Plains"
-630,9,30,45,740,460,"West of Versailles Tower"
-635,1,55,70,700,2420,"Northern River Bank"
-635,2,60,90,1780,2460,"Hawker Trench"
-635,3,70,105,1460,1740,"Klapam Forest Defense"
-635,4,55,70,2020,1740,"Klompfot Defense"
-635,5,70,105,1900,1220,"South of Trench"
-635,6,80,120,1140,940,"Nile Hills"
-635,7,55,70,1780,700,"Aprils Rock Offense"
-635,8,80,150,820,420,"Southern Lower River Bank"
-635,9,80,150,1700,340,"Aprils Rock Defense"
-646,1,10,15,460,1300,"Great W. Forest Vein"
-646,2,10,15,2940,980,"The Hidden Notum Canal"
-646,3,20,30,3220,620,"Mountain Areas"
-646,4,10,15,580,580,"Great W. Forest Dorsal"
-646,5,10,15,1500,460,"Western Mountain Areas"
-647,1,90,135,1100,3100,"The Mineral Mine"
-647,2,20,30,2900,2940,"NE Desert Aperient"
-647,3,37,64,1900,2700,"SurroundingTemple of Three Winds"
-647,4,25,40,2220,1900,"Piercing Thundertube"
-647,5,30,45,2820,1940,"Central Striking Ant"
-647,6,25,40,620,1660,"Tir Prairie"
-647,7,25,40,1180,1700,"Crater Swamp"
-650,1,50,75,540,2820,"West Pass"
-650,2,65,75,900,2300,"Crowning Shallows"
-650,3,100,150,1660,2180,"Haven Notum Crematorium"
-650,4,70,140,2020,1740,"Stret Vale Deux Drilling Field"
-650,5,120,180,1340,1620,"The Flooded Bottomland"
-650,6,75,90,1820,740,"Stret Woods"
-650,7,60,90,940,420,Greenslopes
-655,1,30,45,420,2700,"Skop Notum Mine"
-655,2,30,80,2820,2340,Klor
-655,3,60,80,2820,1660,Harstad
-655,4,40,90,540,1580,Ubleo
-655,5,40,60,1420,1580,"Flubu Notum Mine"
-655,6,40,70,4340,900,Plago
-655,7,60,80,2260,380,jucha
-655,8,70,105,4380,380,Mune
-655,9,30,60,820,340,"Mocnuf Notum Mine"
-665,1,80,150,940,4820,"Central Desert north"
-665,2,45,75,1260,3860,"Notum Disruption Mountain"
-665,3,75,110,1940,3860,"The Notum Plains"
-665,4,100,150,940,3380,"Near Clan Outpost"
-665,5,45,80,1300,3060,"Central Mountains"
-665,6,55,150,380,2300,"Surrounding Evil"
-665,7,45,60,1260,2140,"Notum Mountain"
-665,8,55,100,2020,1980,"Near Omni-Tek Outpost"
-665,9,100,150,420,820,"Shores Notum Vein"
-670,1,30,45,1100,4340,"Yukon Source"
-670,2,35,50,1460,2540,Frisko
-670,3,30,45,2140,2420,"Round Hills"
-670,4,50,75,2140,1900,"Dense Drewen"
-670,5,35,50,1260,1820,"Borrowed Hill"
-670,6,35,50,1340,1340,"Narrow Lune"
-670,7,10,15,2500,1220,"Micron Slopes Notum Mine"
-670,8,50,75,2100,540,"High Juniper"
-670,9,50,75,2300,460,"High Juniper Notum Vein"
-685,1,35,50,2140,2620,"Nature Reverve - East"
-685,2,35,50,1900,2580,"Nature Reverve - West"
-685,3,50,75,1300,1900,"Poole - West"
-685,4,50,75,1580,1820,"Poole - East"
-685,5,15,25,1140,1100,V-Hill
-685,6,20,30,1580,700,"Lunder Hills - North"
-685,7,25,40,2740,460,"Galway hills"
-685,8,20,30,1220,380,"Lunder Hills"
-685,9,25,40,2260,380,"South-east Woods"
-687,1,10,15,500,1900,"Blossom Valley"
-687,2,10,15,380,1300,"Konty Passage Plains"
-687,3,17,28,900,1220,"Vas' Pass"
-687,4,15,25,780,900,"Arthur's Pass"
-687,5,10,15,380,580,"Kontys Sixth Passage - West"
-687,6,10,15,620,540,"Kontys Sixth Passage - East"
-695,1,30,45,940,3260,"North West Lush Fields"
-695,2,20,30,2420,3180,"North East Lush Fields"
-695,3,10,40,3460,2940,"Stret River Island"
-695,4,40,60,1260,2460,"West of Outpost"
-695,5,35,60,1740,2460,"East of Outpost"
-695,6,20,30,1780,1820,"Central Lush Fields"
-695,7,10,15,2860,420,"South East Lush Fields"
-695,8,30,45,980,380,"South West Lush Fields"
-696,1,15,25,780,1420,"Mutant Domain North"
-696,2,20,30,500,860,"Mutant Domain Central"
-696,3,25,40,780,460,"Mutant Domain South"
-716,1,20,35,500,3220,"Northern Grassland"
-716,2,15,30,980,3020,"Moderate Grassland"
-716,3,10,20,460,2180,"Dungeon Hilltop"
-716,4,10,15,700,2180,"Rocky Upsurge"
-716,5,15,25,340,1420,"Northern Easy Swamps Notum Field"
-716,6,15,26,460,820,"Ocean Inlet"
-717,1,30,45,1620,2660,"Greater Omni Forest Swamps"
-717,2,15,25,1180,2460,"Dragonback Ridge"
-717,3,30,45,1900,1820,"Mountainous Regions"
-717,4,20,35,1860,1340,"Waterfall Swamp"
-717,5,10,15,1500,1300,"Greater Omni Forest South"
-717,6,25,40,900,1220,"Northern Semi-Barren Area"
-717,7,10,25,1940,900,"Ring Mountain Range"
-717,8,14,25,940,460,"Southern Isle"
-760,1,60,90,1580,2380,"Notum Ore in Buttu"
-760,2,35,50,940,2020,"Mountain of Fourtyone"
-760,3,35,50,1300,1980,"Mountain in 4Holes"
-760,4,45,60,1660,1740,"South of Ahenus"
-760,5,70,100,1820,1340,"Ibreri Woods North"
-760,6,35,50,1460,1260,"Mountain of Fourtytwo"
-760,7,100,150,1740,1060,"Ibreri Woods"
-760,8,45,70,1180,500,Ibreri
-760,9,45,70,460,420,"Jall Mountain"
-790,1,20,30,1700,3100,"Hells Courtyard"
-790,2,15,25,2300,2860,"Pondus Beach"
-790,3,15,30,1700,2780,"Hound Land"
-790,4,20,40,1980,2780,"Hound Notum Field"
-790,5,20,30,1700,1940,"East Mutie"
-790,6,12,30,1340,1220,"Omni Outpost"
-790,7,20,30,660,1180,"South Mutie"
-790,8,30,60,2260,1140,"The Beach"
-791,1,15,26,420,2020,"Populous Mountain"
-791,2,12,22,660,1500,"Hound Land Mining"
-791,3,12,20,220,1060,"Stret West Notum Ore"
-791,4,10,15,740,820,"Snake Mountain"
-791,5,20,40,780,460,"Southern Empty Wastes and Roads"
-791,6,10,20,380,340,"Transit Valley Ore"
-795,1,40,60,4220,1580,Illuminati
-795,2,100,150,500,1540,"Northern Forest of Illuminations"
-795,3,25,50,3420,1540,"Fate Notum Field"
-795,4,71,120,580,820,Pegrama
-795,5,84,120,1220,700,"Grazeland Notum Field"
-795,6,50,75,4020,620,Winterbottom
-795,7,90,120,540,500,"Southern Forest of Illuminations"
-795,8,60,90,2900,500,Summer
+playfield_id,site_number,min_ql,max_ql,x_coord,y_coord,site_name,timing
+505,1,60,90,2740,4260,"Griffon Frontier",1
+505,2,80,110,540,4180,Draught,1
+505,3,70,95,1740,3460,"Dreadfire Volcano",1
+505,4,80,120,2780,3420,"Northeast Barren Lands",1
+505,5,60,90,580,3140,"Western Desert",1
+505,6,50,75,2420,1900,"Waylander Mines",1
+505,7,70,100,1860,1700,"North of Main Omni Base",1
+505,8,61,82,460,1380,"Dome Ore",1
+505,9,100,150,2700,620,"Crystal Forge Volcano",1
+505,10,100,150,660,460,"SW Low Plateau",1
+550,1,10,20,2660,2020,"Sifter Beach",2
+550,2,20,30,1780,1780,"Academy Ore",2
+550,3,15,25,1980,1340,"Athen Fault",2
+550,4,10,20,2660,820,Grindmoore,2
+550,5,15,23,1380,380,"Gladius Grove",2
+551,1,40,90,1700,3700,"Styx Magma",0
+551,2,35,50,2220,3340,"Carbon Grove",0
+551,3,26,50,980,3140,"Between the Craters",0
+551,4,25,35,340,2420,"Powdered Dunes",0
+551,5,32,45,2540,2060,"Dust Bank",0
+551,6,20,30,580,1740,"Charred Groove",0
+551,7,12,45,940,1540,"West of Perdition",0
+551,8,15,30,660,900,"North of Yuttos",0
+560,1,100,170,1500,3420,"Terraform Edge",1
+560,2,170,250,3060,3020,"West Spirals",1
+560,3,170,250,3500,2980,"East Spirals",1
+560,4,130,170,1220,2220,"Middle Mort Desert",1
+560,5,1,100,900,1460,"Green Crater",1
+560,6,110,160,3100,1460,"Oasis Ore",1
+560,7,150,200,2740,700,"South East Craterwall",1
+560,8,100,150,540,540,"South West Craterwall",1
+560,9,160,210,2780,540,Stormshelter,1
+565,1,25,40,2940,2900,"Rich Desert Ridge",2
+565,2,30,45,1980,2580,"East of Meetmedere",2
+565,3,50,75,540,2020,"Middle of Western Desert",2
+565,4,40,60,2580,1940,"North of Rhino Village",2
+565,5,40,60,2700,1260,"South of Rhino Village",2
+567,1,12,20,1220,1060,"In the Newland Desert",1
+567,2,15,25,540,460,"West of Newland Lake",1
+570,1,200,300,3220,3020,"North of Cyborg Hideout",1
+570,2,191,250,3780,2540,"Middle of Liberty",1
+570,3,120,180,980,2060,"South of Sabulum",1
+570,4,190,230,3940,2060,"Cyborg Border",1
+570,5,200,300,2820,1820,"Middle of Perpetual Wastelands",1
+570,6,200,300,3740,1700,"South of Cyborg Hideout",1
+570,7,100,150,1500,1340,"Lower Plateu Zone",1
+570,8,100,150,2100,1380,"The Mid Canyon Crossing",1
+570,9,120,180,3020,1220,"Plains of dust",1
+570,10,100,150,900,1060,"West of Canyon",1
+570,11,100,150,3180,940,"The Canyon Mines",1
+570,12,190,230,2300,780,"South of Canyon",1
+585,1,40,60,1220,2740,"Northern Wastelands",1
+585,2,11,16,2180,2580,"West Wastelands",1
+585,3,40,55,1020,2460,"Mid Wastelands",1
+585,4,30,45,2140,1660,"Giant Green River Bank North",1
+585,5,11,16,1180,1340,"West of the Dead Forest",1
+585,6,30,45,2100,1340,"Giant Green River Bank South",1
+585,7,15,22,1420,1020,"Canyon East",1
+585,8,25,35,820,780,"Canyon South",1
+585,9,35,50,900,460,"By the River",1
+590,1,140,200,1740,3100,"By the Fisher Village",2
+590,2,140,200,2100,3060,"Fisher Village Approach",2
+590,3,100,170,2900,2820,"North Forest",2
+590,4,90,130,3340,2700,"North-east Forest",2
+590,5,130,170,860,1220,"North-west of Lava Ditches",2
+590,6,100,150,3100,980,"Mid Clutching Forest",2
+590,7,130,170,860,780,"South-west of Lava Ditches",2
+590,8,100,150,3180,620,"South Clutching Forest",2
+595,1,100,150,1140,3380,"Old ruins",0
+595,2,100,150,3180,2900,"Plains of defense",0
+595,3,130,180,1740,2300,"The haunted forest outskirt",0
+595,4,130,180,900,2220,"Forest of Xzawkaz",0
+595,5,200,300,2260,1860,"In the Swamp of Horrors",0
+595,6,130,180,1420,1500,"Island of Control",0
+595,7,130,180,1340,1140,"The swamp of hope",0
+595,8,200,300,2900,1100,"South of the Medusa",0
+595,9,140,210,2140,780,"Middle of the Foul Forest",0
+595,10,200,300,540,540,"Southern Forest of Xzawkaz",0
+600,1,30,45,2420,2980,"By the Rivers Edge",1
+600,2,50,75,620,2900,"North Forest Road",1
+600,3,25,50,1300,2660,"Along the Rivers Edge",1
+600,4,30,45,3740,2500,"East Forest",1
+600,5,25,50,3140,2020,"Rhino Hills",1
+600,6,50,75,580,1700,"West Forest",1
+600,7,60,90,1940,1620,Crossroads,1
+600,8,60,90,1140,1500,Forestdawn,1
+600,9,50,75,3220,1140,"East of Crater",1
+605,1,160,200,2940,2820,"Forest Waters",2
+605,2,110,120,1100,2620,"Muddy Pools",2
+605,3,100,150,1700,2300,"West of Wine",2
+605,4,120,180,2940,2260,"East of Wine",2
+605,5,130,195,1900,1740,"Central Belial Forest",2
+605,6,130,190,2500,1660,"River Delta",2
+605,7,160,200,2540,1220,"Junction Forest",2
+605,8,100,150,2340,860,Borderline,2
+605,9,120,180,2020,420,"Southern belial Mine",2
+605,10,140,200,620,380,"Southwest Belial Mining District",2
+610,1,60,90,1380,2780,"Tetlies Land control area",1
+610,2,80,120,2900,2660,"East of the Great Marsh",1
+610,3,60,90,660,2460,"West of outpost 10-3",1
+610,4,100,150,2300,2020,"Defense of Geholva",1
+610,5,106,143,2740,1180,"South of Forest of Geholva",1
+610,6,120,180,860,900,"Avid Crater",1
+610,7,120,180,1540,900,"East of Avid Crater",1
+610,8,100,150,2460,540,"Bendelham forest Defense",1
+615,1,60,100,1900,3020,"North of Lenne",1
+615,2,100,150,860,2820,"Little Hawaii Defense",1
+615,3,90,120,2620,2660,"Defense of Zoto",1
+615,4,60,100,900,2100,"By the Ocean",1
+615,5,61,100,2300,1180,Birm,1
+615,6,120,180,2700,660,"SFH Defense",1
+615,7,100,150,1860,500,"South in Nightplain",1
+620,1,150,200,2700,3860,"Krud the Lost Valley Defense",2
+620,2,150,225,1900,3180,Pranade,2
+620,3,120,180,620,2980,"Plains of Jarga Defense",2
+620,4,200,300,2460,2260,"Old Plains",2
+620,5,200,300,1540,1780,"Middle of Easter Fouls Plains",2
+620,6,130,200,1540,1140,"Clefre Defense",2
+620,7,100,150,2020,860,"Central Sharewood",2
+620,8,200,300,820,540,Pegradul,2
+625,1,90,130,1460,1940,"The Resilient Forest - North",0
+625,2,90,120,1900,1540,"The Resilient Forest - East",0
+625,3,125,170,2780,1380,"Central Prowler Waste",0
+625,4,100,125,1380,1180,"Central Resilient Forest",0
+625,5,125,170,2860,1020,"Southern Prowler Waste",0
+625,6,100,150,4020,980,"The Barren Hills",0
+625,7,100,125,1740,860,"The Resilient Forest - South",0
+625,8,50,75,2460,540,"The Silent Woods - East",0
+630,1,40,60,1540,2660,"Pleasant Range Offense Hill",0
+630,2,60,90,2380,2500,"Central Pleasant Range",0
+630,3,50,75,580,2420,"West of 20K",0
+630,4,30,70,3220,2220,"Pleasant Range Defense",0
+630,5,60,90,3220,1980,"Pleasant River Defense",0
+630,6,60,90,3260,1500,"Pleasant River Offense",0
+630,7,40,60,2260,1140,"Central Pleasant Plains",0
+630,8,30,70,3020,1020,"East Pleasant Plains",0
+630,9,30,45,740,460,"West of Versailles Tower",0
+635,1,55,70,700,2420,"Northern River Bank",2
+635,2,60,90,1780,2460,"Hawker Trench",2
+635,3,70,105,1460,1740,"Klapam Forest Defense",2
+635,4,55,70,2020,1740,"Klompfot Defense",2
+635,5,70,105,1900,1220,"South of Trench",2
+635,6,80,120,1140,940,"Nile Hills",2
+635,7,55,70,1780,700,"Aprils Rock Offense",2
+635,8,80,150,820,420,"Southern Lower River Bank",2
+635,9,80,150,1700,340,"Aprils Rock Defense",2
+646,1,10,15,460,1300,"Great W. Forest Vein",1
+646,2,10,15,2940,980,"The Hidden Notum Canal",1
+646,3,20,30,3220,620,"Mountain Areas",1
+646,4,10,15,580,580,"Great W. Forest Dorsal",1
+646,5,10,15,1500,460,"Western Mountain Areas",1
+647,1,90,135,1100,3100,"The Mineral Mine",1
+647,2,20,30,2900,2940,"NE Desert Aperient",1
+647,3,37,64,1900,2700,"SurroundingTemple of Three Winds",1
+647,4,25,40,2220,1900,"Piercing Thundertube",1
+647,5,30,45,2820,1940,"Central Striking Ant",1
+647,6,25,40,620,1660,"Tir Prairie",1
+647,7,25,40,1180,1700,"Crater Swamp",1
+650,1,50,75,540,2820,"West Pass",2
+650,2,65,75,900,2300,"Crowning Shallows",2
+650,3,100,150,1660,2180,"Haven Notum Crematorium",2
+650,4,70,140,2020,1740,"Stret Vale Deux Drilling Field",2
+650,5,120,180,1340,1620,"The Flooded Bottomland",2
+650,6,75,90,1820,740,"Stret Woods",2
+650,7,60,90,940,420,Greenslopes,2
+655,1,30,45,420,2700,"Skop Notum Mine",1
+655,2,30,80,2820,2340,Klor,1
+655,3,60,80,2820,1660,Harstad,1
+655,4,40,90,540,1580,Ubleo,1
+655,5,40,60,1420,1580,"Flubu Notum Mine",1
+655,6,40,70,4340,900,Plago,1
+655,7,60,80,2260,380,jucha,1
+655,8,70,105,4380,380,Mune,1
+655,9,30,60,820,340,"Mocnuf Notum Mine",1
+665,1,80,150,940,4820,"Central Desert north",2
+665,2,45,75,1260,3860,"Notum Disruption Mountain",2
+665,3,75,110,1940,3860,"The Notum Plains",2
+665,4,100,150,940,3380,"Near Clan Outpost",2
+665,5,45,80,1300,3060,"Central Mountains",2
+665,6,55,150,380,2300,"Surrounding Evil",2
+665,7,45,60,1260,2140,"Notum Mountain",2
+665,8,55,100,2020,1980,"Near Omni-Tek Outpost",2
+665,9,100,150,420,820,"Shores Notum Vein",2
+670,1,30,45,1100,4340,"Yukon Source",2
+670,2,35,50,1460,2540,Frisko,2
+670,3,30,45,2140,2420,"Round Hills",2
+670,4,50,75,2140,1900,"Dense Drewen",2
+670,5,35,50,1260,1820,"Borrowed Hill",2
+670,6,35,50,1340,1340,"Narrow Lune",2
+670,7,10,15,2500,1220,"Micron Slopes Notum Mine",2
+670,8,50,75,2100,540,"High Juniper",2
+670,9,50,75,2300,460,"High Juniper Notum Vein",2
+685,1,35,50,2140,2620,"Nature Reverve - East",2
+685,2,35,50,1900,2580,"Nature Reverve - West",2
+685,3,50,75,1300,1900,"Poole - West",2
+685,4,50,75,1580,1820,"Poole - East",2
+685,5,15,25,1140,1100,V-Hill,2
+685,6,20,30,1580,700,"Lunder Hills - North",2
+685,7,25,40,2740,460,"Galway hills",2
+685,8,20,30,1220,380,"Lunder Hills",2
+685,9,25,40,2260,380,"South-east Woods",2
+687,1,10,15,500,1900,"Blossom Valley",2
+687,2,10,15,380,1300,"Konty Passage Plains",2
+687,3,17,28,900,1220,"Vas' Pass",2
+687,4,15,25,780,900,"Arthur's Pass",2
+687,5,10,15,380,580,"Kontys Sixth Passage - West",2
+687,6,10,15,620,540,"Kontys Sixth Passage - East",2
+695,1,30,45,940,3260,"North West Lush Fields",0
+695,2,20,30,2420,3180,"North East Lush Fields",0
+695,3,10,40,3460,2940,"Stret River Island",0
+695,4,40,60,1260,2460,"West of Outpost",0
+695,5,35,60,1740,2460,"East of Outpost",0
+695,6,20,30,1780,1820,"Central Lush Fields",0
+695,7,10,15,2860,420,"South East Lush Fields",0
+695,8,30,45,980,380,"South West Lush Fields",0
+696,1,15,25,780,1420,"Mutant Domain North",2
+696,2,20,30,500,860,"Mutant Domain Central",2
+696,3,25,40,780,460,"Mutant Domain South",2
+716,1,20,35,500,3220,"Northern Grassland",0
+716,2,15,30,980,3020,"Moderate Grassland",0
+716,3,10,20,460,2180,"Dungeon Hilltop",0
+716,4,10,15,700,2180,"Rocky Upsurge",0
+716,5,15,25,340,1420,"Northern Easy Swamps Notum Field",0
+716,6,15,26,460,820,"Ocean Inlet",0
+717,1,30,45,1620,2660,"Greater Omni Forest Swamps",1
+717,2,15,25,1180,2460,"Dragonback Ridge",1
+717,3,30,45,1900,1820,"Mountainous Regions",1
+717,4,20,35,1860,1340,"Waterfall Swamp",1
+717,5,10,15,1500,1300,"Greater Omni Forest South",1
+717,6,25,40,900,1220,"Northern Semi-Barren Area",1
+717,7,10,25,1940,900,"Ring Mountain Range",1
+717,8,14,25,940,460,"Southern Isle",1
+760,1,60,90,1580,2380,"Notum Ore in Buttu",2
+760,2,35,50,940,2020,"Mountain of Fourtyone",2
+760,3,35,50,1300,1980,"Mountain in 4Holes",2
+760,4,45,60,1660,1740,"South of Ahenus",2
+760,5,70,100,1820,1340,"Ibreri Woods North",2
+760,6,35,50,1460,1260,"Mountain of Fourtytwo",2
+760,7,100,150,1740,1060,"Ibreri Woods",2
+760,8,45,70,1180,500,Ibreri,2
+760,9,45,70,460,420,"Jall Mountain",2
+790,1,20,30,1700,3100,"Hells Courtyard",2
+790,2,15,25,2300,2860,"Pondus Beach",2
+790,3,15,30,1700,2780,"Hound Land",2
+790,4,20,40,1980,2780,"Hound Notum Field",2
+790,5,20,30,1700,1940,"East Mutie",2
+790,6,12,30,1340,1220,"Omni Outpost",2
+790,7,20,30,660,1180,"South Mutie",2
+790,8,30,60,2260,1140,"The Beach",2
+791,1,15,26,420,2020,"Populous Mountain",2
+791,2,12,22,660,1500,"Hound Land Mining",2
+791,3,12,20,220,1060,"Stret West Notum Ore",2
+791,4,10,15,740,820,"Snake Mountain",2
+791,5,20,40,780,460,"Southern Empty Wastes and Roads",2
+791,6,10,20,380,340,"Transit Valley Ore",2
+795,1,40,60,4220,1580,Illuminati,1
+795,2,100,150,500,1540,"Northern Forest of Illuminations",1
+795,3,25,50,3420,1540,"Fate Notum Field",1
+795,4,71,120,580,820,Pegrama,1
+795,5,84,120,1220,700,"Grazeland Notum Field",1
+795,6,50,75,4020,620,Winterbottom,1
+795,7,90,120,540,500,"Southern Forest of Illuminations",1
+795,8,60,90,2900,500,Summer,1


### PR DESCRIPTION
- Support static and legacy timing
- Load land controllers from parsed image
- Support `!needsscout` to list all fields with missing scout information
- New command `!hot` to list all hoy sites, optionally only of one side or playfield
- Remove `!forcescout` and all the checks it bypasses
- Fix connection of attack and victory
- If all sites in a playfield are scouted, try to correctly guess the tower field
- Several more bugfixes