### PR TITLE
Redo sub commands

### DIFF
--- a/src/Core/CommandHandler.php
+++ b/src/Core/CommandHandler.php
@@ -3,11 +3,18 @@
 namespace Nadybot\Core;
 
 class CommandHandler {
-	public string $file;
-	public string $admin;
+	/** @var string[] */
+	public array $files;
 
-	public function __construct(string $fileName, string $accessLevel) {
-		$this->file = $fileName;
-		$this->admin = $accessLevel;
+	public string $access_level;
+
+	public function __construct(string $admin, string ...$fileName) {
+		$this->access_level = $admin;
+		$this->files = $fileName;
+	}
+
+	public function addFile(string ...$file): self {
+		$this->files = array_merge($this->files, $file);
+		return $this;
 	}
 }

--- a/src/Core/CommandManager.php
+++ b/src/Core/CommandManager.php
@@ -967,7 +967,7 @@ class CommandManager implements MessageEmitter {
 			$header = "<header2>'{$cmdName}' command".
 				((count($refGroups) > 1 || count($refGroups[0]) > 1) ? "s" : "");
 			if ($showRights) {
-				$cmdCfg = $this->get($cmdName);
+				$cmdCfg = $this->get((string)$cmdName);
 				if (isset($cmdCfg) && isset($cmdCfg->permissions[$context->permissionSet])) {
 					$al = $cmdCfg->permissions[$context->permissionSet]->access_level;
 					$al = $this->accessManager->getDisplayName($al);
@@ -1012,14 +1012,14 @@ class CommandManager implements MessageEmitter {
 		 * @param ReflectionMethod[] $refMethods1
 		 * @param ReflectionMethod[] $refMethods2
 		 */
-		$list->sort(function (array $refMethods1, array $refMethods2): int {
+		$sList = $list->sort(function (array $refMethods1, array $refMethods2): int {
 			$n1 = $refMethods1[0]->getDeclaringClass()->getShortName();
 			$n2 = $refMethods2[0]->getDeclaringClass()->getShortName();
 			return strcmp($n1, $n2)
 				?: $refMethods1[0]->getStartLine() <=> $refMethods2[0]->getStartLine();
 		});
 		/** @param ReflectionMethod[] $refMethods */
-		return $list->groupBy(function (array $refMethods): string {
+		return $sList->groupBy(function (array $refMethods): string {
 			if (empty($refMethods)) {
 				return "";
 			}

--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -221,7 +221,7 @@ class DB {
 					if (!$errorShown) {
 						$this->logger->error(
 							"Cannot connect to the PostgreSQL db at {$host}: ".
-							trim($e->errorInfo[2])
+							trim($e->errorInfo[2] ?? $e->getMessage())
 						);
 						$this->logger->notice(
 							"Will keep retrying until the db is back up again"

--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -51,21 +51,9 @@ class DB {
 	private Capsule $capsule;
 
 	/**
-	 * The name of the bot
-	 */
-	private string $botname;
-
-	/**
-	 * The dimension
-	 */
-	private int $dim;
-
-	/**
 	 * The database name
 	 */
 	protected string $dbName;
-
-	private string $guild;
 
 	#[NCA\Logger]
 	public LoggerWrapper $logger;

--- a/src/Core/Migrations/20220115132257_MigrateCmdcfg.php
+++ b/src/Core/Migrations/20220115132257_MigrateCmdcfg.php
@@ -19,6 +19,9 @@ class MigrateCmdcfg implements SchemaMigration {
 		$entries = $db->table($table)->get();
 		$db->table($table)->truncate();
 
+		$db->schema()->table($table, function(Blueprint $table): void {
+			$table->dropUnique(["cmd", "type"]);
+		});
 		$db->schema()->dropColumns($table, ["admin", "status", "type"]);
 		$db->schema()->table($table, function(Blueprint $table): void {
 			$table->unique("cmd");

--- a/src/Core/Migrations/20220209073229_MigrateSubCmds.php
+++ b/src/Core/Migrations/20220209073229_MigrateSubCmds.php
@@ -2,25 +2,28 @@
 
 namespace Nadybot\Core\Migrations;
 
-use Exception;
-use Nadybot\Core\CommandAlias;
-use Nadybot\Core\CommandManager;
-use Nadybot\Core\DB;
-use Nadybot\Core\LoggerWrapper;
-use Nadybot\Core\SchemaMigration;
-use Nadybot\Modules\BASIC_CHAT_MODULE\ChatAssistController;
-use Nadybot\Modules\BASIC_CHAT_MODULE\ChatLeaderController;
-use Nadybot\Modules\BASIC_CHAT_MODULE\ChatRallyController;
-use Nadybot\Modules\BASIC_CHAT_MODULE\ChatTopicController;
-use Nadybot\Modules\EVENTS_MODULE\EventsController;
-use Nadybot\Modules\LOOT_MODULE\LootController;
-use Nadybot\Modules\RAFFLE_MODULE\RaffleController;
-use Nadybot\Modules\RAID_MODULE\AuctionController;
-use Nadybot\Modules\RAID_MODULE\RaidBlockController;
-use Nadybot\Modules\RAID_MODULE\RaidController;
-use Nadybot\Modules\RAID_MODULE\RaidMemberController;
-use Nadybot\Modules\RAID_MODULE\RaidPointsController;
-use Nadybot\Modules\WORLDBOSS_MODULE\WorldBossController;
+use Nadybot\Core\{
+	CommandAlias,
+	CommandManager,
+	DB,
+	LoggerWrapper,
+	SchemaMigration,
+};
+use Nadybot\Modules\{
+	BASIC_CHAT_MODULE\ChatAssistController,
+	BASIC_CHAT_MODULE\ChatLeaderController,
+	BASIC_CHAT_MODULE\ChatRallyController,
+	BASIC_CHAT_MODULE\ChatTopicController,
+	EVENTS_MODULE\EventsController,
+	LOOT_MODULE\LootController,
+	RAFFLE_MODULE\RaffleController,
+	RAID_MODULE\AuctionController,
+	RAID_MODULE\RaidBlockController,
+	RAID_MODULE\RaidController,
+	RAID_MODULE\RaidMemberController,
+	RAID_MODULE\RaidPointsController,
+	WORLDBOSS_MODULE\WorldBossController,
+};
 
 class MigrateSubCmds implements SchemaMigration {
 	protected function deleteAlias(DB $db, LoggerWrapper $logger, string $alias): void {

--- a/src/Core/Migrations/20220209073229_MigrateSubCmds.php
+++ b/src/Core/Migrations/20220209073229_MigrateSubCmds.php
@@ -12,11 +12,15 @@ use Nadybot\Modules\BASIC_CHAT_MODULE\ChatAssistController;
 use Nadybot\Modules\BASIC_CHAT_MODULE\ChatLeaderController;
 use Nadybot\Modules\BASIC_CHAT_MODULE\ChatRallyController;
 use Nadybot\Modules\BASIC_CHAT_MODULE\ChatTopicController;
+use Nadybot\Modules\EVENTS_MODULE\EventsController;
+use Nadybot\Modules\LOOT_MODULE\LootController;
+use Nadybot\Modules\RAFFLE_MODULE\RaffleController;
 use Nadybot\Modules\RAID_MODULE\AuctionController;
 use Nadybot\Modules\RAID_MODULE\RaidBlockController;
 use Nadybot\Modules\RAID_MODULE\RaidController;
 use Nadybot\Modules\RAID_MODULE\RaidMemberController;
 use Nadybot\Modules\RAID_MODULE\RaidPointsController;
+use Nadybot\Modules\WORLDBOSS_MODULE\WorldBossController;
 
 class MigrateSubCmds implements SchemaMigration {
 	protected function deleteAlias(DB $db, LoggerWrapper $logger, string $alias): void {
@@ -56,6 +60,13 @@ class MigrateSubCmds implements SchemaMigration {
 			"points rem",
 			"raid reward",
 			"raid punish",
+			"comment categories",
+			"comment category",
+			"raffle start",
+			"raffle end",
+			"raffle cancel",
+			"raffle timer",
+			"raffle announce",
 		];
 
 		$renamedCmds = [
@@ -63,9 +74,8 @@ class MigrateSubCmds implements SchemaMigration {
 			"leader (.+)" => ChatLeaderController::CMD_LEADER_SET,
 			"rally .+" => ChatRallyController::CMD_RALLY_SET,
 			"topic .+" => ChatTopicController::CMD_TOPIC_SET,
-			"auction" => AuctionController::CMD_BID_AUCTIONS,
+			"auction" => AuctionController::CMD_BID_AUCTION,
 			"auction reimburse .+" => AuctionController::CMD_BID_REIMBURSE,
-
 			"raid .+" => RaidController::CMD_RAID_MANAGE,
 			"raid spp .+" => RaidController::CMD_RAID_TICKER,
 			"raid (join|leave)" => RaidMemberController::CMD_RAID_JOIN_LEAVE,
@@ -75,6 +85,15 @@ class MigrateSubCmds implements SchemaMigration {
 			"points .+" => RaidPointsController::CMD_POINTS_OTHER,
 			"pointsmod" => RaidPointsController::CMD_POINTS_MODIFY,
 			"raidblock .+" => RaidBlockController::CMD_RAIDBLOCK_EDIT,
+			"commentcategories" => "comment categories",
+			"events add .+" => EventsController::CMD_EVENT_MANAGE,
+			"loot .+" => LootController::CMD_LOOT_MANAGE,
+			"raffleadmin" => RaffleController::CMD_RAFFLE_MANAGE,
+			"tara .+" => WorldBossController::CMD_TARA_UPDATE,
+			"father .+" => WorldBossController::CMD_FATHER_UPDATE,
+			"loren .+" => WorldBossController::CMD_LOREN_UPDATE,
+			"gauntlet .+" => WorldBossController::CMD_GAUNTLET_UPDATE,
+			"reaper .+" => WorldBossController::CMD_REAPER_UPDATE,
 		];
 
 		foreach ($deletedAliases as $alias) {
@@ -84,6 +103,5 @@ class MigrateSubCmds implements SchemaMigration {
 		foreach ($renamedCmds as $oldName => $newName) {
 			$this->migrateSubCmdRights($db, $logger, $oldName, $newName);
 		}
-		throw new Exception("Boom!");
 	}
 }

--- a/src/Core/Migrations/20220209073229_MigrateSubCmds.php
+++ b/src/Core/Migrations/20220209073229_MigrateSubCmds.php
@@ -33,16 +33,13 @@ class MigrateSubCmds implements SchemaMigration {
 	}
 
 	protected function migrateSubCmdRights(DB $db, LoggerWrapper $logger, string $old, string $new): void {
-		$updated = $db->table(CommandManager::DB_TABLE)
+		$db->table(CommandManager::DB_TABLE)
 			->where('cmd', $old)
 			->update([
 				'cmd' => $new,
 				'cmdevent' => "subcmd",
 				'dependson' => strtolower(explode(" ", $new)[0]),
 			]);
-		if (!$updated) {
-			$logger->warning("Command {$old} not found");
-		}
 		$db->table(CommandManager::DB_TABLE_PERMS)
 			->where('cmd', $old)
 			->update(['cmd' => $new]);

--- a/src/Core/Migrations/20220209073229_MigrateSubCmds.php
+++ b/src/Core/Migrations/20220209073229_MigrateSubCmds.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core\Migrations;
+
+use Exception;
+use Nadybot\Core\CommandAlias;
+use Nadybot\Core\CommandManager;
+use Nadybot\Core\DB;
+use Nadybot\Core\LoggerWrapper;
+use Nadybot\Core\SchemaMigration;
+use Nadybot\Modules\BASIC_CHAT_MODULE\ChatAssistController;
+use Nadybot\Modules\BASIC_CHAT_MODULE\ChatLeaderController;
+use Nadybot\Modules\BASIC_CHAT_MODULE\ChatRallyController;
+use Nadybot\Modules\BASIC_CHAT_MODULE\ChatTopicController;
+use Nadybot\Modules\RAID_MODULE\AuctionController;
+use Nadybot\Modules\RAID_MODULE\RaidBlockController;
+use Nadybot\Modules\RAID_MODULE\RaidController;
+use Nadybot\Modules\RAID_MODULE\RaidMemberController;
+use Nadybot\Modules\RAID_MODULE\RaidPointsController;
+
+class MigrateSubCmds implements SchemaMigration {
+	protected function deleteAlias(DB $db, LoggerWrapper $logger, string $alias): void {
+		$db->table(CommandAlias::DB_TABLE)
+			->where("alias", $alias)
+			->delete();
+	}
+
+	protected function migrateSubCmdRights(DB $db, LoggerWrapper $logger, string $old, string $new): void {
+		$updated = $db->table(CommandManager::DB_TABLE)
+			->where('cmd', $old)
+			->update([
+				'cmd' => $new,
+				'cmdevent' => "subcmd",
+				'dependson' => strtolower(explode(" ", $new)[0]),
+			]);
+		if (!$updated) {
+			$logger->warning("Command {$old} not found");
+		}
+		$db->table(CommandManager::DB_TABLE_PERMS)
+			->where('cmd', $old)
+			->update(['cmd' => $new]);
+	}
+
+	public function migrate(LoggerWrapper $logger, DB $db): void {
+		$deletedAliases = [
+			"bid start",
+			"bid end",
+			"bid cancel",
+			"bid reimburse",
+			"bid payback",
+			"bid refund",
+			"adminhelp",
+			"raid add",
+			"raid kick",
+			"points add",
+			"points rem",
+			"raid reward",
+			"raid punish",
+		];
+
+		$renamedCmds = [
+			"assist .+" => ChatAssistController::CMD_SET_ADD_CLEAR,
+			"leader (.+)" => ChatLeaderController::CMD_LEADER_SET,
+			"rally .+" => ChatRallyController::CMD_RALLY_SET,
+			"topic .+" => ChatTopicController::CMD_TOPIC_SET,
+			"auction" => AuctionController::CMD_BID_AUCTIONS,
+			"auction reimburse .+" => AuctionController::CMD_BID_REIMBURSE,
+
+			"raid .+" => RaidController::CMD_RAID_MANAGE,
+			"raid spp .+" => RaidController::CMD_RAID_TICKER,
+			"raid (join|leave)" => RaidMemberController::CMD_RAID_JOIN_LEAVE,
+			"raidmember" => RaidMemberController::CMD_RAID_KICK_ADD,
+			"raidpoints" => RaidPointsController::CMD_RAID_REWARD_PUNISH,
+			"reward .+" => RaidPointsController::CMD_REWARD_EDIT,
+			"points .+" => RaidPointsController::CMD_POINTS_OTHER,
+			"pointsmod" => RaidPointsController::CMD_POINTS_MODIFY,
+			"raidblock .+" => RaidBlockController::CMD_RAIDBLOCK_EDIT,
+		];
+
+		foreach ($deletedAliases as $alias) {
+			$this->deleteAlias($db, $logger, $alias);
+		}
+
+		foreach ($renamedCmds as $oldName => $newName) {
+			$this->migrateSubCmdRights($db, $logger, $oldName, $newName);
+		}
+		throw new Exception("Boom!");
+	}
+}

--- a/src/Core/Modules/BUDDYLIST/BuddylistController.php
+++ b/src/Core/Modules/BUDDYLIST/BuddylistController.php
@@ -2,16 +2,18 @@
 
 namespace Nadybot\Core\Modules\BUDDYLIST;
 
-use Nadybot\Core\Attributes as NCA;
-use Nadybot\Core\BuddylistEntry;
-use Nadybot\Core\Nadybot;
-use Nadybot\Core\BuddylistManager;
-use Nadybot\Core\CmdContext;
-use Nadybot\Core\ModuleInstance;
-use Nadybot\Core\Text;
-use Nadybot\Core\ParamClass\PCharacter;
-use Nadybot\Core\ParamClass\PRemove;
-use Nadybot\Core\ParamClass\PWord;
+use Nadybot\Core\{
+	Attributes as NCA,
+	BuddylistEntry,
+	Nadybot,
+	BuddylistManager,
+	CmdContext,
+	ModuleInstance,
+	Text,
+	ParamClass\PCharacter,
+	ParamClass\PRemove,
+	ParamClass\PWord,
+};
 
 /**
  * @author Tyrence (RK2)

--- a/src/Core/Modules/CONFIG/AliasController.php
+++ b/src/Core/Modules/CONFIG/AliasController.php
@@ -2,17 +2,17 @@
 
 namespace Nadybot\Core\Modules\CONFIG;
 
-use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\{
+	Attributes as NCA,
 	CmdContext,
 	CommandAlias,
 	CommandManager,
+	DBSchema\CmdAlias,
 	ModuleInstance,
+	ParamClass\PRemove,
+	ParamClass\PWord,
 	Text,
 };
-use Nadybot\Core\DBSchema\CmdAlias;
-use Nadybot\Core\ParamClass\PRemove;
-use Nadybot\Core\ParamClass\PWord;
 
 #[
 	NCA\Instance,

--- a/src/Core/Modules/CONFIG/CommandSearchController.php
+++ b/src/Core/Modules/CONFIG/CommandSearchController.php
@@ -54,7 +54,7 @@ class CommandSearchController extends ModuleInstance {
 			->asObj(CommandSearchResult::class)
 			->each(function (CommandSearchResult $cmd) use ($permissions): void {
 				$cmd->permissions = $permissions->get($cmd->cmd, new Collection())
-					->keyBy("name")->toArray();
+					->keyBy("permission_set")->toArray();
 			});
 	}
 

--- a/src/Core/Modules/CONFIG/CommandSearchController.php
+++ b/src/Core/Modules/CONFIG/CommandSearchController.php
@@ -2,21 +2,21 @@
 
 namespace Nadybot\Core\Modules\CONFIG;
 
-use Nadybot\Core\Attributes as NCA;
 use Exception;
 use Illuminate\Support\Collection;
 use Nadybot\Core\{
 	AccessManager,
+	Attributes as NCA,
 	CmdContext,
 	CommandManager,
 	DB,
+	DBSchema\CommandSearchResult,
+	DBSchema\CmdPermission,
 	ModuleInstance,
 	Nadybot,
 	SQLException,
 	Text,
 };
-use Nadybot\Core\DBSchema\CommandSearchResult;
-use Nadybot\Core\DBSchema\CmdPermission;
 
 #[
 	NCA\Instance,

--- a/src/Core/Modules/CONFIG/CommandlistController.php
+++ b/src/Core/Modules/CONFIG/CommandlistController.php
@@ -2,17 +2,17 @@
 
 namespace Nadybot\Core\Modules\CONFIG;
 
-use Nadybot\Core\Attributes as NCA;
 use Illuminate\Support\Collection;
 use Nadybot\Core\{
+	Attributes as NCA,
 	AccessManager,
 	CmdContext,
 	CommandManager,
 	DB,
+	DBSchema\CmdCfg,
 	ModuleInstance,
 	Text,
 };
-use Nadybot\Core\DBSchema\CmdCfg;
 
 #[
 	NCA\Instance,

--- a/src/Core/Modules/CONFIG/ConfigApiController.php
+++ b/src/Core/Modules/CONFIG/ConfigApiController.php
@@ -10,6 +10,7 @@ use Nadybot\Core\{
 	CommandManager,
 	DB,
 	DBSchema\CmdPermissionSet,
+	DBSchema\CmdPermSetMapping,
 	DBSchema\EventCfg,
 	DBSchema\Setting,
 	EventManager,
@@ -19,7 +20,6 @@ use Nadybot\Core\{
 	SettingManager,
 	SQLException,
 };
-use Nadybot\Core\DBSchema\CmdPermSetMapping;
 use Nadybot\Modules\{
 	DISCORD_GATEWAY_MODULE\DiscordRelayController,
 	WEBSERVER_MODULE\ApiResponse,

--- a/src/Core/Modules/CONFIG/ConfigController.php
+++ b/src/Core/Modules/CONFIG/ConfigController.php
@@ -694,7 +694,7 @@ class ConfigController extends ModuleInstance {
 				if (in_array(true, $enabled, true)) {
 					$statusLinks []= $this->text->makeChatcmd("disable", "/tell <myname> config subcmd {$row->cmd} disable all");
 				}
-				$cmdNameLink = "<tab>{$row->cmd}";
+				$cmdNameLink = "<tab>" . explode(" ", $row->cmd, 2)[1];
 			}
 
 			$status = [];

--- a/src/Core/Modules/CONFIG/ConfigController.php
+++ b/src/Core/Modules/CONFIG/ConfigController.php
@@ -878,10 +878,10 @@ class ConfigController extends ModuleInstance {
 	public function getModules(): array {
 		$eventQuery = $this->db->table(EventManager::DB_TABLE)
 			->select("module");
-		$eventQuery->selectRaw($eventQuery->grammar->wrap("status") . "+2");
+		$eventQuery->selectRaw($eventQuery->grammar->wrap("status") . "+2 " . $eventQuery->as("status"));
 		$settingsQuery = $this->db->table(SettingManager::DB_TABLE)
 			->select("module");
-		$settingsQuery->selectRaw("4");
+		$settingsQuery->selectRaw("4 " . $settingsQuery->as("status"));
 
 		$outerQuery = $this->db->fromSub(
 			$eventQuery->unionAll($settingsQuery),

--- a/src/Core/Modules/HELP/HelpController.php
+++ b/src/Core/Modules/HELP/HelpController.php
@@ -16,6 +16,7 @@ use Nadybot\Core\{
 	ModuleInstance,
 	Modules\PREFERENCES\Preferences,
 	Nadybot,
+	SettingManager,
 	Text,
 };
 
@@ -59,6 +60,9 @@ class HelpController extends ModuleInstance {
 	public ConfigController $configController;
 
 	#[NCA\Inject]
+	public SettingManager $settingManager;
+
+	#[NCA\Inject]
 	public DB $db;
 
 	#[NCA\Inject]
@@ -72,6 +76,18 @@ class HelpController extends ModuleInstance {
 			"about.txt",
 			"all",
 			"Info about the development of Nadybot"
+		);
+
+		$this->settingManager->add(
+			module: $this->moduleName,
+			name: "help_show_al",
+			description: 'Show mods the required access level for each command',
+			mode: 'edit',
+			type: "options",
+			options: "true;false",
+			intoptions: "1;0",
+			accessLevel: "mod",
+			value: "1",
 		);
 
 		$this->commandAlias->register($this->moduleName, "help about", "about");

--- a/src/Core/Modules/LIMITS/LimitsController.php
+++ b/src/Core/Modules/LIMITS/LimitsController.php
@@ -8,26 +8,26 @@ use Nadybot\Core\{
 	CmdEvent,
 	CommandHandler,
 	ConfigFile,
-	ModuleInstance,
+	DBSchema\Audit,
+	DBSchema\Player,
 	LoggerWrapper,
 	MessageHub,
+	ModuleInstance,
+	Modules\BAN\BanController,
+	Modules\CONFIG\ConfigController,
 	Nadybot,
+	Routing\RoutableMessage,
+	Routing\Source,
 	SettingManager,
 	Timer,
 	Util,
 };
-use Nadybot\Core\DBSchema\Audit;
-use Nadybot\Core\DBSchema\Player;
-use Nadybot\Core\Modules\BAN\BanController;
-use Nadybot\Core\Modules\CONFIG\ConfigController;
 use Nadybot\Core\Modules\PLAYER_LOOKUP\{
 	PlayerHistory,
 	PlayerHistoryData,
 	PlayerHistoryManager,
 	PlayerManager,
 };
-use Nadybot\Core\Routing\RoutableMessage;
-use Nadybot\Core\Routing\Source;
 
 /**
  * @author Tyrence (RK2)

--- a/src/Core/Modules/LIMITS/LimitsController.php
+++ b/src/Core/Modules/LIMITS/LimitsController.php
@@ -417,7 +417,7 @@ class LimitsController extends ModuleInstance {
 	 * Aliases for example do not count, because else they would count twice.
 	 */
 	public function commandHandlerCounts(CommandHandler $ch): bool {
-		if ($ch->file === "CommandAlias.process") {
+		if ($ch->files === ["CommandAlias.process"]) {
 			return false;
 		}
 		return true;

--- a/src/Core/Modules/LIMITS/RateIgnoreController.php
+++ b/src/Core/Modules/LIMITS/RateIgnoreController.php
@@ -2,19 +2,19 @@
 
 namespace Nadybot\Core\Modules\LIMITS;
 
-use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\{
+	Attributes as NCA,
 	CmdContext,
 	DB,
+	DBSchema\RateIgnoreList,
 	ModuleInstance,
 	Nadybot,
+	ParamClass\PCharacter,
+	ParamClass\PRemove,
 	SQLException,
 	Text,
 	Util,
 };
-use Nadybot\Core\DBSchema\RateIgnoreList;
-use Nadybot\Core\ParamClass\PCharacter;
-use Nadybot\Core\ParamClass\PRemove;
 
 /**
  * @author Tyrence (RK2)

--- a/src/Core/Modules/PLAYER_LOOKUP/GuildManager.php
+++ b/src/Core/Modules/PLAYER_LOOKUP/GuildManager.php
@@ -2,22 +2,22 @@
 
 namespace Nadybot\Core\Modules\PLAYER_LOOKUP;
 
-use Nadybot\Core\Attributes as NCA;
 use Closure;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
 use Safe\Exceptions\JsonException;
 use Nadybot\Core\{
+	Attributes as NCA,
 	CacheManager,
 	CacheResult,
 	ConfigFile,
 	DB,
+	DBSchema\Player,
 	EventManager,
 	ModuleInstance,
 	Nadybot,
 };
-use Nadybot\Core\DBSchema\Player;
 
 /**
  * @author Tyrence (RK2)

--- a/src/Core/Modules/PROFILE/ProfileController.php
+++ b/src/Core/Modules/PROFILE/ProfileController.php
@@ -325,7 +325,7 @@ class ProfileController extends ModuleInstance {
 					/** @var CmdPermission|null $data */
 					$data = $this->db->table(CommandManager::DB_TABLE_PERMS)
 						->where("cmd", $parts[2])
-						->where("name", $parts[4])
+						->where("permission_set", $parts[4])
 						->asObj(CmdPermission::class)
 						->first();
 					if (isset($data) && ($data->enabled === ($parts[3] === 'enable'))) {

--- a/src/Core/Nadybot.php
+++ b/src/Core/Nadybot.php
@@ -1279,7 +1279,7 @@ class Nadybot extends AOChat {
 				/** @var NCA\HandlesCommand */
 				$command = $command->newInstance();
 				$commandName = $command->command;
-				$handlerName = "{$name}.{$method->name}";
+				$handlerName = "{$name}.{$method->name}:".$method->getStartLine();
 				if (isset($commands[$commandName])) {
 					$commands[$commandName]['handlers'][] = $handlerName;
 				} elseif (isset($subcommands[$commandName])) {

--- a/src/Modules/BASIC_CHAT_MODULE/ChatAssistController.php
+++ b/src/Modules/BASIC_CHAT_MODULE/ChatAssistController.php
@@ -26,7 +26,7 @@ use Nadybot\Core\{
 		alias: "callers"
 	),
 	NCA\DefineCommand(
-		command: "assist .+",
+		command: ChatAssistController::CMD_SET_ADD_CLEAR,
 		accessLevel: "rl",
 		description: "Set, add or clear assists",
 	),
@@ -35,6 +35,8 @@ use Nadybot\Core\{
 	NCA\ProvidesEvent("assist(add)")
 ]
 class ChatAssistController extends ModuleInstance {
+	public const CMD_SET_ADD_CLEAR = "assist set/add/clear";
+
 	#[NCA\Inject]
 	public Nadybot $chatBot;
 
@@ -175,7 +177,7 @@ class ChatAssistController extends ModuleInstance {
 	}
 
 	/** Remove a player from all or only a specific assist list */
-	#[NCA\HandlesCommand("assist .+")]
+	#[NCA\HandlesCommand(ChatAssistController::CMD_SET_ADD_CLEAR)]
 	#[NCA\Help\Example("<symbol>assist rem Nady", "Remove Nady from all assist lists")]
 	#[NCA\Help\Example("<symbol>assist rem FOO.Nady", "Remove Nady from the assist lists FOO")]
 	public function assistRemCommand(CmdContext $context, PRemove $action, string $toRemove): void {
@@ -218,7 +220,7 @@ class ChatAssistController extends ModuleInstance {
 	}
 
 	/** Clear a specific assist list */
-	#[NCA\HandlesCommand("assist .+")]
+	#[NCA\HandlesCommand(ChatAssistController::CMD_SET_ADD_CLEAR)]
 	#[NCA\Help\Example("<symbol>assist clear FOO", "Clear the assist list FOO")]
 	#[NCA\Help\Example(
 		"<symbol>assist clear mine",
@@ -285,7 +287,7 @@ class ChatAssistController extends ModuleInstance {
 	}
 
 	/** Clear all assist lists */
-	#[NCA\HandlesCommand("assist .+")]
+	#[NCA\HandlesCommand(ChatAssistController::CMD_SET_ADD_CLEAR)]
 	public function assistClearCommand(CmdContext $context, #[NCA\Str("clear")] string $action): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {
 			$context->reply("You must be Raid Leader to use this command.");
@@ -311,7 +313,7 @@ class ChatAssistController extends ModuleInstance {
 	}
 
 	/** Create an assist macro for multiple characters */
-	#[NCA\HandlesCommand("assist .+")]
+	#[NCA\HandlesCommand(ChatAssistController::CMD_SET_ADD_CLEAR)]
 	public function assistSetCommand(CmdContext $context, #[NCA\Str("set")] string $action, PCharacter ...$callers): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {
 			$context->reply("You must be Raid Leader to use this command.");
@@ -375,7 +377,7 @@ class ChatAssistController extends ModuleInstance {
 	}
 
 	/** Add a new player to the global assist list, or the one given */
-	#[NCA\HandlesCommand("assist .+")]
+	#[NCA\HandlesCommand(ChatAssistController::CMD_SET_ADD_CLEAR)]
 	public function assistAddCommand(CmdContext $context, #[NCA\Str("add")] string $action, ?PWord $assistList, PCharacter $caller): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {
 			$context->reply("You must be Raid Leader to use this command.");
@@ -435,7 +437,7 @@ class ChatAssistController extends ModuleInstance {
 	}
 
 	/** Undo the last &lt;steps&gt; or 1 modification(s) of the caller list */
-	#[NCA\HandlesCommand("assist .+")]
+	#[NCA\HandlesCommand(ChatAssistController::CMD_SET_ADD_CLEAR)]
 	public function assistUndoCommand(CmdContext $context, #[NCA\Str("undo")] string $action, ?int $steps): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {
 			$context->reply("You must be Raid Leader to use this command.");
@@ -464,7 +466,7 @@ class ChatAssistController extends ModuleInstance {
 	}
 
 	/** See the most recent changes to the list of callers */
-	#[NCA\HandlesCommand("assist .+")]
+	#[NCA\HandlesCommand(ChatAssistController::CMD_SET_ADD_CLEAR)]
 	public function assistHistoryCommand(CmdContext $context, #[NCA\Str("history")] string $action): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {
 			$context->reply("You must be Raid Leader to use this command.");
@@ -492,7 +494,7 @@ class ChatAssistController extends ModuleInstance {
 	}
 
 	/** Create an assist macro for a single character */
-	#[NCA\HandlesCommand("assist .+")]
+	#[NCA\HandlesCommand(ChatAssistController::CMD_SET_ADD_CLEAR)]
 	public function assistOnceCommand(CmdContext $context, PCharacter $char): void {
 		$name = $char();
 		if (!$this->chatBot->get_uid($name)) {

--- a/src/Modules/BASIC_CHAT_MODULE/ChatLeaderController.php
+++ b/src/Modules/BASIC_CHAT_MODULE/ChatLeaderController.php
@@ -23,7 +23,7 @@ use Nadybot\Core\{
 		description: "Sets the Leader of the raid",
 	),
 	NCA\DefineCommand(
-		command: "leader (.+)",
+		command: ChatLeaderController::CMD_LEADER_SET,
 		accessLevel: "rl",
 		description: "Sets a specific Leader",
 	),
@@ -36,6 +36,8 @@ use Nadybot\Core\{
 	NCA\ProvidesEvent("leader(set)")
 ]
 class ChatLeaderController extends ModuleInstance implements AccessLevelProvider {
+	public const CMD_LEADER_SET = "leader set leader";
+
 	#[NCA\Inject]
 	public Nadybot $chatBot;
 
@@ -105,7 +107,7 @@ class ChatLeaderController extends ModuleInstance implements AccessLevelProvider
 	/**
 	 * Set someone to be raid leader
 	 */
-	#[NCA\HandlesCommand("leader (.+)")]
+	#[NCA\HandlesCommand(self::CMD_LEADER_SET)]
 	public function leaderSetCommand(CmdContext $context, PCharacter $newLeader): void {
 		$msg = $this->setLeader($newLeader(), $context->char->name);
 		if ($msg !== null) {

--- a/src/Modules/BASIC_CHAT_MODULE/ChatRallyController.php
+++ b/src/Modules/BASIC_CHAT_MODULE/ChatRallyController.php
@@ -27,7 +27,7 @@ use Nadybot\Modules\HELPBOT_MODULE\PlayfieldController;
 		description: "Shows the rally waypoint",
 	),
 	NCA\DefineCommand(
-		command: "rally .+",
+		command: ChatRallyController::CMD_RALLY_SET,
 		accessLevel: "rl",
 		description: "Sets the rally waypoint",
 	),
@@ -41,6 +41,8 @@ use Nadybot\Modules\HELPBOT_MODULE\PlayfieldController;
 	)
 ]
 class ChatRallyController extends ModuleInstance {
+	public const CMD_RALLY_SET = "rally set/clear";
+
 	#[NCA\Inject]
 	public SettingManager $settingManager;
 
@@ -82,7 +84,7 @@ class ChatRallyController extends ModuleInstance {
 	/**
 	 * Clear the current rally location
 	 */
-	#[NCA\HandlesCommand("rally .+")]
+	#[NCA\HandlesCommand(self::CMD_RALLY_SET)]
 	public function rallyClearCommand(
 		CmdContext $context,
 		#[NCA\Str("clear")] string $action
@@ -104,7 +106,7 @@ class ChatRallyController extends ModuleInstance {
 	/**
 	 * Set the rally waypoint
 	 */
-	#[NCA\HandlesCommand("rally .+")]
+	#[NCA\HandlesCommand(self::CMD_RALLY_SET)]
 	#[NCA\Help\Example("<symbol>rally 10.9 x 30 x 560")]
 	#[NCA\Help\Example("<symbol>rally 10.9 . 30 . 4HO")]
 	#[NCA\Help\Example("<symbol>rally 10.9, 30, 560")]
@@ -154,7 +156,7 @@ class ChatRallyController extends ModuleInstance {
 	/**
 	 * Set the rally waypoint
 	 */
-	#[NCA\HandlesCommand("rally .+")]
+	#[NCA\HandlesCommand(self::CMD_RALLY_SET)]
 	#[NCA\Help\Example("<symbol>rally (10.9 30.0 y 20.1 550)")]
 	public function rallySet1Command(CmdContext $context, string $pasteFromF9): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {

--- a/src/Modules/BASIC_CHAT_MODULE/ChatTopicController.php
+++ b/src/Modules/BASIC_CHAT_MODULE/ChatTopicController.php
@@ -23,7 +23,7 @@ use Nadybot\Core\{
 		description: "Shows Topic",
 	),
 	NCA\DefineCommand(
-		command: "topic .+",
+		command: ChatTopicController::CMD_TOPIC_SET,
 		accessLevel: "rl",
 		description: "Changes Topic",
 	),
@@ -31,6 +31,8 @@ use Nadybot\Core\{
 	NCA\ProvidesEvent("topic(clear)")
 ]
 class ChatTopicController extends ModuleInstance {
+	public const CMD_TOPIC_SET = "topic set/clear";
+
 	#[NCA\Inject]
 	public Nadybot $chatBot;
 
@@ -96,7 +98,7 @@ class ChatTopicController extends ModuleInstance {
 	/**
 	 * Clear the topic
 	 */
-	#[NCA\HandlesCommand("topic .+")]
+	#[NCA\HandlesCommand(self::CMD_TOPIC_SET)]
 	public function topicClearCommand(CmdContext $context, #[NCA\Str("clear")] string $action): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {
 			$context->reply("You must be Raid Leader to use this command.");
@@ -115,7 +117,7 @@ class ChatTopicController extends ModuleInstance {
 	/**
 	 * Set a new topic
 	 */
-	#[NCA\HandlesCommand("topic .+")]
+	#[NCA\HandlesCommand(self::CMD_TOPIC_SET)]
 	public function topicSetCommand(CmdContext $context, string $topic): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {
 			$context->reply("You must be Raid Leader to use this command.");

--- a/src/Modules/COMMENT_MODULE/CommentController.php
+++ b/src/Modules/COMMENT_MODULE/CommentController.php
@@ -33,9 +33,10 @@ use Nadybot\Core\{
 		command: "comment",
 		accessLevel: "member",
 		description: "read/write comments about players",
+		alias: 'comments',
 	),
 	NCA\DefineCommand(
-		command: "commentcategories",
+		command: "comment categories",
 		accessLevel: "mod",
 		description: "Manage comment categories",
 	)
@@ -68,13 +69,10 @@ class CommentController extends ModuleInstance {
 	#[NCA\Logger]
 	public LoggerWrapper $logger;
 
-	public const ADMIN="admin";
+	public const ADMIN = "admin";
 
 	#[NCA\Setup]
 	public function setup(): void {
-		$this->commandAlias->register($this->moduleName, "commentcategories", "comment categories");
-		$this->commandAlias->register($this->moduleName, "commentcategories", "comment category");
-		$this->commandAlias->register($this->moduleName, "comment", "comments");
 		$sm = $this->settingManager;
 		$sm->add(
 			$this->moduleName,
@@ -231,8 +229,11 @@ class CommentController extends ModuleInstance {
 	/**
 	 * Get a list of all defined comment categories
 	 */
-	#[NCA\HandlesCommand("commentcategories")]
-	public function listCategoriesCommand(CmdContext $context): void {
+	#[NCA\HandlesCommand("comment categories")]
+	public function listCategoriesCommand(
+		CmdContext $context,
+		#[NCA\Str("category", "categories")] string $action,
+	): void {
 		/** @var CommentCategory[] */
 		$categories = $this->db->table("<table:comment_categories>")
 			->asObj(CommentCategory::class)->toArray();
@@ -271,10 +272,11 @@ class CommentController extends ModuleInstance {
 	 *
 	 * You can only delete categories to which you have the access level for reading and writing
 	 */
-	#[NCA\HandlesCommand("commentcategories")]
+	#[NCA\HandlesCommand("comment categories")]
 	public function deleteCategoryCommand(
 		CmdContext $context,
-		PRemove $action,
+		#[NCA\Str("category", "categories")] string $action,
+		PRemove $subAction,
 		string $category
 	): void {
 		$cat = $this->getCategory($category);
@@ -315,10 +317,11 @@ class CommentController extends ModuleInstance {
 	 * Add a new comment category with a minimum access level of
 	 * &lt;al for reading&gt; and optionally a &lt;al for writing&gt;
 	 */
-	#[NCA\HandlesCommand("commentcategories")]
+	#[NCA\HandlesCommand("comment categories")]
 	public function addCategoryCommand(
 		CmdContext $context,
-		#[NCA\Str("add", "create", "new", "edit", "change")] string $action,
+		#[NCA\Str("category", "categories")] string $action,
+		#[NCA\Str("add", "create", "new", "edit", "change")] string $subAction,
 		PWord $category,
 		PWord $alForReading,
 		?PWord $alForWriting

--- a/src/Modules/DEV_MODULE/DevController.php
+++ b/src/Modules/DEV_MODULE/DevController.php
@@ -27,22 +27,22 @@ use ReflectionException;
 	NCA\DefineCommand(
 		command: "showcmdregex",
 		accessLevel: "admin",
-		description: "Test the bot commands",
+		description: "View regex masks used to match commands",
 	),
 	NCA\DefineCommand(
 		command: "intransaction",
 		accessLevel: "admin",
-		description: "Test the bot commands",
+		description: "Check if a DB transaction is open",
 	),
 	NCA\DefineCommand(
 		command: "rollbacktransaction",
 		accessLevel: "admin",
-		description: "Test the bot commands",
+		description: "Rollback an open DB transaction",
 	),
 	NCA\DefineCommand(
 		command: "stacktrace",
 		accessLevel: "admin",
-		description: "Test the bot commands",
+		description: "Show a stacktrace",
 	),
 	NCA\DefineCommand(
 		command: "cmdhandlers",
@@ -184,7 +184,7 @@ class DevController extends ModuleInstance {
 			if (isset($this->subcommandManager->subcommands[$cmd])) {
 				foreach ($this->subcommandManager->subcommands[$cmd] as $handler) {
 					if (isset($handler->permissions[$channel])) {
-						$handlers []= new CommandHandler($handler->file, $handler->permissions[$channel]->access_level);
+						$handlers []= new CommandHandler($handler->permissions[$channel]->access_level, ...explode(",", $handler->file));
 					}
 				}
 			}

--- a/src/Modules/DEV_MODULE/DevController.php
+++ b/src/Modules/DEV_MODULE/DevController.php
@@ -102,7 +102,7 @@ class DevController extends ModuleInstance {
 		// filter command handlers by access level
 		$accessManager = $this->accessManager;
 		$handlers = array_filter($handlers, function (CommandHandler $handler) use ($context, $accessManager): bool {
-			return $accessManager->checkAccess($context->char->name, $handler->admin);
+			return $accessManager->checkAccess($context->char->name, $handler->access_level);
 		});
 
 		// get calls for handlers
@@ -110,7 +110,7 @@ class DevController extends ModuleInstance {
 		$calls = array_reduce(
 			$handlers,
 			function (array $handlers, CommandHandler $handler): array {
-				return array_merge($handlers, explode(',', $handler->file));
+				return array_merge($handlers, $handler->files);
 			},
 			[]
 		);
@@ -239,7 +239,7 @@ class DevController extends ModuleInstance {
 		foreach ($this->commandManager->commands as $channelName => $channel) {
 			if (isset($channel[$cmd])) {
 				$blob .= "<header2>$channelName ($cmd)<end>\n";
-				$blob .= $channel[$cmd]->file . "\n\n";
+				$blob .= join(", ", $channel[$cmd]->files) . "\n\n";
 			}
 		}
 

--- a/src/Modules/DEV_MODULE/TestController.php
+++ b/src/Modules/DEV_MODULE/TestController.php
@@ -44,110 +44,10 @@ use Safe\Exceptions\FilesystemException;
 		description: "Test the bot commands",
 	),
 	NCA\DefineCommand(
-		command: "test orgjoin .+",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test orgkick .+",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test orgleave .+",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test towerattack .+",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test towerattackorgless .+",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test towervictory .+",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test towerabandon .+",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test orgattack .+",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test orgattackprep .+",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test os .+",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test event .+",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test cloaklower",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
-		command: "test cloakraise",
-		accessLevel: "admin",
-		description: "Test the bot commands",
-	),
-	NCA\DefineCommand(
 		command: "msginfo",
 		accessLevel: "all",
 		description: "Show number of characters in response and the time it took to process",
 	),
-	NCA\DefineCommand(
-		command: "test tradebotmsg",
-		accessLevel: "admin",
-		description: "Test a tradebot message",
-	),
-	NCA\DefineCommand(
-		command: "test discordpriv .+",
-		accessLevel: "admin",
-		description: "Test a discord channel message",
-	),
-	NCA\DefineCommand(
-		command: "test logon .+",
-		accessLevel: "admin",
-		description: "Test a logon event",
-	),
-	NCA\DefineCommand(
-		command: "test logoff .+",
-		accessLevel: "admin",
-		description: "Test a logoff event",
-	),
-	NCA\DefineCommand(
-		command: "test join .+",
-		accessLevel: "admin",
-		description: "Test a priv channel join event",
-	),
-	NCA\DefineCommand(
-		command: "test leave .+",
-		accessLevel: "admin",
-		description: "Test a priv channel leave event",
-	),
-	NCA\DefineCommand(
-		command: "test sleep .+",
-		accessLevel: "admin",
-		description: "Sleep for a give time in seconds",
-	)
 ]
 class TestController extends ModuleInstance {
 	#[NCA\Inject]
@@ -251,24 +151,36 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Pretend that &lt;char&gt; joins your org */
-	#[NCA\HandlesCommand("test orgjoin .+")]
-	public function testOrgJoinCommand(CmdContext $context, #[NCA\Str("orgjoin")] string $action, PCharacter $char): void {
+	#[NCA\HandlesCommand("test")]
+	public function testOrgJoinCommand(
+		CmdContext $context,
+		#[NCA\Str("orgjoin")] string $action,
+		PCharacter $char
+	): void {
 		$this->sendOrgMsg(
 			"{$context->char->name} invited {$char} to your organization."
 		);
 	}
 
 	/** Pretend that &lt;char&gt; was kicked from your org */
-	#[NCA\HandlesCommand("test orgkick .+")]
-	public function testOrgKickCommand(CmdContext $context, #[NCA\Str("orgkick")] string $action, PCharacter $char): void {
+	#[NCA\HandlesCommand("test")]
+	public function testOrgKickCommand(
+		CmdContext $context,
+		#[NCA\Str("orgkick")] string $action,
+		PCharacter $char
+	): void {
 		$this->sendOrgMsg(
 			"{$context->char->name} kicked {$char} from your organization."
 		);
 	}
 
 	/** Pretend that &lt;char&gt; left your org */
-	#[NCA\HandlesCommand("test orgleave .+")]
-	public function testOrgLeaveCommand(CmdContext $context, #[NCA\Str("orgleave")] string $action, PCharacter $char): void {
+	#[NCA\HandlesCommand("test")]
+	public function testOrgLeaveCommand(
+		CmdContext $context,
+		#[NCA\Str("orgleave")] string $action,
+		PCharacter $char
+	): void {
 		$this->sendOrgMsg("{$char} just left your organization.");
 	}
 
@@ -300,7 +212,7 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Run a fictional tower attack by another org */
-	#[NCA\HandlesCommand("test towerattack .+")]
+	#[NCA\HandlesCommand("test")]
 	public function testTowerAttackCommand(
 		CmdContext $context,
 		#[NCA\Str("towerattack")] string $action,
@@ -324,7 +236,7 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Run a fictional tower attack by an orgless attacker */
-	#[NCA\HandlesCommand("test towerattackorgless .+")]
+	#[NCA\HandlesCommand("test")]
 	public function testTowerAttackOrglessCommand(
 		CmdContext $context,
 		#[NCA\Str("towerattackorgless")] string $action,
@@ -345,7 +257,7 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Pretend an org /terminates a Control Tower */
-	#[NCA\HandlesCommand("test towerabandon .+")]
+	#[NCA\HandlesCommand("test")]
 	public function testTowerAbandonCommand(
 		CmdContext $context,
 		#[NCA\Str("towerabandon")] string $action,
@@ -365,7 +277,7 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Simulate your own Control Tower being attacked */
-	#[NCA\HandlesCommand("test orgattack .+")]
+	#[NCA\HandlesCommand("test")]
 	public function testOrgAttackCommand(
 		CmdContext $context,
 		#[NCA\Str("orgattack")] string $action,
@@ -380,7 +292,7 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Simulate your own Control Tower gets the defense shield disabled */
-	#[NCA\HandlesCommand("test orgattackprep .+")]
+	#[NCA\HandlesCommand("test")]
 	public function testOrgAttackPrepCommand(
 		CmdContext $context,
 		#[NCA\Str("orgattackprep")] string $action,
@@ -396,7 +308,7 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Pretend &lt;att org&gt; won the attack against &lt;def org&gt; */
-	#[NCA\HandlesCommand("test towervictory .+")]
+	#[NCA\HandlesCommand("test")]
 	public function testTowerVictoryCommand(
 		CmdContext $context,
 		#[NCA\Str("towervictory")] string $action,
@@ -419,7 +331,7 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Pretend &lt;launcher&gt; just launched an orbital strike */
-	#[NCA\HandlesCommand("test os .+")]
+	#[NCA\HandlesCommand("test")]
 	public function testOSCommand(
 		CmdContext $context,
 		#[NCA\Str("os")] string $action,
@@ -435,7 +347,7 @@ class TestController extends ModuleInstance {
 	 *
 	 * Note that the $eventObj will be null, so this typically only works for cron events
 	 */
-	#[NCA\HandlesCommand("test event .+")]
+	#[NCA\HandlesCommand("test")]
 	public function testEventCommand(
 		CmdContext $context,
 		#[NCA\Str("event")] string $action,
@@ -456,8 +368,11 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Pretend you just lowered your city cloak */
-	#[NCA\HandlesCommand("test cloaklower")]
-	public function testCloakLowerCommand(CmdContext $context, #[NCA\Str("cloaklower")] string $action): void {
+	#[NCA\HandlesCommand("test")]
+	public function testCloakLowerCommand(
+		CmdContext $context,
+		#[NCA\Str("cloaklower")] string $action
+	): void {
 		foreach ($this->chatBot->grp as $gid => $status) {
 			if (ord(substr((string)$gid, 0, 1)) === 3) {
 				break;
@@ -480,8 +395,11 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Pretend you just raised your city cloak */
-	#[NCA\HandlesCommand("test cloakraise")]
-	public function testCloakRaiseCommand(CmdContext $context, #[NCA\Str("cloakraise")] string $action): void {
+	#[NCA\HandlesCommand("test")]
+	public function testCloakRaiseCommand(
+		CmdContext $context,
+		#[NCA\Str("cloakraise")] string $action
+	): void {
 		foreach ($this->chatBot->grp as $gid => $status) {
 			if (ord(substr((string)$gid, 0, 1)) === 3) {
 				break;
@@ -515,8 +433,11 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Receive a dummy message from a tradebot */
-	#[NCA\HandlesCommand("test tradebotmsg")]
-	public function testTradebotMessageCommand(CmdContext $context, #[NCA\Str("tradebotmsg")] string $action): void {
+	#[NCA\HandlesCommand("test")]
+	public function testTradebotMessageCommand(
+		CmdContext $context,
+		#[NCA\Str("tradebotmsg")] string $action
+	): void {
 		$eventObj = new AOChatEvent();
 		$tradebot = $this->settingManager->getString('tradebot') ?? "Darknet";
 		$eventObj->sender = $tradebot;
@@ -564,7 +485,7 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Receive a discord message from &lt;nick&gt; */
-	#[NCA\HandlesCommand("test discordpriv .+")]
+	#[NCA\HandlesCommand("test")]
 	public function testDiscordMessageCommand(
 		CmdContext $context,
 		#[NCA\Str("discordpriv")] string $action,
@@ -621,8 +542,12 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Simulate &lt;char&gt; logging on */
-	#[NCA\HandlesCommand("test logon .+")]
-	public function testLogonCommand(CmdContext $context, #[NCA\Str("logon")] string $action, PCharacter $char): void {
+	#[NCA\HandlesCommand("test")]
+	public function testLogonCommand(
+		CmdContext $context,
+		#[NCA\Str("logon")] string $action,
+		PCharacter $char
+	): void {
 		$uid = $this->chatBot->get_uid($char());
 		if ($uid === false) {
 			$context->reply("The character <highlight>{$char}<end> does not exist.");
@@ -634,8 +559,12 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Simulate &lt;char&gt; logging off */
-	#[NCA\HandlesCommand("test logoff .+")]
-	public function testLogoffCommand(CmdContext $context, #[NCA\Str("logoff")] string $action, PCharacter $char): void {
+	#[NCA\HandlesCommand("test")]
+	public function testLogoffCommand(
+		CmdContext $context,
+		#[NCA\Str("logoff")] string $action,
+		PCharacter $char
+	): void {
 		$uid = $this->chatBot->get_uid($char());
 		if ($uid === false) {
 			$context->reply("The character <highlight>{$char}<end> does not exist.");
@@ -647,8 +576,12 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Simulate &lt;char&gt; joining the private channel */
-	#[NCA\HandlesCommand("test join .+")]
-	public function testJoinCommand(CmdContext $context, #[NCA\Str("join")] string $action, PCharacter $char): void {
+	#[NCA\HandlesCommand("test")]
+	public function testJoinCommand(
+		CmdContext $context,
+		#[NCA\Str("join")] string $action,
+		PCharacter $char
+	): void {
 		$uid = $this->chatBot->get_uid($char());
 		if ($uid === false) {
 			$context->reply("The character <highlight>{$char}<end> does not exist.");
@@ -661,8 +594,12 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Simulate &lt;char&gt; leaving the private channel */
-	#[NCA\HandlesCommand("test leave .+")]
-	public function testLeaveCommand(CmdContext $context, #[NCA\Str("leave")] string $action, PCharacter $char): void {
+	#[NCA\HandlesCommand("test")]
+	public function testLeaveCommand(
+		CmdContext $context,
+		#[NCA\Str("leave")] string $action,
+		PCharacter $char
+	): void {
 		$uid = $this->chatBot->get_uid($char());
 		if ($uid === false) {
 			$context->reply("The character <highlight>{$char}<end> does not exist.");
@@ -675,8 +612,12 @@ class TestController extends ModuleInstance {
 	}
 
 	/** Sleep for &lt;duration&gt; seconds. This can lead to lots of timeouts */
-	#[NCA\HandlesCommand("test sleep .+")]
-	public function testSleepCommand(CmdContext $context, #[NCA\Str("sleep")] string $action, int $duration): void {
+	#[NCA\HandlesCommand("test")]
+	public function testSleepCommand(
+		CmdContext $context,
+		#[NCA\Str("sleep")] string $action,
+		int $duration
+	): void {
 		\Safe\sleep($duration);
 	}
 
@@ -697,7 +638,10 @@ class TestController extends ModuleInstance {
 
 	/** Run absolutely all bot tests */
 	#[NCA\HandlesCommand("test")]
-	public function testAllCommand(CmdContext $context, #[NCA\Str("all")] string $action): void {
+	public function testAllCommand(
+		CmdContext $context,
+		#[NCA\Str("all")] string $action
+	): void {
 		$testContext = clone $context;
 		$testContext->sendto = new MockCommandReply("buddylist clear");
 		$this->buddylistController->buddylistClearCommand($testContext, "clear");

--- a/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/20210822104239_MigrateToRoutes.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/20210822104239_MigrateToRoutes.php
@@ -62,7 +62,6 @@ class MigrateToRoutes implements SchemaMigration {
 		$tagColor = $this->getColor($db, "discord_color_channel");
 		$textColor = $this->getColor($db, "discord_color_guild", "discord_color_priv");
 		$this->saveColor($db, Source::DISCORD_PRIV, $tagColor, $textColor);
-		$this->messageHub->loadTagColor();
 
 		$relayChannel = $this->getSetting($db, "discord_relay_channel");
 		$relayWhat = $this->getSetting($db, "discord_relay");

--- a/src/Modules/EVENTS_MODULE/EventsController.php
+++ b/src/Modules/EVENTS_MODULE/EventsController.php
@@ -30,29 +30,17 @@ use Nadybot\Core\{
 		command: "events",
 		accessLevel: "all",
 		description: "View/Join/Leave events",
+		alias: 'event',
 	),
 	NCA\DefineCommand(
-		command: "events add .+",
+		command: EventsController::CMD_EVENT_MANAGE,
 		accessLevel: "mod",
-		description: "Add an event",
+		description: "Add/change or delete an event",
 	),
-	NCA\DefineCommand(
-		command: "events (rem|del) .+",
-		accessLevel: "mod",
-		description: "Remove an event",
-	),
-	NCA\DefineCommand(
-		command: "events setdesc .+",
-		accessLevel: "mod",
-		description: "Change or set the description for an event",
-	),
-	NCA\DefineCommand(
-		command: "events setdate .+",
-		accessLevel: "mod",
-		description: "Change or set the date for an event",
-	)
 ]
 class EventsController extends ModuleInstance {
+	public const CMD_EVENT_MANAGE = "events add/change/delete";
+
 	#[NCA\Inject]
 	public DB $db;
 
@@ -103,7 +91,7 @@ class EventsController extends ModuleInstance {
 	 * An event ID is returned when you submit an event.
 	 * This is the ID you will use to change data regarding that event.
 	 */
-	#[NCA\HandlesCommand("events add .+")]
+	#[NCA\HandlesCommand(self::CMD_EVENT_MANAGE)]
 	public function eventsAddCommand(CmdContext $context, #[NCA\Str("add")] string $action, string $eventName): void {
 		$eventId = $this->db->table("events")
 			->insertGetId([
@@ -117,7 +105,7 @@ class EventsController extends ModuleInstance {
 	}
 
 	/** Delete an event */
-	#[NCA\HandlesCommand("events (rem|del) .+")]
+	#[NCA\HandlesCommand(self::CMD_EVENT_MANAGE)]
 	public function eventsRemoveCommand(CmdContext $context, PRemove $action, int $id): void {
 		$row = $this->getEvent($id);
 		if ($row === null) {
@@ -130,7 +118,7 @@ class EventsController extends ModuleInstance {
 	}
 
 	/** Change the description of an event */
-	#[NCA\HandlesCommand("events setdesc .+")]
+	#[NCA\HandlesCommand(self::CMD_EVENT_MANAGE)]
 	public function eventsSetDescCommand(CmdContext $context, #[NCA\Str("setdesc")] string $action, int $id, string $description): void {
 		$row = $this->getEvent($id);
 		if ($row === null) {
@@ -145,7 +133,7 @@ class EventsController extends ModuleInstance {
 	}
 
 	/** Change the date of an event */
-	#[NCA\HandlesCommand("events setdate .+")]
+	#[NCA\HandlesCommand(self::CMD_EVENT_MANAGE)]
 	public function eventsSetDateCommand(
 		CmdContext $context,
 		#[NCA\Str("setdate")] string $action,

--- a/src/Modules/GUIDE_MODULE/GuideController.php
+++ b/src/Modules/GUIDE_MODULE/GuideController.php
@@ -53,12 +53,6 @@ class GuideController extends ModuleInstance {
 		$this->commandAlias->register($this->moduleName, "guides gos", "gos");
 		$this->commandAlias->register($this->moduleName, "guides gos", "faction");
 		$this->commandAlias->register($this->moduleName, "guides gos", "guardian");
-		$row = $this->commandAlias->get("adminhelp");
-		if (isset($row) && $row->status === 1) {
-			$row->status = 0;
-			$this->commandAlias->update($row);
-			$this->commandAlias->deactivate("adminhelp");
-		}
 		$this->commandAlias->register($this->moduleName, "guides light", "light");
 
 		$this->path = __DIR__ . "/guides/";

--- a/src/Modules/HELPBOT_MODULE/ArbiterController.php
+++ b/src/Modules/HELPBOT_MODULE/ArbiterController.php
@@ -29,6 +29,11 @@ use Safe\Exceptions\DatetimeException;
 		accessLevel: "all",
 		description: "Show current arbiter mission",
 		alias: "icc",
+	),
+	NCA\DefineCommand(
+		command: "arbiter change",
+		accessLevel: "member",
+		description: "Change current arbiter mission",
 	)
 ]
 class ArbiterController extends ModuleInstance {
@@ -129,7 +134,7 @@ class ArbiterController extends ModuleInstance {
 	 * <tab>'<symbol>arbiter set bs ends'
 	 * This will set that today is the last day of the PvP week.
 	 */
-	#[NCA\HandlesCommand("arbiter")]
+	#[NCA\HandlesCommand("arbiter change")]
 	public function arbiterSetCommand(
 		CmdContext $context,
 		#[NCA\Str("set")] string $action,

--- a/src/Modules/ITEMS_MODULE/WhatBuffsController.php
+++ b/src/Modules/ITEMS_MODULE/WhatBuffsController.php
@@ -591,14 +591,19 @@ class WhatBuffsController extends ModuleInstance {
 			return $results->toArray();
 		}
 
-		$skillsQuery = $this->db->table('skills')->select(['id', 'name', 'unit'])->distinct();
-		$aliasQuery = $this->db->table('skill_alias')->select(['id', 'name', 'unit'])->distinct();
+		$skillsQuery = $this->db->table('skills')
+			->select(['id', 'name', 'unit'])
+			->distinct();
+		$aliasQuery = $this->db->table('skill_alias', 'a')
+			->join('skills AS s', 'a.id', 's.id')
+			->select(['s.id', 's.name', 's.unit'])
+			->distinct();
 
 		$tmp = explode(" ", $skill);
 		$this->db->addWhereFromParams($skillsQuery, $tmp, 'name');
-		$this->db->addWhereFromParams($aliasQuery, $tmp, 'name');
+		$this->db->addWhereFromParams($aliasQuery, $tmp, 'a.name');
 
-		return $this->db
+		$skills = $this->db
 			->fromSub(
 				$skillsQuery->union($aliasQuery),
 				"foo"
@@ -608,6 +613,7 @@ class WhatBuffsController extends ModuleInstance {
 			->select(["id", "name", "unit"])
 			->asObj(Skill::class)
 			->toArray();
+		return $skills;
 	}
 
 	public function showItemLink(AODBEntry $item, int $ql): string {

--- a/src/Modules/LOOT_MODULE/LootController.php
+++ b/src/Modules/LOOT_MODULE/LootController.php
@@ -39,7 +39,7 @@ use Nadybot\Modules\{
 		description: "Show the loot list",
 	),
 	NCA\DefineCommand(
-		command: "loot .+",
+		command: LootController::CMD_LOOT_MANAGE,
 		accessLevel: "rl",
 		description: "Modify the loot list",
 	),
@@ -61,15 +61,17 @@ use Nadybot\Modules\{
 	NCA\DefineCommand(
 		command: "add",
 		accessLevel: "all",
-		description: "Add a player to a roll slot",
+		description: "Add yourself to a roll slot",
 	),
 	NCA\DefineCommand(
 		command: "rem",
 		accessLevel: "all",
-		description: "Remove a player from a roll slot",
+		description: "Remove yoruself from a roll slot",
 	)
 ]
 class LootController extends ModuleInstance {
+	public const CMD_LOOT_MANAGE = "loot add/change/delete";
+
 	#[NCA\Inject]
 	public DB $db;
 
@@ -170,7 +172,7 @@ class LootController extends ModuleInstance {
 	/**
 	 * Clear the current loot list
 	 */
-	#[NCA\HandlesCommand("loot .+")]
+	#[NCA\HandlesCommand(self::CMD_LOOT_MANAGE)]
 	#[NCA\Help\Group("loot")]
 	public function lootClearCommand(CmdContext $context, #[NCA\Str("clear")] string $action): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {
@@ -211,7 +213,7 @@ class LootController extends ModuleInstance {
 	/**
 	 * Add an item from a loot list to the loot roll
 	 */
-	#[NCA\HandlesCommand("loot .+")]
+	#[NCA\HandlesCommand(self::CMD_LOOT_MANAGE)]
 	#[NCA\Help\Group("loot")]
 	public function lootAddByIdCommand(CmdContext $context, #[NCA\Str("add")] string $action, int $id): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {
@@ -261,7 +263,7 @@ class LootController extends ModuleInstance {
 	/**
 	 * Auction off an item from a loot list
 	 */
-	#[NCA\HandlesCommand("loot .+")]
+	#[NCA\HandlesCommand(self::CMD_LOOT_MANAGE)]
 	#[NCA\Help\Group("loot")]
 	public function lootAuctionByIdCommand(CmdContext $context, #[NCA\Str("auction")] string $action, int $id): void {
 		$loot = $this->getLootEntryID($id);
@@ -284,7 +286,7 @@ class LootController extends ModuleInstance {
 	/**
 	 * Add an item to the loot roll by name or by pasting it
 	 */
-	#[NCA\HandlesCommand("loot .+")]
+	#[NCA\HandlesCommand(self::CMD_LOOT_MANAGE)]
 	#[NCA\Help\Group("loot")]
 	public function lootAddCommand(CmdContext $context, #[NCA\Str("add")] string $action, string $item): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {
@@ -298,7 +300,7 @@ class LootController extends ModuleInstance {
 	/**
 	 * Add multiple items to the loot roll
 	 */
-	#[NCA\HandlesCommand("loot .+")]
+	#[NCA\HandlesCommand(self::CMD_LOOT_MANAGE)]
 	#[NCA\Help\Group("loot")]
 	#[NCA\Help\Example("<symbol>loot addmulti 3 Lockpick")]
 	public function multilootCommand(
@@ -392,7 +394,7 @@ class LootController extends ModuleInstance {
 	/**
 	 * Remove a single item from the loot list
 	 */
-	#[NCA\HandlesCommand("loot .+")]
+	#[NCA\HandlesCommand(self::CMD_LOOT_MANAGE)]
 	#[NCA\Help\Group("loot")]
 	public function lootRemCommand(CmdContext $context, PRemove $action, int $key): void {
 		if (!$this->chatLeaderController->checkLeaderAccess($context->char->name)) {

--- a/src/Modules/NEWS_MODULE/NewsController.php
+++ b/src/Modules/NEWS_MODULE/NewsController.php
@@ -41,12 +41,7 @@ use Nadybot\Modules\WEBSERVER_MODULE\{
 		description: "Shows news",
 	),
 	NCA\DefineCommand(
-		command: "news confirm .+",
-		accessLevel: "member",
-		description: "Mark news as read",
-	),
-	NCA\DefineCommand(
-		command: "news .+",
+		command: NewsController::CMD_NEWS_MANAGE,
 		accessLevel: "mod",
 		description: "Adds, removes, pins or unpins a news entry",
 	),
@@ -60,6 +55,8 @@ use Nadybot\Modules\WEBSERVER_MODULE\{
 	)
 ]
 class NewsController extends ModuleInstance {
+	public const CMD_NEWS_MANAGE = "news add/change/delete";
+
 	#[NCA\Inject]
 	public DB $db;
 
@@ -269,8 +266,12 @@ class NewsController extends ModuleInstance {
 	/**
 	 * Confirm having read a news entry
 	 */
-	#[NCA\HandlesCommand("news confirm .+")]
-	public function newsconfirmCommand(CmdContext $context, #[NCA\Str("confirm")] string $action, int $id): void {
+	#[NCA\HandlesCommand("news")]
+	public function newsconfirmCommand(
+		CmdContext $context,
+		#[NCA\Str("confirm")] string $action,
+		int $id
+	): void {
 		$row = $this->getNewsItem($id);
 		if ($row === null) {
 			$msg = "No news entry found with the ID <highlight>{$id}<end>.";
@@ -303,8 +304,12 @@ class NewsController extends ModuleInstance {
 	/**
 	 * Add a news entry
 	 */
-	#[NCA\HandlesCommand("news .+")]
-	public function newsAddCommand(CmdContext $context, #[NCA\Str("add")] string $action, string $news): void {
+	#[NCA\HandlesCommand(self::CMD_NEWS_MANAGE)]
+	public function newsAddCommand(
+		CmdContext $context,
+		#[NCA\Str("add")] string $action,
+		string $news
+	): void {
 		$entry = [
 			"time" => time(),
 			"name" => $context->char->name,
@@ -331,8 +336,12 @@ class NewsController extends ModuleInstance {
 	/**
 	 * Remove a news entry by ID
 	 */
-	#[NCA\HandlesCommand("news .+")]
-	public function newsRemCommand(CmdContext $context, PRemove $action, int $id): void {
+	#[NCA\HandlesCommand(self::CMD_NEWS_MANAGE)]
+	public function newsRemCommand(
+		CmdContext $context,
+		PRemove $action,
+		int $id
+	): void {
 		$row = $this->getNewsItem($id);
 		if ($row === null) {
 			$msg = "No news entry found with the ID <highlight>{$id}<end>.";
@@ -353,8 +362,12 @@ class NewsController extends ModuleInstance {
 	/**
 	 * Pin a news entry to the top
 	 */
-	#[NCA\HandlesCommand("news .+")]
-	public function newsPinCommand(CmdContext $context, #[NCA\Str("pin")] string $action, int $id): void {
+	#[NCA\HandlesCommand(self::CMD_NEWS_MANAGE)]
+	public function newsPinCommand(
+		CmdContext $context,
+		#[NCA\Str("pin")] string $action,
+		int $id
+	): void {
 		$row = $this->getNewsItem($id);
 
 		if (!isset($row)) {
@@ -381,8 +394,12 @@ class NewsController extends ModuleInstance {
 	/**
 	 * Unpin a news entry from the top
 	 */
-	#[NCA\HandlesCommand("news .+")]
-	public function newsUnpinCommand(CmdContext $context, #[NCA\Str("unpin")] string $action, int $id): void {
+	#[NCA\HandlesCommand(self::CMD_NEWS_MANAGE)]
+	public function newsUnpinCommand(
+		CmdContext $context,
+		#[NCA\Str("unpin")] string $action,
+		int $id
+	): void {
 		$row = $this->getNewsItem($id);
 
 		if (!isset($row)) {

--- a/src/Modules/PRIVATE_CHANNEL_MODULE/Migrations/20210812173658_MoveSettingsToHopColors.php
+++ b/src/Modules/PRIVATE_CHANNEL_MODULE/Migrations/20210812173658_MoveSettingsToHopColors.php
@@ -50,6 +50,5 @@ class MoveSettingsToHopColors implements SchemaMigration {
 			$hop->hop = Source::ORG . "({$this->config->orgName})";
 			$hop->id = $db->insert(MessageHub::DB_TABLE_COLORS, $hop);
 		}
-		$this->messageHub->loadTagColor();
 	}
 }

--- a/src/Modules/RAFFLE_MODULE/RaffleController.php
+++ b/src/Modules/RAFFLE_MODULE/RaffleController.php
@@ -34,7 +34,7 @@ use Nadybot\Modules\RAID_MODULE\RaidController;
 		description: "Join or leave raffles",
 	),
 	NCA\DefineCommand(
-		command: "raffleadmin",
+		command: RaffleController::CMD_RAFFLE_MANAGE,
 		accessLevel: "all",
 		description: "Raffle off items to players",
 	),
@@ -47,6 +47,8 @@ use Nadybot\Modules\RAID_MODULE\RaidController;
 class RaffleController extends ModuleInstance {
 	public const DB_TABLE = "raffle_bonus_<myname>";
 	public const NO_RAFFLE_ERROR = "There is no active raffle.";
+
+	public const CMD_RAFFLE_MANAGE = "raffle manage";
 
 	#[NCA\Inject]
 	public SettingManager $settingManager;
@@ -167,11 +169,6 @@ class RaffleController extends ModuleInstance {
 			type: "rank",
 			value: 'mod'
 		);
-		$this->commandAlias->register($this->moduleName, "raffleadmin start", "raffle start");
-		$this->commandAlias->register($this->moduleName, "raffleadmin end", "raffle end");
-		$this->commandAlias->register($this->moduleName, "raffleadmin cancel", "raffle cancel");
-		$this->commandAlias->register($this->moduleName, "raffleadmin timer", "raffle timer");
-		$this->commandAlias->register($this->moduleName, "raffleadmin announce", "raffle announce");
 	}
 
 	protected function fancyFrame(string $text): string {
@@ -209,8 +206,7 @@ class RaffleController extends ModuleInstance {
 	 * Use 0x 'item/group' to raffle an unlimited number of an item or group
 	 * Use &lt;duration&gt; 'items/groups' to start with a custom timer
 	 */
-	#[NCA\HandlesCommand("raffleadmin")]
-	#[NCA\Help\Group("raffle")]
+	#[NCA\HandlesCommand(self::CMD_RAFFLE_MANAGE)]
 	#[NCA\Help\Example("<symbol>raffle start Alpha Box")]
 	#[NCA\Help\Example("<symbol>raffle start Alpha Box, Beta Box")]
 	#[NCA\Help\Example("<symbol>raffle start 3x Alpha Box, 3x Beta Box")]
@@ -322,11 +318,10 @@ class RaffleController extends ModuleInstance {
 	}
 
 	/** Cancel the running raffle immediately, no one wins */
-	#[NCA\HandlesCommand("raffleadmin")]
-	#[NCA\Help\Group("raffle")]
+	#[NCA\HandlesCommand(self::CMD_RAFFLE_MANAGE)]
 	public function raffleCancelCommand(
 		CmdContext $context,
-		#[NCA\Str("cancel")] string $action
+		#[NCA\Str("cancel", "stop")] string $action
 	): void {
 		if (!isset($this->raffle)) {
 			$context->reply(static::NO_RAFFLE_ERROR);
@@ -350,9 +345,11 @@ class RaffleController extends ModuleInstance {
 	}
 
 	/** End the raffle immediately and post the results */
-	#[NCA\HandlesCommand("raffleadmin")]
-	#[NCA\Help\Group("raffle")]
-	public function raffleEndCommand(CmdContext $context, #[NCA\Str("end")] string $action): void {
+	#[NCA\HandlesCommand(self::CMD_RAFFLE_MANAGE)]
+	public function raffleEndCommand(
+		CmdContext $context,
+		#[NCA\Str("end")] string $action
+	): void {
 		if (!isset($this->raffle)) {
 			$context->reply(static::NO_RAFFLE_ERROR);
 			return;
@@ -372,9 +369,12 @@ class RaffleController extends ModuleInstance {
 	 *
 	 * If the timer was unset before, the bot will immediately start it now
 	 */
-	#[NCA\HandlesCommand("raffleadmin")]
-	#[NCA\Help\Group("raffle")]
-	public function raffleTimerCommand(CmdContext $context, #[NCA\Str("timer")] string $action, PDuration $duration): void {
+	#[NCA\HandlesCommand(self::CMD_RAFFLE_MANAGE)]
+	public function raffleTimerCommand(
+		CmdContext $context,
+		#[NCA\Str("timer")] string $action,
+		PDuration $duration
+	): void {
 		if (!isset($this->raffle)) {
 			$context->reply(static::NO_RAFFLE_ERROR);
 			return;
@@ -400,8 +400,7 @@ class RaffleController extends ModuleInstance {
 	}
 
 	/** Announce the raffle, optionally with an extra message */
-	#[NCA\HandlesCommand("raffleadmin")]
-	#[NCA\Help\Group("raffle")]
+	#[NCA\HandlesCommand(self::CMD_RAFFLE_MANAGE)]
 	public function raffleAnnounceCommand(
 		CmdContext $context,
 		#[NCA\Str("announce")] string $action,
@@ -425,7 +424,6 @@ class RaffleController extends ModuleInstance {
 	 * If more than 1 item is raffled, a slot must be given
 	 */
 	#[NCA\HandlesCommand("raffle")]
-	#[NCA\Help\Group("raffle")]
 	public function raffleJoinCommand(
 		CmdContext $context,
 		#[NCA\Str("join", "enter")] string $action,
@@ -491,7 +489,6 @@ class RaffleController extends ModuleInstance {
 
 	/** Leave the raffle for all or just a single slot */
 	#[NCA\HandlesCommand("raffle")]
-	#[NCA\Help\Group("raffle")]
 	public function raffleLeaveCommand(
 		CmdContext $context,
 		#[NCA\Str("leave")] string $action,

--- a/src/Modules/RAID_MODULE/AuctionController.php
+++ b/src/Modules/RAID_MODULE/AuctionController.php
@@ -36,12 +36,12 @@ use Nadybot\Modules\RAFFLE_MODULE\RaffleItem;
 		description: "Bid points for an auctioned item",
 	),
 	NCA\DefineCommand(
-		command: "auction",
+		command: AuctionController::CMD_BID_AUCTIONS,
 		accessLevel: "raid_leader_1",
 		description: "Manage auctions",
 	),
 	NCA\DefineCommand(
-		command: "auction reimburse .+",
+		command: AuctionController::CMD_BID_REIMBURSE,
 		accessLevel: "raid_leader_1",
 		description: "Give back points for an auction",
 	),
@@ -51,6 +51,8 @@ use Nadybot\Modules\RAFFLE_MODULE\RaffleItem;
 	NCA\ProvidesEvent("auction(bid)")
 ]
 class AuctionController extends ModuleInstance {
+	public const CMD_BID_AUCTIONS = "bid auctions";
+	public const CMD_BID_REIMBURSE = "bid reimburse";
 	public const DB_TABLE = "auction_<myname>";
 	public const ERR_NO_AUCTION = "There's currently nothing being auctioned.";
 
@@ -200,16 +202,16 @@ class AuctionController extends ModuleInstance {
 			intoptions: '1;2;3;4;5;6'
 		);
 		$this->commandAlias->register($this->moduleName, "bid history", "bh");
-		$this->commandAlias->register($this->moduleName, "auction start", "bid start");
-		$this->commandAlias->register($this->moduleName, "auction end", "bid end");
-		$this->commandAlias->register($this->moduleName, "auction cancel", "bid cancel");
-		$this->commandAlias->register($this->moduleName, "auction reimburse", "bid reimburse");
-		$this->commandAlias->register($this->moduleName, "auction reimburse", "bid payback");
-		$this->commandAlias->register($this->moduleName, "auction reimburse", "bid refund");
+		// $this->commandAlias->register($this->moduleName, "auction start", "bid start");
+		// $this->commandAlias->register($this->moduleName, "auction end", "bid end");
+		// $this->commandAlias->register($this->moduleName, "auction cancel", "bid cancel");
+		// $this->commandAlias->register($this->moduleName, "auction reimburse", "bid reimburse");
+		// $this->commandAlias->register($this->moduleName, "auction reimburse", "bid payback");
+		// $this->commandAlias->register($this->moduleName, "auction reimburse", "bid refund");
 	}
 
 	/** Auction an item */
-	#[NCA\HandlesCommand("auction")]
+	#[NCA\HandlesCommand(self::CMD_BID_AUCTIONS)]
 	#[NCA\Help\Group("auction")]
 	public function bidStartCommand(
 		CmdContext $context,
@@ -233,7 +235,7 @@ class AuctionController extends ModuleInstance {
 	}
 
 	/** Cancel the running auction */
-	#[NCA\HandlesCommand("auction")]
+	#[NCA\HandlesCommand(self::CMD_BID_AUCTIONS)]
 	#[NCA\Help\Group("auction")]
 	public function bidCancelCommand(
 		CmdContext $context,
@@ -255,7 +257,7 @@ class AuctionController extends ModuleInstance {
 	}
 
 	/** End the running auction prematurely */
-	#[NCA\HandlesCommand("auction")]
+	#[NCA\HandlesCommand(self::CMD_BID_AUCTIONS)]
 	#[NCA\Help\Group("auction")]
 	public function bidEndCommand(
 		CmdContext $context,
@@ -280,7 +282,7 @@ class AuctionController extends ModuleInstance {
 	 * If you want custom refunds or refunds further back than the last
 	 * auction, take a look at the '<symbol>points add' and '<symbol>points rem' commands.
 	 */
-	#[NCA\HandlesCommand("auction reimburse .+")]
+	#[NCA\HandlesCommand(self::CMD_BID_REIMBURSE)]
 	#[NCA\Help\Group("auction")]
 	public function bidReimburseCommand(
 		CmdContext $context,

--- a/src/Modules/RAID_MODULE/AuctionController.php
+++ b/src/Modules/RAID_MODULE/AuctionController.php
@@ -36,7 +36,7 @@ use Nadybot\Modules\RAFFLE_MODULE\RaffleItem;
 		description: "Bid points for an auctioned item",
 	),
 	NCA\DefineCommand(
-		command: AuctionController::CMD_BID_AUCTIONS,
+		command: AuctionController::CMD_BID_AUCTION,
 		accessLevel: "raid_leader_1",
 		description: "Manage auctions",
 	),
@@ -51,7 +51,7 @@ use Nadybot\Modules\RAFFLE_MODULE\RaffleItem;
 	NCA\ProvidesEvent("auction(bid)")
 ]
 class AuctionController extends ModuleInstance {
-	public const CMD_BID_AUCTIONS = "bid auctions";
+	public const CMD_BID_AUCTION = "bid auction";
 	public const CMD_BID_REIMBURSE = "bid reimburse";
 	public const DB_TABLE = "auction_<myname>";
 	public const ERR_NO_AUCTION = "There's currently nothing being auctioned.";
@@ -211,8 +211,7 @@ class AuctionController extends ModuleInstance {
 	}
 
 	/** Auction an item */
-	#[NCA\HandlesCommand(self::CMD_BID_AUCTIONS)]
-	#[NCA\Help\Group("auction")]
+	#[NCA\HandlesCommand(self::CMD_BID_AUCTION)]
 	public function bidStartCommand(
 		CmdContext $context,
 		#[NCA\Str("start")] string $action,
@@ -235,7 +234,7 @@ class AuctionController extends ModuleInstance {
 	}
 
 	/** Cancel the running auction */
-	#[NCA\HandlesCommand(self::CMD_BID_AUCTIONS)]
+	#[NCA\HandlesCommand(self::CMD_BID_AUCTION)]
 	#[NCA\Help\Group("auction")]
 	public function bidCancelCommand(
 		CmdContext $context,
@@ -257,8 +256,7 @@ class AuctionController extends ModuleInstance {
 	}
 
 	/** End the running auction prematurely */
-	#[NCA\HandlesCommand(self::CMD_BID_AUCTIONS)]
-	#[NCA\Help\Group("auction")]
+	#[NCA\HandlesCommand(self::CMD_BID_AUCTION)]
 	public function bidEndCommand(
 		CmdContext $context,
 		#[NCA\Str("end")] string $action
@@ -283,7 +281,6 @@ class AuctionController extends ModuleInstance {
 	 * auction, take a look at the '<symbol>points add' and '<symbol>points rem' commands.
 	 */
 	#[NCA\HandlesCommand(self::CMD_BID_REIMBURSE)]
-	#[NCA\Help\Group("auction")]
 	public function bidReimburseCommand(
 		CmdContext $context,
 		#[NCA\Str("reimburse", "payback", "refund")] string $action,
@@ -398,7 +395,6 @@ class AuctionController extends ModuleInstance {
 	 * but not to lower it.
 	 */
 	#[NCA\HandlesCommand("bid")]
-	#[NCA\Help\Group("auction")]
 	public function bidCommand(CmdContext $context, int $bid): void {
 		if (!$context->isDM()) {
 			$context->reply("<red>The <symbol>bid command only works in tells<end>.");
@@ -440,7 +436,6 @@ class AuctionController extends ModuleInstance {
 
 	/** See a list of the last 40 auctions */
 	#[NCA\HandlesCommand("bid")]
-	#[NCA\Help\Group("auction")]
 	public function bidHistoryCommand(
 		CmdContext $context,
 		#[NCA\Str("history")] string $action
@@ -465,7 +460,6 @@ class AuctionController extends ModuleInstance {
 
 	/** Search the bid history for an item */
 	#[NCA\HandlesCommand("bid")]
-	#[NCA\Help\Group("auction")]
 	public function bidHistorySearchCommand(
 		CmdContext $context,
 		#[NCA\Str("history")] string $action,

--- a/src/Modules/RAID_MODULE/RaidBlockController.php
+++ b/src/Modules/RAID_MODULE/RaidBlockController.php
@@ -29,7 +29,7 @@ use Nadybot\Core\{
 		description: "Check your raid blocks",
 	),
 	NCA\DefineCommand(
-		command: "raidblock .+",
+		command: RaidBlockController::CMD_RAIDBLOCK_EDIT,
 		accessLevel: "raid_leader_1",
 		description: "Temporarily block raiders",
 	)
@@ -39,6 +39,9 @@ class RaidBlockController extends ModuleInstance {
 	public const POINTS_GAIN = "points";
 	public const JOIN_RAIDS = "join";
 	public const AUCTION_BIDS = "bid";
+
+	public const CMD_RAIDBLOCK_EDIT = "raidblock add/remove";
+
 	public int $lastExpiration = 0;
 
 	/** @var array<string,array<string,RaidBlock>> */
@@ -126,7 +129,7 @@ class RaidBlockController extends ModuleInstance {
 	 * If &lt;duration&gt; is given, then the block is only temporary.
 	 * Permanent blocks can only be lifted manually.
 	 */
-	#[NCA\HandlesCommand("raidblock .+")]
+	#[NCA\HandlesCommand(self::CMD_RAIDBLOCK_EDIT)]
 	public function raidBlockAddCommand(
 		CmdContext $context,
 		#[NCA\StrChoice("points", "join", "bid")] string $blockFrom,
@@ -190,7 +193,7 @@ class RaidBlockController extends ModuleInstance {
 	}
 
 	/** Check another character's blocks */
-	#[NCA\HandlesCommand("raidblock .+")]
+	#[NCA\HandlesCommand(self::CMD_RAIDBLOCK_EDIT)]
 	public function raidBlockShowCommand(CmdContext $context, PCharacter $char): void {
 		$player = $char();
 		$player = $this->altsController->getMainOf($player);
@@ -215,7 +218,7 @@ class RaidBlockController extends ModuleInstance {
 	}
 
 	/** Lift all or just one raid block from a character */
-	#[NCA\HandlesCommand("raidblock .+")]
+	#[NCA\HandlesCommand(self::CMD_RAIDBLOCK_EDIT)]
 	public function raidBlockLiftCommand(
 		CmdContext $context,
 		PRemove $action,

--- a/src/Modules/RAID_MODULE/RaidController.php
+++ b/src/Modules/RAID_MODULE/RaidController.php
@@ -317,17 +317,12 @@ class RaidController extends ModuleInstance {
 			$context->reply(static::ERR_NO_RAID);
 			return;
 		}
-		$handler = isset($context->permissionSet)
-			? $this->commandManager->getActiveCommandHandler("raid", $context->permissionSet, "raid start test")
-			: null;
-		if (isset($handler)) {
-			$canAdminRaid = $this->accessManager->checkAccess($context->char->name, $handler->access_level);
-			if ($canAdminRaid) {
-				$this->chatBot->sendTell(
-					$this->text->makeBlob("Raid Control", $this->getControlInterface()),
-					$context->char->name
-				);
-			}
+		$canAdminRaid = $this->commandManager->couldRunCommand($context, "raid start test");
+		if ($canAdminRaid) {
+			$this->chatBot->sendTell(
+				$this->text->makeBlob("Raid Control", $this->getControlInterface()),
+				$context->char->name
+			);
 		}
 		$msg = ((array)$this->text->makeBlob("click to join", $this->getRaidJoinLink(), "Raid information"))[0];
 		$announceMsg = $this->raid->getAnnounceMessage($msg);

--- a/src/Modules/RAID_MODULE/RaidController.php
+++ b/src/Modules/RAID_MODULE/RaidController.php
@@ -46,12 +46,12 @@ use Nadybot\Modules\{
 		description: "Check if the raid is running",
 	),
 	NCA\DefineCommand(
-		command: "raid .+",
+		command: RaidController::CMD_RAID_MANAGE,
 		accessLevel: "raid_leader_1",
 		description: "Everything to run a points raid",
 	),
 	NCA\DefineCommand(
-		command: "raid spp .+",
+		command: RaidController::CMD_RAID_TICKER,
 		accessLevel: "raid_leader_2",
 		description: "Change the raid points ticker",
 	),
@@ -64,6 +64,8 @@ use Nadybot\Modules\{
 class RaidController extends ModuleInstance {
 	public const DB_TABLE = "raid_<myname>";
 	public const DB_TABLE_LOG = "raid_log_<myname>";
+	public const CMD_RAID_MANAGE = 'raid manage';
+	public const CMD_RAID_TICKER = 'raid change ticker';
 
 	#[NCA\Inject]
 	public Nadybot $chatBot;
@@ -363,7 +365,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Start a raid with a given description
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidStartCommand(
 		CmdContext $context,
 		#[NCA\Str("start", "run", "create")] string $action,
@@ -395,7 +397,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Stop the currently running raid
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidStopCommand(
 		CmdContext $context,
 		#[NCA\Str("stop", "end")] string $action
@@ -410,7 +412,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Change the raid's description
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidChangeDescCommand(
 		CmdContext $context,
 		#[NCA\Regexp("description|descr?", example: "description")] string $action,
@@ -432,7 +434,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Change the interval for getting a participation raid point, 'off' to turn it off
 	 */
-	#[NCA\HandlesCommand("raid spp .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_TICKER)]
 	public function raidChangeSppCommand(
 		CmdContext $context,
 		#[NCA\Str("spp")] string $action,
@@ -464,7 +466,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Change the raid announcement interval. 'off' to turn it off completely
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidChangeAnnounceCommand(
 		CmdContext $context,
 		#[NCA\Str("announce", "announcement")] string $action,
@@ -497,7 +499,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Lock the raid, preventing raiders from joining with <symbol>raid join
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidLockCommand(
 		CmdContext $context,
 		#[NCA\Str("lock")] string $action
@@ -526,7 +528,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Unlock the raid, allowing raiders to join with <symbol>raid join
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidUnlockCommand(
 		CmdContext $context,
 		#[NCA\Str("unlock")] string $action
@@ -551,7 +553,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Get a list of all raiders, with a link to check if everyone is in the vicinity
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidCheckCommand(
 		CmdContext $context,
 		#[NCA\Str("check")] string $action
@@ -566,7 +568,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Get a list of all raiders
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidListCommand(
 		CmdContext $context,
 		#[NCA\Str("list")] string $action
@@ -582,7 +584,7 @@ class RaidController extends ModuleInstance {
 	 * Kick everyone in the private channel who's not in the raid.
 	 * If the additional 'all' is given, it will also kick raiders' alts not in the raid.
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidNotinKickCommand(
 		CmdContext $context,
 		#[NCA\Str("notinkick")] string $action,
@@ -607,7 +609,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Send everyone in the private channel who's not in the raid a reminder to join
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidNotinCommand(CmdContext $context, #[NCA\Str("notin")] string $action): void {
 		if (!isset($this->raid)) {
 			$context->reply(static::ERR_NO_RAID);
@@ -652,7 +654,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Show a list of old raids with details about them
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidHistoryCommand(
 		CmdContext $context,
 		#[NCA\Str("history")] string $action
@@ -720,7 +722,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Get detailed information about an old raid
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidHistoryDetailCommand(
 		CmdContext $context,
 		#[NCA\Str("history")] string $action,
@@ -779,7 +781,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Get detailed information about raid member of an old raid
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidHistoryDetailRaiderCommand(
 		CmdContext $context,
 		#[NCA\Str("history")] string $action,
@@ -856,7 +858,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Check if anyone in the current raid is dual-logged
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidDualCommand(CmdContext $context, #[NCA\Str("dual")] string $action): void {
 		if (!isset($this->raid)) {
 			$context->reply(static::ERR_NO_RAID);
@@ -1065,7 +1067,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Show the notes about all people in the current raid
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidCommentsCommand(
 		CmdContext $context,
 		#[NCA\Regexp("notes?|comments?", example: "notes")] string $action
@@ -1095,7 +1097,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Add a new raid note about a character
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidCommentAddCommand(
 		CmdContext $context,
 		#[NCA\Regexp("notes?|comments?", example: "note")] string $action,
@@ -1115,7 +1117,7 @@ class RaidController extends ModuleInstance {
 	/**
 	 * Get all raid notes about a character
 	 */
-	#[NCA\HandlesCommand("raid .+")]
+	#[NCA\HandlesCommand(self::CMD_RAID_MANAGE)]
 	public function raidCommentSearchCommand(
 		CmdContext $context,
 		#[NCA\Regexp("notes?|comments?", example: "notes")] string $action,

--- a/src/Modules/RAID_MODULE/RaidController.php
+++ b/src/Modules/RAID_MODULE/RaidController.php
@@ -437,7 +437,7 @@ class RaidController extends ModuleInstance {
 	#[NCA\HandlesCommand(self::CMD_RAID_TICKER)]
 	public function raidChangeSppCommand(
 		CmdContext $context,
-		#[NCA\Str("spp")] string $action,
+		#[NCA\Str("ticker", "spp")] string $action,
 		#[NCA\PDuration] #[NCA\Str("off")] string $interval
 	): void {
 		if (!isset($this->raid)) {

--- a/src/Modules/RAID_MODULE/RaidController.php
+++ b/src/Modules/RAID_MODULE/RaidController.php
@@ -321,7 +321,7 @@ class RaidController extends ModuleInstance {
 			? $this->commandManager->getActiveCommandHandler("raid", $context->permissionSet, "raid start test")
 			: null;
 		if (isset($handler)) {
-			$canAdminRaid = $this->accessManager->checkAccess($context->char->name, $handler->admin);
+			$canAdminRaid = $this->accessManager->checkAccess($context->char->name, $handler->access_level);
 			if ($canAdminRaid) {
 				$this->chatBot->sendTell(
 					$this->text->makeBlob("Raid Control", $this->getControlInterface()),

--- a/src/Modules/RAID_MODULE/RaidMemberController.php
+++ b/src/Modules/RAID_MODULE/RaidMemberController.php
@@ -25,12 +25,12 @@ use Nadybot\Modules\ONLINE_MODULE\OnlineController;
 	NCA\Instance,
 	NCA\HasMigrations("Migrations/Member"),
 	NCA\DefineCommand(
-		command: "raid (join|leave)",
+		command: RaidMemberController::CMD_RAID_JOIN_LEAVE,
 		accessLevel: "member",
 		description: "Join or leave the raid",
 	),
 	NCA\DefineCommand(
-		command: "raidmember",
+		command: RaidMemberController::CMD_RAID_KICK_ADD,
 		accessLevel: "raid_leader_1",
 		description: "Add or remove someone from/to the raid",
 	),
@@ -39,6 +39,8 @@ use Nadybot\Modules\ONLINE_MODULE\OnlineController;
 ]
 class RaidMemberController extends ModuleInstance {
 	public const DB_TABLE = "raid_member_<myname>";
+	public const CMD_RAID_JOIN_LEAVE = "raid join/leave";
+	public const CMD_RAID_KICK_ADD = "raid kick/add";
 
 	#[NCA\Inject]
 	public DB $db;
@@ -79,9 +81,6 @@ class RaidMemberController extends ModuleInstance {
 
 	#[NCA\Setup]
 	public function setup(): void {
-		$this->commandAlias->register($this->moduleName, "raidmember add", "raid add");
-		$this->commandAlias->register($this->moduleName, "raidmember rem", "raid kick");
-
 		$this->settingManager->add(
 			module: $this->moduleName,
 			name: 'raid_announce_raidmember_loc',
@@ -253,7 +252,7 @@ class RaidMemberController extends ModuleInstance {
 	/**
 	 * Join the currently running raid
 	 */
-	#[NCA\HandlesCommand("raid (join|leave)")]
+	#[NCA\HandlesCommand(self::CMD_RAID_JOIN_LEAVE)]
 	#[NCA\Help\Group("raid-members")]
 	public function raidJoinCommand(
 		CmdContext $context,
@@ -272,7 +271,7 @@ class RaidMemberController extends ModuleInstance {
 	/**
 	 * Leave the currently running raid
 	 */
-	#[NCA\HandlesCommand("raid (join|leave)")]
+	#[NCA\HandlesCommand(self::CMD_RAID_JOIN_LEAVE)]
 	#[NCA\Help\Group("raid-members")]
 	public function raidLeaveCommand(
 		CmdContext $context,
@@ -291,7 +290,7 @@ class RaidMemberController extends ModuleInstance {
 	/**
 	 * Add someone to the raid, even if they currently cannot join, because it is locked
 	 */
-	#[NCA\HandlesCommand("raidmember")]
+	#[NCA\HandlesCommand(self::CMD_RAID_KICK_ADD)]
 	#[NCA\Help\Group("raid-members")]
 	public function raidAddCommand(
 		CmdContext $context,
@@ -307,7 +306,7 @@ class RaidMemberController extends ModuleInstance {
 	/**
 	 * Kick someone from the raid
 	 */
-	#[NCA\HandlesCommand("raidmember")]
+	#[NCA\HandlesCommand(self::CMD_RAID_KICK_ADD)]
 	#[NCA\Help\Group("raid-members")]
 	public function raidKickCommand(
 		CmdContext $context,

--- a/src/Modules/RELAY_MODULE/Migrations/20210821213338_MigrateRelayColors.php
+++ b/src/Modules/RELAY_MODULE/Migrations/20210821213338_MigrateRelayColors.php
@@ -66,7 +66,6 @@ class MigrateRelayColors implements SchemaMigration {
 			$this->migrateAllianceRelayModuleColors($db);
 		}
 
-		$this->messageHub->loadTagColor();
 		if ($db->table(CommandManager::DB_TABLE)
 			->where("module", "ALLIANCE_RELAY_MODULE")
 			->update(["status" => 0])) {

--- a/src/Modules/TOWER_MODULE/Migrations/20210826144709_MigrateToRoutes.php
+++ b/src/Modules/TOWER_MODULE/Migrations/20210826144709_MigrateToRoutes.php
@@ -60,7 +60,6 @@ class MigrateToRoutes implements SchemaMigration {
 		$hopFormat->render = true;
 		$db->insert(Source::DB_TABLE, $hopFormat);
 
-		$this->messageHub->loadTagColor();
 		$this->messageHub->loadTagFormat();
 
 		$table = MessageHub::DB_TABLE_ROUTES;

--- a/src/Modules/WORLDBOSS_MODULE/WorldBossController.php
+++ b/src/Modules/WORLDBOSS_MODULE/WorldBossController.php
@@ -43,7 +43,7 @@ use Nadybot\Core\{
 		description: "Show next Tarasque spawntime(s)",
 	),
 	NCA\DefineCommand(
-		command: "tara .+",
+		command: WorldBossController::CMD_TARA_UPDATE,
 		accessLevel: "member",
 		description: "Update, set or delete Tarasque killtimer",
 	),
@@ -53,7 +53,7 @@ use Nadybot\Core\{
 		description: "Show next Reaper spawntime(s)",
 	),
 	NCA\DefineCommand(
-		command: "reaper .+",
+		command: WorldBossController::CMD_REAPER_UPDATE,
 		accessLevel: "member",
 		description: "Update, set or delete Reaper killtimer",
 	),
@@ -63,7 +63,7 @@ use Nadybot\Core\{
 		description: "Show next Loren Warr spawntime(s)",
 	),
 	NCA\DefineCommand(
-		command: "loren .+",
+		command: WorldBossController::CMD_LOREN_UPDATE,
 		accessLevel: "member",
 		description: "Update, set or delete Loren Warr killtimer",
 	),
@@ -73,7 +73,7 @@ use Nadybot\Core\{
 		description: "shows timer of Gauntlet",
 	),
 	NCA\DefineCommand(
-		command: "gauntlet .+",
+		command: WorldBossController::CMD_GAUNTLET_UPDATE,
 		accessLevel: "member",
 		description: "Update or set Gaunlet timer",
 	),
@@ -83,7 +83,7 @@ use Nadybot\Core\{
 		description: "shows timer of Father Time",
 	),
 	NCA\DefineCommand(
-		command: "father .+",
+		command: WorldBossController::CMD_FATHER_UPDATE,
 		accessLevel: "member",
 		description: "Update or set Father Time timer",
 	),
@@ -97,6 +97,12 @@ use Nadybot\Core\{
 	)
 ]
 class WorldBossController extends ModuleInstance {
+	public const CMD_TARA_UPDATE = "tara set/delete";
+	public const CMD_FATHER_UPDATE = "father set/delete";
+	public const CMD_GAUNTLET_UPDATE = "gauntlet set/delete";
+	public const CMD_LOREN_UPDATE = "loren set/delete";
+	public const CMD_REAPER_UPDATE = "reaper set/delete";
+
 	public const WORLDBOSS_API = "https://timers.aobots.org/api/v1.0/bosses";
 
 	public const DB_TABLE = "worldboss_timers_<myname>";
@@ -545,11 +551,11 @@ class WorldBossController extends ModuleInstance {
 
 	/** Mark a worldboss as killed, setting a new timer for it */
 	#[
-		NCA\HandlesCommand("tara .+"),
-		NCA\HandlesCommand("loren .+"),
-		NCA\HandlesCommand("reaper .+"),
-		NCA\HandlesCommand("gauntlet .+"),
-		NCA\HandlesCommand("father .+"),
+		NCA\HandlesCommand(self::CMD_TARA_UPDATE),
+		NCA\HandlesCommand(self::CMD_LOREN_UPDATE),
+		NCA\HandlesCommand(self::CMD_REAPER_UPDATE),
+		NCA\HandlesCommand(self::CMD_GAUNTLET_UPDATE),
+		NCA\HandlesCommand(self::CMD_FATHER_UPDATE),
 		NCA\Help\Group("worldboss")
 	]
 	public function bossKillCommand(CmdContext $context, #[NCA\Str("kill")] string $action): void {
@@ -564,11 +570,11 @@ class WorldBossController extends ModuleInstance {
 
 	/** Manually update a worldboss's timer by giving the time until it is vulnerable */
 	#[
-		NCA\HandlesCommand("tara .+"),
-		NCA\HandlesCommand("loren .+"),
-		NCA\HandlesCommand("reaper .+"),
-		NCA\HandlesCommand("gauntlet .+"),
-		NCA\HandlesCommand("father .+"),
+		NCA\HandlesCommand(self::CMD_TARA_UPDATE),
+		NCA\HandlesCommand(self::CMD_LOREN_UPDATE),
+		NCA\HandlesCommand(self::CMD_REAPER_UPDATE),
+		NCA\HandlesCommand(self::CMD_GAUNTLET_UPDATE),
+		NCA\HandlesCommand(self::CMD_FATHER_UPDATE),
 		NCA\Help\Group("worldboss")
 	]
 	public function bossUpdateCommand(
@@ -585,10 +591,10 @@ class WorldBossController extends ModuleInstance {
 
 	/** Completely remove a worldboss's timer, because you are not interested in it */
 	#[
-		NCA\HandlesCommand("tara .+"),
-		NCA\HandlesCommand("loren .+"),
-		NCA\HandlesCommand("reaper .+"),
-		NCA\HandlesCommand("father .+"),
+		NCA\HandlesCommand(self::CMD_TARA_UPDATE),
+		NCA\HandlesCommand(self::CMD_LOREN_UPDATE),
+		NCA\HandlesCommand(self::CMD_REAPER_UPDATE),
+		NCA\HandlesCommand(self::CMD_FATHER_UPDATE),
 		NCA\Help\Group("worldboss")
 	]
 	public function bossDeleteCommand(CmdContext $context, PRemove $action): void {


### PR DESCRIPTION
Until now, sub-commands were defined as regular expressions. If it matched, then only the sub-commands with that regexp as "cmd" were even considered for execution. This caused several problems:
1. In order to understand which command-invocations were affected by which sub-command, you had to be able to understand regexps
2. If your sub-command had something like `points .+`, then it was impossible to to the rights of the base-command for everything but `points` and all other sub-commands would have to "poke holes" into the `.+` catchall like `points log` `points log all`, even though, there was no need for a new access level for these commands.

This change removes regular expressions from sub-commands. The "cmd" of the sub-command  is now a text to your choosing and all regexps of all command handlers of the base-command will now be compared against the issued command.
The only meaning of the "cmd" of a sub-command is to give all the handlers assigned to it a "group name" and their own access level.