### PR TITLE
Timers as channel

### DIFF
--- a/src/Core/Channels/DiscordMsg.php
+++ b/src/Core/Channels/DiscordMsg.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core\Channels;
+
+use Nadybot\Core\AccessManager;
+use Nadybot\Core\MessageHub;
+use Nadybot\Core\MessageReceiver;
+use Nadybot\Core\Modules\DISCORD\DiscordAPIClient;
+use Nadybot\Core\Modules\DISCORD\DiscordController;
+use Nadybot\Core\Nadybot;
+use Nadybot\Core\Routing\Events\Online;
+use Nadybot\Core\Routing\RoutableEvent;
+use Nadybot\Core\Routing\Source;
+use Nadybot\Core\SettingManager;
+use Nadybot\Core\Text;
+
+class DiscordMsg implements MessageReceiver {
+	/** @Inject */
+	public Nadybot $chatBot;
+
+	/** @Inject */
+	public DiscordAPIClient $discordAPIClient;
+
+	/** @Inject */
+	public MessageHub $messageHub;
+
+	/** @Inject */
+	public DiscordController $discordController;
+
+	/** @Inject */
+	public AccessManager $accessManager;
+
+	/** @Inject */
+	public SettingManager $settingManager;
+
+	/** @Inject */
+	public Text $text;
+
+	protected string $channel;
+	protected string $id;
+
+	public function getChannelName(): string {
+		return Source::DISCORD_MSG . "(*)";
+	}
+
+	public function receive(RoutableEvent $event, string $destination): bool {
+		$renderPath = true;
+		if ($event->getType() !== $event::TYPE_MESSAGE) {
+			if (!is_string($event->data->message??null)) {
+				return false;
+			}
+			$msg = $event->data->message;
+			$renderPath = $event->data->renderPath;
+			if ($event->data->type === Online::TYPE) {
+				$msg = $this->text->removePopups($msg);
+			}
+		} else {
+			$msg = $event->getData();
+		}
+		$pathText = "";
+		if ($renderPath) {
+			$pathText = $this->messageHub->renderPath($event, $this->getChannelName());
+		}
+		if (isset($event->char)) {
+			$pathText = preg_replace("/<a\s[^>]*href=['\"]?user.*?>(.+)<\/a>/s", '<highlight>$1<end>', $pathText);
+			$pathText = preg_replace("/(\s)([^:\s]+): $/s", '$1<highlight>$2<end>: ', $pathText);
+		}
+		$message = $pathText.$msg;
+		$discordMsg = $this->discordController->formatMessage($message);
+
+		if (isset($event->char)) {
+			$minRankForMentions = $this->settingManager->getString('discord_relay_mention_rank');
+			$sendersRank = $this->accessManager->getAccessLevelForCharacter($event->char->name);
+			if ($this->accessManager->compareAccessLevels($sendersRank, $minRankForMentions) < 0) {
+				$discordMsg->allowed_mentions = (object)[
+					"parse" => ["users"]
+				];
+			}
+		}
+
+		//Relay the message to the discord channel
+		if (preg_match("/^\d+$/", $destination)) {
+			$this->discordAPIClient->queueToChannel($destination, $discordMsg->toJSON());
+		} else {
+			$this->discordAPIClient->sendToUser($destination, $discordMsg);
+		}
+		return true;
+	}
+}

--- a/src/Core/GuildChannelCommandReply.php
+++ b/src/Core/GuildChannelCommandReply.php
@@ -2,11 +2,17 @@
 
 namespace Nadybot\Core;
 
-class GuildChannelCommandReply implements CommandReply {
+use Nadybot\Core\Routing\Source;
+
+class GuildChannelCommandReply implements CommandReply, MessageEmitter {
 	private Nadybot $chatBot;
 
 	public function __construct(Nadybot $chatBot) {
 		$this->chatBot = $chatBot;
+	}
+
+	public function getChannelName(): string {
+		return Source::ORG;
 	}
 
 	/**

--- a/src/Core/MessageHub.php
+++ b/src/Core/MessageHub.php
@@ -298,6 +298,9 @@ class MessageHub {
 				continue;
 			}
 			foreach ($dest as $destName => $routes) {
+				if (empty($routes)) {
+					continue;
+				}
 				$receiver = $this->getReceiver($destName);
 				if (!isset($receiver)) {
 					continue;
@@ -510,6 +513,9 @@ class MessageHub {
 				$this->routes[$source][$dest] = array_values(
 					$this->routes[$source][$dest]
 				);
+				if (empty($this->routes[$source][$dest])) {
+					unset($this->routes[$source][$dest]);
+				}
 			}
 		}
 		return $result;

--- a/src/Core/MessageHub.php
+++ b/src/Core/MessageHub.php
@@ -286,6 +286,31 @@ class MessageHub {
 	}
 
 	/**
+	 * Check if there is a route defined for a MessageSender to a receiver
+	 */
+	public function hasRouteFromTo(string $sender, string $destination): bool {
+		$sender = strtolower($sender);
+		foreach ($this->routes as $source => $dest) {
+			if (!strpos($source, '(')) {
+				$source .= '(*)';
+			}
+			if (!fnmatch($source, $sender, FNM_CASEFOLD)) {
+				continue;
+			}
+			foreach ($dest as $destName => $routes) {
+				$receiver = $this->getReceiver($destName);
+				if (!isset($receiver)) {
+					continue;
+				}
+				if (fnmatch($receiver->getChannelName(), $destination, FNM_CASEFOLD)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Get a list of all message emitters
 	 * @return array<string,MessageEmitter>
 	 */

--- a/src/Core/Modules/CONSOLE/ConsoleCommandReply.php
+++ b/src/Core/Modules/CONSOLE/ConsoleCommandReply.php
@@ -3,13 +3,19 @@
 namespace Nadybot\Core\Modules\CONSOLE;
 
 use Nadybot\Core\CommandReply;
+use Nadybot\Core\MessageEmitter;
 use Nadybot\Core\Nadybot;
+use Nadybot\Core\Routing\Source;
 
-class ConsoleCommandReply implements CommandReply {
+class ConsoleCommandReply implements CommandReply, MessageEmitter {
 	private Nadybot $chatBot;
 
 	public function __construct(Nadybot $chatBot) {
 		$this->chatBot = $chatBot;
+	}
+
+	public function getChannelName(): string {
+		return Source::CONSOLE;
 	}
 
 	public function reply($msg): void {

--- a/src/Core/PrivateChannelCommandReply.php
+++ b/src/Core/PrivateChannelCommandReply.php
@@ -2,13 +2,19 @@
 
 namespace Nadybot\Core;
 
-class PrivateChannelCommandReply implements CommandReply {
+use Nadybot\Core\Routing\Source;
+
+class PrivateChannelCommandReply implements CommandReply, MessageEmitter {
 	private Nadybot $chatBot;
 	private string $channel;
 
 	public function __construct(Nadybot $chatBot, string $channel) {
 		$this->chatBot = $chatBot;
 		$this->channel = $channel;
+	}
+
+	public function getChannelName(): string {
+		return Source::PRIV . "({$this->channel})";
 	}
 
 	public function reply($msg): void {

--- a/src/Core/PrivateMessageCommandReply.php
+++ b/src/Core/PrivateMessageCommandReply.php
@@ -2,7 +2,9 @@
 
 namespace Nadybot\Core;
 
-class PrivateMessageCommandReply implements CommandReply {
+use Nadybot\Core\Routing\Source;
+
+class PrivateMessageCommandReply implements CommandReply, MessageEmitter {
 	private Nadybot $chatBot;
 	private string $sender;
 	private ?int $worker = null;
@@ -11,6 +13,10 @@ class PrivateMessageCommandReply implements CommandReply {
 		$this->chatBot = $chatBot;
 		$this->sender = $sender;
 		$this->worker = $worker;
+	}
+
+	public function getChannelName(): string {
+		return Source::TELL . "({$this->sender})";
 	}
 
 	public function reply($msg): void {

--- a/src/Modules/DISCORD_GATEWAY_MODULE/DiscordGatewayController.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/DiscordGatewayController.php
@@ -30,6 +30,7 @@ use Nadybot\Core\Routing\Character;
 use Nadybot\Core\Routing\RoutableMessage;
 use Nadybot\Core\Routing\Source;
 use Nadybot\Core\Channels\DiscordChannel as RoutedChannel;
+use Nadybot\Core\Channels\DiscordMsg;
 use Nadybot\Modules\DISCORD_GATEWAY_MODULE\Model\{
 	Activity,
 	CloseEvents,
@@ -613,6 +614,11 @@ class DiscordGatewayController {
 				->registerMessageReceiver($dc)
 				->registerMessageEmitter($dc);
 		}
+		$dm = new DiscordMsg();
+		Registry::injectDependencies($dm);
+		$this->messageHub
+			->registerMessageReceiver($dm)
+			->registerMessageEmitter($dm);
 	}
 
 	/**

--- a/src/Modules/DISCORD_GATEWAY_MODULE/DiscordMessageCommandReply.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/DiscordMessageCommandReply.php
@@ -2,7 +2,9 @@
 
 namespace Nadybot\Modules\DISCORD_GATEWAY_MODULE;
 
+use Nadybot\Core\Channels\DiscordChannel as ChannelsDiscordChannel;
 use Nadybot\Core\CommandReply;
+use Nadybot\Core\MessageEmitter;
 use Nadybot\Core\MessageHub;
 use Nadybot\Core\Modules\DISCORD\DiscordAPIClient;
 use Nadybot\Core\Modules\DISCORD\DiscordChannel;
@@ -14,7 +16,7 @@ use Nadybot\Core\Routing\RoutableMessage;
 use Nadybot\Core\Routing\Source;
 use Nadybot\Modules\DISCORD_GATEWAY_MODULE\Model\GuildMember;
 
-class DiscordMessageCommandReply implements CommandReply {
+class DiscordMessageCommandReply implements CommandReply, MessageEmitter {
 	/** @Inject */
 	public DiscordAPIClient $discordAPIClient;
 
@@ -38,6 +40,18 @@ class DiscordMessageCommandReply implements CommandReply {
 		$this->channelId = $channelId;
 		$this->isDirectMsg = $isDirectMsg;
 		$this->message = $message;
+	}
+
+	public function getChannelName(): string {
+		$emitters = $this->messageHub->getEmitters();
+		foreach ($emitters as $emitter) {
+			if ($emitter instanceof ChannelsDiscordChannel
+				&& $emitter->getChannelID() === $this->channelId
+			) {
+				return $emitter->getChannelName();
+			}
+		}
+		return Source::DISCORD_PRIV . "({$this->channelId})";
 	}
 
 	public function reply($msg): void {

--- a/src/Modules/DISCORD_GATEWAY_MODULE/DiscordMessageCommandReply.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/DiscordMessageCommandReply.php
@@ -43,6 +43,9 @@ class DiscordMessageCommandReply implements CommandReply, MessageEmitter {
 	}
 
 	public function getChannelName(): string {
+		if ($this->isDirectMsg) {
+			return Source::DISCORD_MSG . "({$this->channelId})";
+		}
 		$emitters = $this->messageHub->getEmitters();
 		foreach ($emitters as $emitter) {
 			if ($emitter instanceof ChannelsDiscordChannel

--- a/src/Modules/TIMERS_MODULE/Migrations/20210908074258_MigrateToRoutes.php
+++ b/src/Modules/TIMERS_MODULE/Migrations/20210908074258_MigrateToRoutes.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\TIMERS_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\DB;
+use Nadybot\Core\DBSchema\Route;
+use Nadybot\Core\DBSchema\Setting;
+use Nadybot\Core\LoggerWrapper;
+use Nadybot\Core\MessageHub;
+use Nadybot\Core\Modules\DISCORD\DiscordAPIClient;
+use Nadybot\Core\Modules\DISCORD\DiscordChannel;
+use Nadybot\Core\Routing\Source;
+use Nadybot\Core\SchemaMigration;
+use Nadybot\Core\SettingManager;
+use Nadybot\Modules\TIMERS_MODULE\TimerController;
+use Throwable;
+
+class MigrateToRoutes implements SchemaMigration {
+	/** @Inject */
+	public DiscordAPIClient $discordAPIClient;
+
+	/** @Inject */
+	public MessageHub $messageHub;
+
+	protected function getSetting(DB $db, string $name): ?Setting {
+		return $db->table(SettingManager::DB_TABLE)
+			->where("name", $name)
+			->asObj(Setting::class)
+			->first();
+	}
+
+	public function migrate(LoggerWrapper $logger, DB $db): void {
+		$table = TimerController::DB_TABLE;
+		$db->schema()->table($table, function(Blueprint $table) {
+			$table->string("mode", 50)->nullable()->change();
+		});
+		$defaultChannel = $this->getSetting($db, 'timer_alert_location');
+		if (!isset($defaultChannel)) {
+			$defaultChannel = 3;
+		} else {
+			$defaultChannel = (int)$defaultChannel->value;
+		}
+		$defaultMode = [];
+		if ($defaultChannel & 1) {
+			$this->addRoute($db, Source::PRIV . "(" . $db->getMyname() . ")");
+			$defaultMode []= "priv";
+		}
+		if ($defaultChannel & 2) {
+			$this->addRoute($db, Source::ORG);
+			$defaultMode []= "org";
+		}
+		if ($defaultChannel & 4) {
+			$discordCannel = $this->getSetting($db, "discord_notify_channel") ?? null;
+			if (isset($discordCannel) && $discordCannel->value !== 'off') {
+				$this->discordAPIClient->getChannel(
+					$discordCannel->value,
+					[$this, "migrateChannelToRoute"],
+					$db,
+				);
+				$defaultMode []= "discord";
+			}
+		}
+		sort($defaultMode);
+		$timerIds = $db->table($table)
+			->asObj()
+			->filter(function ($timer): bool {
+				if (!isset($timer->mode) || !preg_match("/^timercontroller/", $timer->callback)) {
+					return false;
+				}
+				if ($timer->mode === 'msg') {
+					return false;
+				}
+				return true;
+			})->pluck("id")
+			->toArray();
+		if (count($timerIds)) {
+			$db->table($table)
+				->whereIn("id", $timerIds)
+				->update(["mode" => null]);
+		}
+	}
+
+	public function migrateChannelToRoute(DiscordChannel $channel, DB $db): void {
+		$route = $this->addRoute(
+			$db,
+			Source::DISCORD_PRIV . "({$channel->name})",
+		);
+		try {
+			$msgRoute = $this->messageHub->createMessageRoute($route);
+			$this->messageHub->addRoute($msgRoute);
+		} catch (Throwable $e) {
+			// Ain't nothing we can do, errors will be given on next restart
+		}
+	}
+
+	protected function addRoute(DB $db, string $to): Route {
+		$route = new Route();
+		$route->source = Source::SYSTEM . "(timers)";
+		$route->destination = $to;
+		$route->id = $db->insert(MessageHub::DB_TABLE_ROUTES, $route);
+		return $route;
+	}
+}

--- a/src/Modules/TIMERS_MODULE/Migrations/20210908074258_MigrateToRoutes.php
+++ b/src/Modules/TIMERS_MODULE/Migrations/20210908074258_MigrateToRoutes.php
@@ -36,7 +36,7 @@ class MigrateToRoutes implements SchemaMigration {
 			$table->string("mode", 50)->nullable()->change();
 		});
 		$defaultChannel = $this->getSetting($db, 'timer_alert_location');
-		if (!isset($defaultChannel)) {
+		if (!isset($defaultChannel) || $defaultChannel->value === "0") {
 			$defaultChannel = 3;
 		} else {
 			$defaultChannel = (int)$defaultChannel->value;

--- a/src/Modules/TIMERS_MODULE/Migrations/20210908074258_MigrateToRoutes.php
+++ b/src/Modules/TIMERS_MODULE/Migrations/20210908074258_MigrateToRoutes.php
@@ -34,6 +34,7 @@ class MigrateToRoutes implements SchemaMigration {
 		$table = TimerController::DB_TABLE;
 		$db->schema()->table($table, function(Blueprint $table) {
 			$table->string("mode", 50)->nullable()->change();
+			$table->string("origin", 100)->nullable();
 		});
 		$defaultChannel = $this->getSetting($db, 'timer_alert_location');
 		if (!isset($defaultChannel) || $defaultChannel->value === "0") {

--- a/src/Modules/TIMERS_MODULE/Timer.php
+++ b/src/Modules/TIMERS_MODULE/Timer.php
@@ -13,7 +13,7 @@ class Timer {
 	public string $owner;
 
 	/** Comma-separated list where to display the alerts (priv,guild,discord) */
-	public string $mode;
+	public ?string $mode=null;
 
 	/** Timestamp when this timer goes off */
 	public ?int $endtime;

--- a/src/Modules/TIMERS_MODULE/Timer.php
+++ b/src/Modules/TIMERS_MODULE/Timer.php
@@ -27,6 +27,8 @@ class Timer {
 	/** For repeating timers, this is the repeat interval in seconds */
 	public ?string $data;
 
+	public ?string $origin=null;
+
 	/**
 	 * A list of alerts, each calling $callback
 	 * @var Alert[]

--- a/src/Modules/TIMERS_MODULE/TimerController.php
+++ b/src/Modules/TIMERS_MODULE/TimerController.php
@@ -230,7 +230,7 @@ class TimerController implements MessageEmitter {
 
 	public function sendAlertMessage(Timer $timer, Alert $alert): void {
 		$msg = $alert->message;
-		if (!isset($timer->mode)) {
+		if (!isset($timer->mode) || $timer->mode === "") {
 			$rMsg = new RoutableMessage($msg);
 			$rMsg->appendPath(new Source(Source::SYSTEM, "timers"));
 			$delivered = false;
@@ -248,7 +248,7 @@ class TimerController implements MessageEmitter {
 				return;
 			}
 		}
-		$mode = isset($timer->mode) ? explode(",", $timer->mode) : [];
+		$mode = strlen($timer->mode??"") ? explode(",", $timer->mode) : [];
 		$sent = false;
 		foreach ($mode as $sendMode) {
 			if ($sendMode === "priv") {
@@ -362,7 +362,6 @@ class TimerController implements MessageEmitter {
 	}
 
 	protected function getTimerAlertChannel(string ...$channels): string {
-		return "";
 		// Timers via tell always create tell alerts only
 		if ($channels === ["msg"]) {
 			return "msg";

--- a/src/Modules/TIMERS_MODULE/TimerController.php
+++ b/src/Modules/TIMERS_MODULE/TimerController.php
@@ -128,16 +128,6 @@ class TimerController implements MessageEmitter {
 			'mod',
 			'timer_alert_times.txt'
 		);
-		// $this->settingManager->add(
-		// 	$this->moduleName,
-		// 	'timer_alert_location',
-		// 	'Where to display timer alerts',
-		// 	'edit',
-		// 	"options",
-		// 	"0",
-		// 	"Source only;Source+Priv;Source+Guild;Source+Priv+Guild;Source+Discord;Source+Discord+Priv;Source+Discord+Guild;Source+Discord+Priv+Guild",
-		// 	"0;1;2;3;4;5;6;7"
-		// );
 		$this->settingManager->registerChangeListener(
 			'timer_alert_times',
 			[$this, 'changeTimerAlertTimes']
@@ -247,7 +237,7 @@ class TimerController implements MessageEmitter {
 				return;
 			}
 		}
-		$mode = isset($timer->mode)? explode(",", $timer->mode) : [];
+		$mode = isset($timer->mode) ? explode(",", $timer->mode) : [];
 		$sent = false;
 		foreach ($mode as $sendMode) {
 			if ($sendMode === "priv") {

--- a/src/Modules/TIMERS_MODULE/timers.txt
+++ b/src/Modules/TIMERS_MODULE/timers.txt
@@ -8,15 +8,10 @@ To set a named timer:
 <highlight><tab><symbol>timer 'time' 'name'<end>
 
 To remove a timer (only your own):
-<highlight><tab><symbol>timer rem 'name'<end>
+<highlight><tab><symbol>timer rem 'id'<end>
 
 To create a repeating timer:
 <highlight><tab><symbol>rtimer 'intial time' 'repeating time' 'name'<end>
-
-If you want a timer to show up on discord as well in addition to the configured
-location, prefix the name with +discord like so:
-<highlight><tab><symbol>timer 10m +discord Test timer<end>
-<highlight><tab><symbol>rtimer 10m 8h +discord Test repeating timer<end>
 
 See <a href='chatcmd:///tell <myname> help budatime'><symbol>help budatime</a> for info on the format of the 'time' parameter.
 Note: you can use <symbol>timers and <symbol>timer interchangeably.

--- a/src/Modules/WEBSERVER_MODULE/WebUIChannel.php
+++ b/src/Modules/WEBSERVER_MODULE/WebUIChannel.php
@@ -3,15 +3,20 @@
 namespace Nadybot\Modules\WEBSERVER_MODULE;
 
 use Nadybot\Core\CommandReply;
+use Nadybot\Core\MessageEmitter;
 use Nadybot\Core\MessageHub;
 use Nadybot\Core\Routing\RoutableMessage;
 use Nadybot\Core\Routing\Source;
 
-class WebUIChannel implements CommandReply {
+class WebUIChannel implements CommandReply, MessageEmitter {
 	public MessageHub $messageHub;
 
 	public function __construct(MessageHub $hub) {
 		$this->messageHub = $hub;
+	}
+
+	public function getChannelName(): string {
+		return Source::SYSTEM . "(webui)";
 	}
 
 	public function reply($msg): void {

--- a/src/Modules/WEBSOCKET_MODULE/WebsocketCommandReply.php
+++ b/src/Modules/WEBSOCKET_MODULE/WebsocketCommandReply.php
@@ -5,6 +5,7 @@ namespace Nadybot\Modules\WEBSOCKET_MODULE;
 use Nadybot\Core\AOChatEvent;
 use Nadybot\Core\CommandReply;
 use Nadybot\Core\EventManager;
+use Nadybot\Core\MessageEmitter;
 use Nadybot\Core\MessageHub;
 use Nadybot\Core\Nadybot;
 use Nadybot\Core\Routing\Character;
@@ -13,7 +14,7 @@ use Nadybot\Core\Routing\Source;
 use Nadybot\Core\SettingManager;
 use Nadybot\Modules\WEBSERVER_MODULE\WebChatConverter;
 
-class WebsocketCommandReply implements CommandReply {
+class WebsocketCommandReply implements CommandReply, MessageEmitter {
 	/** @Inject */
 	public Nadybot $chatBot;
 
@@ -33,6 +34,10 @@ class WebsocketCommandReply implements CommandReply {
 
 	public function __construct(string $type) {
 		$this->type = $type;
+	}
+
+	public function getChannelName(): string {
+		return Source::WEB;
 	}
 
 	public function reply($msg): void {


### PR DESCRIPTION
This patch will add a new source `system(timers)`, routing timers that were created with `!timer` or `!rtimer` command.
It removes the ability to use `+discord` for timers, but supports sending the timer to any channel it was created in, including web, console and discordpriv/discordmsg.

Closes #213 