### PR TITLE
Provide a Prometheus endpoint

### DIFF
--- a/src/Core/Attributes/HttpOwnAuth.php
+++ b/src/Core/Attributes/HttpOwnAuth.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class HttpOwnAuth {
+	public function __construct() {
+	}
+}

--- a/src/Core/WebsocketBase.php
+++ b/src/Core/WebsocketBase.php
@@ -23,6 +23,7 @@ class WebsocketBase {
 	public const ON_CLOSE = "close";
 	public const ON_PING = "ping";
 	public const ON_ERROR = "error";
+	public const ON_WRITE = "write";
 
 	public const ALLOWED_EVENTS = [
 		self::ON_CONNECT,
@@ -30,6 +31,7 @@ class WebsocketBase {
 		self::ON_BINARY,
 		self::ON_CLOSE,
 		self::ON_PING,
+		self::ON_WRITE,
 		self::ON_ERROR,
 	];
 
@@ -200,6 +202,9 @@ class WebsocketBase {
 	}
 
 	protected function write(string $data): bool {
+		$event = $this->getEvent();
+		$event->data = $data;
+		$this->fireEvent(self::ON_WRITE, $event);
 		$uri = ($this->uri ?? $this->peerName);
 		if (strlen($data) === 0 || !is_resource($this->socket)) {
 			return true;

--- a/src/Modules/CITY_MODULE/CloakController.php
+++ b/src/Modules/CITY_MODULE/CloakController.php
@@ -15,6 +15,7 @@ use Nadybot\Core\{
 	MessageHub,
 	Modules\ALTS\AltsController,
 	Nadybot,
+	Registry,
 	Routing\RoutableMessage,
 	Routing\Source,
 	SettingManager,
@@ -22,6 +23,7 @@ use Nadybot\Core\{
 	UserStateEvent,
 	Util,
 };
+use Nadybot\Modules\WEBSERVER_MODULE\StatsController;
 
 /**
  * @author Tyrence (RK2)
@@ -68,6 +70,9 @@ class CloakController extends ModuleInstance implements MessageEmitter {
 	#[NCA\Inject]
 	public CityWaveController $cityWaveController;
 
+	#[NCA\Inject]
+	public StatsController $statsController;
+
 	#[NCA\Setup]
 	public function setup(): void {
 		$this->settingManager->add(
@@ -91,6 +96,9 @@ class CloakController extends ModuleInstance implements MessageEmitter {
 		);
 
 		$this->messageHub->registerMessageEmitter($this);
+		$cloakStats = new CloakStatsCollector();
+		Registry::injectDependencies($cloakStats);
+		$this->statsController->registerProvider($cloakStats, "states");
 	}
 
 	public function getChannelName(): string {

--- a/src/Modules/CITY_MODULE/CloakStatsCollector.php
+++ b/src/Modules/CITY_MODULE/CloakStatsCollector.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\CITY_MODULE;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class CloakStatsCollector implements GaugeProvider {
+	#[NCA\Inject]
+	public CloakController $cloakController;
+
+	public function getValue(): float {
+		$entry = $this->cloakController->getLastOrgEntry();
+		return isset($entry) ? ($entry->action === "on" ? 1 : 0) : -1;
+	}
+
+	public function getTags(): array {
+		return ["type" => "cloak"];
+	}
+}

--- a/src/Modules/DISCORD_GATEWAY_MODULE/DiscordPacketsStats.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/DiscordPacketsStats.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\DISCORD_GATEWAY_MODULE;
+
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\CounterProvider;
+
+class DiscordPacketsStats implements CounterProvider {
+	private int $counter = 0;
+
+	public function __construct(
+		private string $direction,
+	) {
+	}
+
+	public function getValue(): int {
+		return $this->counter;
+	}
+
+	public function inc(int $amount=1): void {
+		$this->counter += max(1, $amount);
+	}
+
+	public function getTags(): array {
+		return ["direction" => $this->direction];
+	}
+}

--- a/src/Modules/ONLINE_MODULE/OnlineController.php
+++ b/src/Modules/ONLINE_MODULE/OnlineController.php
@@ -20,6 +20,7 @@ use Nadybot\Core\{
 	Modules\PLAYER_LOOKUP\PlayerManager,
 	Nadybot,
 	QueryBuilder,
+	Registry,
 	SettingManager,
 	StopExecutionException,
 	Text,
@@ -32,9 +33,10 @@ use Nadybot\Modules\{
 	RELAY_MODULE\RelayController,
 	RELAY_MODULE\Relay,
 	WEBSERVER_MODULE\ApiResponse,
+	WEBSERVER_MODULE\HttpProtocolWrapper,
 	WEBSERVER_MODULE\Request,
 	WEBSERVER_MODULE\Response,
-	WEBSERVER_MODULE\HttpProtocolWrapper,
+	WEBSERVER_MODULE\StatsController,
 };
 
 /**
@@ -101,6 +103,9 @@ class OnlineController extends ModuleInstance {
 
 	#[NCA\Inject]
 	public AltsController $altsController;
+
+	#[NCA\Inject]
+	public StatsController $statsController;
 
 	#[NCA\Inject]
 	public Text $text;
@@ -237,6 +242,12 @@ class OnlineController extends ModuleInstance {
 
 		$this->commandAlias->register($this->moduleName, "online", "o");
 		$this->commandAlias->register($this->moduleName, "online", "sm");
+		$onlineOrg = new OnlineOrgStats();
+		$onlinePriv = new OnlinePrivStats();
+		Registry::injectDependencies($onlineOrg);
+		Registry::injectDependencies($onlinePriv);
+		$this->statsController->registerProvider($onlineOrg, "online");
+		$this->statsController->registerProvider($onlinePriv, "online");
 	}
 
 	public function buildOnlineQuery(string $sender, string $channelType): QueryBuilder {

--- a/src/Modules/ONLINE_MODULE/OnlineOrgStats.php
+++ b/src/Modules/ONLINE_MODULE/OnlineOrgStats.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\ONLINE_MODULE;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\BuddylistEntry;
+use Nadybot\Core\BuddylistManager;
+use Nadybot\Core\ConfigFile;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class OnlineOrgStats implements GaugeProvider {
+	#[NCA\Inject]
+	public BuddylistManager $buddylistManager;
+
+	#[NCA\Inject]
+	public ConfigFile $config;
+
+	public function getValue(): float {
+		return count(array_filter(
+			$this->buddylistManager->buddyList,
+			function (BuddylistEntry $entry): bool {
+				return $entry->online && $entry->hasType('org');
+			}
+		));
+	}
+
+	public function getTags(): array {
+		return ["type" => "org"];
+	}
+}

--- a/src/Modules/ONLINE_MODULE/OnlinePrivStats.php
+++ b/src/Modules/ONLINE_MODULE/OnlinePrivStats.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\ONLINE_MODULE;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\Nadybot;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class OnlinePrivStats implements GaugeProvider {
+	#[NCA\Inject]
+	public Nadybot $chatBot;
+
+	public function getValue(): float {
+		return count($this->chatBot->chatlist);
+	}
+
+	public function getTags(): array {
+		return ["type" => "priv"];
+	}
+}

--- a/src/Modules/PRIVATE_CHANNEL_MODULE/PrivLockStats.php
+++ b/src/Modules/PRIVATE_CHANNEL_MODULE/PrivLockStats.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\PRIVATE_CHANNEL_MODULE;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class PrivLockStats implements GaugeProvider {
+	#[NCA\Inject]
+	public PrivateChannelController $privChan;
+
+	public function getValue(): float {
+		return $this->privChan->isLocked() ? 1 : 0;
+	}
+
+	public function getTags(): array {
+		return ["type" => "private_channel_locked"];
+	}
+}

--- a/src/Modules/RAID_MODULE/RaidController.php
+++ b/src/Modules/RAID_MODULE/RaidController.php
@@ -21,6 +21,7 @@ use Nadybot\Core\{
 	Nadybot,
 	ParamClass\PCharacter,
 	ParamClass\PWord,
+	Registry,
 	SettingManager,
 	Text,
 	Timer,
@@ -31,6 +32,7 @@ use Nadybot\Modules\{
 	COMMENT_MODULE\CommentCategory,
 	COMMENT_MODULE\CommentController,
 	ONLINE_MODULE\OnlineController,
+	WEBSERVER_MODULE\StatsController,
 };
 
 /**
@@ -114,6 +116,9 @@ class RaidController extends ModuleInstance {
 
 	#[NCA\Inject]
 	public ChatAssistController $chatAssistController;
+
+	#[NCA\Inject]
+	public StatsController $statsController;
 
 	/**
 	 * The currently running raid or null if none running
@@ -206,6 +211,12 @@ class RaidController extends ModuleInstance {
 			accessLevel: 'raid_admin_2'
 		);
 		$this->timer->callLater(0, [$this, 'resumeRaid']);
+		$stateStats = new RaidStateStats();
+		Registry::injectDependencies($stateStats);
+		$this->statsController->registerProvider($stateStats, "states");
+		$raidStats = new RaidMemberStats("raid");
+		Registry::injectDependencies($raidStats);
+		$this->statsController->registerDataset($raidStats, "raid");
 	}
 
 	public function getRaidCategory(): CommentCategory {

--- a/src/Modules/RAID_MODULE/RaidMemberStats.php
+++ b/src/Modules/RAID_MODULE/RaidMemberStats.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\RAID_MODULE;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Modules\WEBSERVER_MODULE\Dataset;
+
+class RaidMemberStats extends Dataset {
+	#[NCA\Inject]
+	public RaidController $raidController;
+
+	public function getValues(): array {
+		$numActive = 0;
+		$numInactive = 0;
+		$raid = $this->raidController->raid;
+		if (isset($raid)) {
+			foreach ($raid->raiders as $name => $raider) {
+				if (isset($raider->left)) {
+					$numInactive++;
+				} else {
+					$numActive++;
+				}
+			}
+		}
+		return [
+			"# TYPE raid gauge",
+			"raid{type=\"inactive\"} {$numInactive}",
+			"raid{type=\"active\"} {$numActive}",
+		];
+	}
+}

--- a/src/Modules/RAID_MODULE/RaidStateStats.php
+++ b/src/Modules/RAID_MODULE/RaidStateStats.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\RAID_MODULE;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class RaidStateStats implements GaugeProvider {
+	#[NCA\Inject]
+	public RaidController $raidController;
+
+	public function getValue(): float {
+		return isset($this->raidController->raid) ? 1 : 0;
+	}
+
+	public function getTags(): array {
+		return ["type" => "raid"];
+	}
+}

--- a/src/Modules/RELAY_MODULE/OnlineRelayStats.php
+++ b/src/Modules/RELAY_MODULE/OnlineRelayStats.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\RELAY_MODULE;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\ConfigFile;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class OnlineRelayStats implements GaugeProvider {
+	#[NCA\Inject]
+	public RelayController $relayController;
+
+	#[NCA\Inject]
+	public ConfigFile $config;
+
+	public function getValue(): float {
+		$sum = 0;
+		foreach ($this->relayController->relays as $relay) {
+			foreach ($relay->getOnlineList() as $type => $online) {
+				$sum += count($online);
+			}
+		}
+		return $sum;
+	}
+
+	public function getTags(): array {
+		return ["type" => "relay"];
+	}
+}

--- a/src/Modules/RELAY_MODULE/RelayController.php
+++ b/src/Modules/RELAY_MODULE/RelayController.php
@@ -47,6 +47,7 @@ use Nadybot\Modules\{
 	WEBSERVER_MODULE\JsonImporter,
 	WEBSERVER_MODULE\Request,
 	WEBSERVER_MODULE\Response,
+	WEBSERVER_MODULE\StatsController,
 };
 
 /**
@@ -120,6 +121,9 @@ class RelayController extends ModuleInstance {
 	public PlayerManager $playerManager;
 
 	#[NCA\Inject]
+	public StatsController $statsController;
+
+	#[NCA\Inject]
 	public CommandAlias $commandAlias;
 
 	#[NCA\Inject]
@@ -178,6 +182,9 @@ class RelayController extends ModuleInstance {
 		);
 		$this->loadStackComponents();
 		$this->settingManager->registerChangeListener("relay_queue_size", [$this, "adaptQueueSize"]);
+		$relayStats = new OnlineRelayStats();
+		Registry::injectDependencies($relayStats);
+		$this->statsController->registerProvider($relayStats, "online");
 	}
 
 	public function adaptQueueSize(string $setting, string $old, string $new): void {

--- a/src/Modules/RELAY_MODULE/RelayPacketsStats.php
+++ b/src/Modules/RELAY_MODULE/RelayPacketsStats.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\RELAY_MODULE;
+
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\CounterProvider;
+
+class RelayPacketsStats implements CounterProvider {
+	private int $counter = 0;
+
+	public function __construct(
+		private string $relayType,
+		private string $relayName,
+		private string $direction,
+	) {
+	}
+
+	public function getValue(): int {
+		return $this->counter;
+	}
+
+	public function inc(int $amount=1): void {
+		$this->counter += max(1, $amount);
+	}
+
+	public function getTags(): array {
+		return ["type" => $this->relayType, "name" => $this->relayName, "direction" => $this->direction];
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Collector/AoDataInbound.php
+++ b/src/Modules/WEBSERVER_MODULE/Collector/AoDataInbound.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Collector;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\Nadybot;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\CounterProvider;
+
+class AoDataInbound implements CounterProvider {
+	#[NCA\Inject]
+	public Nadybot $chatBot;
+
+	public function getValue(): int {
+		return $this->chatBot->numBytesIn;
+	}
+
+	public function getTags(): array {
+		return ["direction" => "in"];
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Collector/AoDataOutbound.php
+++ b/src/Modules/WEBSERVER_MODULE/Collector/AoDataOutbound.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Collector;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\Nadybot;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\CounterProvider;
+
+class AoDataOutbound implements CounterProvider {
+	#[NCA\Inject]
+	public Nadybot $chatBot;
+
+	public function getValue(): int {
+		return $this->chatBot->numBytesOut;
+	}
+
+	public function getTags(): array {
+		return ["direction" => "out"];
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Collector/AoPackets.php
+++ b/src/Modules/WEBSERVER_MODULE/Collector/AoPackets.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Collector;
+
+use Nadybot\Core\AOChatPacket;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\Nadybot;
+use Nadybot\Modules\WEBSERVER_MODULE\Dataset;
+use ReflectionClass;
+use ReflectionClassConstant;
+
+class AoPackets extends Dataset {
+	#[NCA\Inject]
+	public Nadybot $chatBot;
+
+	public function getValues(): array {
+		$ref = new ReflectionClass(AOChatPacket::class);
+		$lookup = array_flip($ref->getConstants(ReflectionClassConstant::IS_PUBLIC));
+		$lines = ["# TYPE ao_packets counter"];
+		foreach ($this->chatBot->packetsIn as $type => $count) {
+			$lines []= 'ao_packets{direction="in",type="'.
+				($lookup[$type] ?? $type) . "\"} {$count}";
+		}
+		foreach ($this->chatBot->packetsOut as $type => $count) {
+			$lines []= 'ao_packets{direction="out",type="'.
+				($lookup[$type] ?? $type) . "\"} {$count}";
+		}
+		return $lines;
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Collector/BuddylistOffline.php
+++ b/src/Modules/WEBSERVER_MODULE/Collector/BuddylistOffline.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Collector;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\BuddylistManager;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class BuddylistOffline implements GaugeProvider {
+	#[NCA\Inject]
+	public BuddylistManager $buddylistManager;
+
+	public function getValue(): float {
+		return $this->buddylistManager->getUsedBuddySlots()
+			- count($this->buddylistManager->getOnline());
+	}
+
+	public function getTags(): array {
+		return ["type" => "offline"];
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Collector/BuddylistOnline.php
+++ b/src/Modules/WEBSERVER_MODULE/Collector/BuddylistOnline.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Collector;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\BuddylistManager;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class BuddylistOnline implements GaugeProvider {
+	#[NCA\Inject]
+	public BuddylistManager $buddylistManager;
+
+	public function getValue(): float {
+		return count($this->buddylistManager->getOnline());
+	}
+
+	public function getTags(): array {
+		return ["type" => "online"];
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Collector/BuddylistSize.php
+++ b/src/Modules/WEBSERVER_MODULE/Collector/BuddylistSize.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Collector;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\Nadybot;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class BuddylistSize implements GaugeProvider {
+	#[NCA\Inject]
+	public Nadybot $chatBot;
+
+	public function getValue(): float {
+		return $this->chatBot->getBuddyListSize();
+	}
+
+	public function getTags(): array {
+		return ["type" => "size"];
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Collector/CmdStats.php
+++ b/src/Modules/WEBSERVER_MODULE/Collector/CmdStats.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Collector;
+
+use Nadybot\Core\CmdContext;
+use Nadybot\Modules\WEBSERVER_MODULE\Dataset;
+
+class CmdStats extends Dataset {
+	public function getValues(): array {
+		$cmdStats = CmdContext::$cmdStats;
+		$cmdStats = array_values(
+			array_filter($cmdStats, function (array $stats): bool {
+				return time() - $stats[0] <= 600;
+			})
+		);
+		if (empty($cmdStats)) {
+			return [];
+		}
+		usort($cmdStats, function (array $stats1, array $stats2): int {
+			return $stats1[1] <=> $stats2[1];
+		});
+		$num = count($cmdStats);
+		return [
+			"# TYPE cmd_stats summary",
+			"cmd_stats{quantile=\"0.01\"} " . (int)ceil($cmdStats[(int)floor($num*0.01)][1]),
+			"cmd_stats{quantile=\"0.05\"} " . (int)ceil($cmdStats[(int)floor($num*0.05)][1]),
+			"cmd_stats{quantile=\"0.5\"} " . (int)ceil($cmdStats[(int)floor($num*0.5)][1]),
+			"cmd_stats{quantile=\"0.9\"} " . (int)ceil($cmdStats[(int)floor($num*0.9)][1]),
+			"cmd_stats{quantile=\"0.99\"} " . (int)ceil($cmdStats[(int)floor($num*0.99)][1]),
+			"cmd_stats_sum " . (int)ceil(array_sum(array_column($cmdStats, 1))),
+			"cmd_stats_count " . count($cmdStats),
+		];
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Collector/MemoryPeakUsage.php
+++ b/src/Modules/WEBSERVER_MODULE/Collector/MemoryPeakUsage.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Collector;
+
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class MemoryPeakUsage implements GaugeProvider {
+	public function getValue(): float {
+		return memory_get_peak_usage(true);
+	}
+
+	public function getTags(): array {
+		return ["type" => "peak"];
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Collector/MemoryRealUsage.php
+++ b/src/Modules/WEBSERVER_MODULE/Collector/MemoryRealUsage.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Collector;
+
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class MemoryRealUsage implements GaugeProvider {
+	public function getValue(): float {
+		return memory_get_usage(true);
+	}
+
+	public function getTags(): array {
+		return ["type" => "allocated"];
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Collector/MemoryUsage.php
+++ b/src/Modules/WEBSERVER_MODULE/Collector/MemoryUsage.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Collector;
+
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class MemoryUsage implements GaugeProvider {
+	public function getValue(): float {
+		return memory_get_usage();
+	}
+
+	public function getTags(): array {
+		return ["type" => "used"];
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Dataset.php
+++ b/src/Modules/WEBSERVER_MODULE/Dataset.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE;
+
+use Exception;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\ValueProvider;
+
+use function Safe\json_encode;
+
+class Dataset {
+	/** @var string[] */
+	private array $tags = [];
+
+	/** @var ValueProvider[] */
+	private array $providers = [];
+
+	private string $name;
+
+	public function __construct(string $name, string ...$tags) {
+		sort($tags);
+		$this->tags = $tags;
+		$this->name = $name;
+	}
+
+	public function registerProvider(ValueProvider $provider): void {
+		$tags = $provider->getTags();
+		$tagKeys = array_keys($tags);
+		sort($tagKeys);
+		if ($tagKeys !== $this->tags) {
+			throw new Exception("Incompatible tag-sets provided");
+		}
+		$this->providers []= $provider;
+	}
+
+	/** @return string[] */
+	public function getValues(): array {
+		if (empty($this->providers)) {
+			return [];
+		}
+		$type = ($this->providers[0] instanceof GaugeProvider) ? "gauge" : "counter";
+		$result = ["# TYPE {$this->name} {$type}"];
+		foreach ($this->providers as $provider) {
+			$line = $this->name;
+			$tags = $provider->getTags();
+			$attrs = join(
+				",",
+				array_map(
+					function (string $tag) use ($tags): string {
+						return "{$tag}=" . json_encode((string)$tags[$tag]);
+					},
+					$this->tags
+				)
+			);
+			if (count($tags)) {
+				$line .= "{" . $attrs . "}";
+			}
+			$line .= " " . (string)$provider->getValue();
+			$result []= $line;
+		}
+		return $result;
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Interfaces/CounterProvider.php
+++ b/src/Modules/WEBSERVER_MODULE/Interfaces/CounterProvider.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Interfaces;
+
+interface CounterProvider extends ValueProvider {
+	public function getValue(): int;
+}

--- a/src/Modules/WEBSERVER_MODULE/Interfaces/GaugeProvider.php
+++ b/src/Modules/WEBSERVER_MODULE/Interfaces/GaugeProvider.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Interfaces;
+
+interface GaugeProvider extends ValueProvider {
+	public function getValue(): float;
+}

--- a/src/Modules/WEBSERVER_MODULE/Interfaces/ValueProvider.php
+++ b/src/Modules/WEBSERVER_MODULE/Interfaces/ValueProvider.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Interfaces;
+
+interface ValueProvider {
+	/** @return array<string,string> */
+	public function getTags(): array;
+
+	public function getValue(): int|float|string;
+}

--- a/src/Modules/WEBSERVER_MODULE/StatsController.php
+++ b/src/Modules/WEBSERVER_MODULE/StatsController.php
@@ -17,6 +17,7 @@ use Nadybot\Modules\WEBSERVER_MODULE\Collector\{
 	BuddylistOffline,
 	BuddylistOnline,
 	BuddylistSize,
+	CmdStats,
 	MemoryPeakUsage,
 	MemoryRealUsage,
 	MemoryUsage,
@@ -73,6 +74,7 @@ class StatsController extends ModuleInstance {
 		$aoPackets = new Aopackets("ao_packets");
 		Registry::injectDependencies($aoPackets);
 		$this->registerDataset($aoPackets, "ao_packets");
+		$this->registerDataset(new CmdStats("cmd_times"), "cmd_times");
 		$this->settingManager->registerChangeListener("prometheus_enabled", [$this, "changePrometheusStatus"]);
 	}
 

--- a/src/Modules/WEBSERVER_MODULE/StatsController.php
+++ b/src/Modules/WEBSERVER_MODULE/StatsController.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE;
+
+use Nadybot\Core\{
+	Attributes as NCA,
+	ConfigFile,
+	ModuleInstance,
+	Registry,
+	SettingManager,
+	Util,
+};
+use Nadybot\Modules\WEBSERVER_MODULE\Collector\{
+	AoDataInbound,
+	AoDataOutbound,
+	AoPackets,
+	BuddylistOffline,
+	BuddylistOnline,
+	BuddylistSize,
+	MemoryPeakUsage,
+	MemoryRealUsage,
+	MemoryUsage,
+};
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\ValueProvider;
+
+#[NCA\Instance]
+class StatsController extends ModuleInstance {
+	#[NCA\Inject]
+	public SettingManager $settingManager;
+
+	#[NCA\Inject]
+	public ConfigFile $config;
+
+	#[NCA\Inject]
+	public Util $util;
+
+	/** @var array<string,Dataset> */
+	private array $dataSets = [];
+
+	#[NCA\Setup]
+	public function setup(): void {
+		$this->settingManager->add(
+			module: $this->moduleName,
+			name: 'prometheus_enabled',
+			description: 'Enable Prometheus endpoint at /metrics',
+			mode: 'edit',
+			type: 'options',
+			value: '1',
+			options: 'true;false',
+			intoptions: '1;0',
+			accessLevel: 'admin'
+		);
+		$this->settingManager->add(
+			module: $this->moduleName,
+			name: 'prometheus_auth_token',
+			description: 'Auth token for Prometheus endpoint',
+			mode: 'noedit',
+			type: 'text',
+			value: $this->util->getPassword(16),
+			accessLevel: 'admin'
+		);
+		$collectors = [
+			"ao_data" => [new AoDataInbound(), new AoDataOutbound],
+			"buddylist" => [new BuddylistSize(), new BuddylistOnline(), new BuddylistOffline()],
+			"memory" => [new MemoryRealUsage(), new MemoryUsage(), new MemoryPeakUsage()],
+		];
+		foreach ($collectors as $name => $objs) {
+			foreach ($objs as $obj) {
+				Registry::injectDependencies($obj);
+				$this->registerProvider($obj, $name);
+			}
+		}
+		$aoPackets = new Aopackets("ao_packets");
+		Registry::injectDependencies($aoPackets);
+		$this->registerDataset($aoPackets, "ao_packets");
+		$this->settingManager->registerChangeListener("prometheus_enabled", [$this, "changePrometheusStatus"]);
+	}
+
+	public function changePrometheusStatus(string $settingName, string $oldValue, string $newValue, mixed $data): void {
+		if ($oldValue === $newValue) {
+			return;
+		}
+		if ($newValue === "1") {
+			$this->settingManager->save("prometheus_auth_token", $this->util->getPassword(16));
+		} else {
+			$this->settingManager->save("prometheus_auth_token", "<none>");
+		}
+	}
+
+	public function registerDataset(Dataset $set, string $name): void {
+		$this->dataSets[$name] = $set;
+	}
+
+	public function registerProvider(ValueProvider $provider, string $name): void {
+		if (!isset($this->dataSets[$name])) {
+			$this->registerDataset(new Dataset($name, ...array_keys($provider->getTags())), $name);
+		}
+		$this->dataSets[$name]->registerProvider($provider);
+	}
+
+	/**
+	 * Query prometheus-formatted statistics
+	 */
+	#[
+		NCA\HttpGet("/metrics"),
+		NCA\HttpOwnAuth,
+	]
+	public function getMetricsEndpoint(Request $request, HttpProtocolWrapper $server): void {
+		if (!$this->settingManager->getBool('prometheus_enabled')) {
+			$server->httpError(new Response(
+				Response::NOT_FOUND,
+			));
+			return;
+		}
+		$authHeader = $request->headers["authorization"] ?? null;
+		if (
+			!isset($authHeader)
+			|| !preg_match("/^([bB]earer +)?" . preg_quote($this->settingManager->getString('prometheus_auth_token') ?? '') . '$/', $authHeader)
+		) {
+			$server->httpError(new Response(
+				Response::UNAUTHORIZED,
+				["WWW-Authenticate" => "Bearer realm=\"{$this->config->name}\""],
+			));
+			return;
+		}
+		$server->sendResponse(new Response(
+			Response::OK,
+			['Content-type' => "text/plain; version=0.0.4"],
+			$this->getMetricsData()
+		), true);
+	}
+
+	public function getMetricsData(): string {
+		$lines = [];
+		foreach ($this->dataSets as $name => $dataset) {
+			$values = $dataset->getValues();
+			if (count($values) > 0) {
+				$lines []= join("\n", $values);
+			}
+		}
+		return join("\n\n", $lines);
+	}
+}

--- a/src/Modules/WORLDBOSS_MODULE/GauntletBuffController.php
+++ b/src/Modules/WORLDBOSS_MODULE/GauntletBuffController.php
@@ -31,6 +31,7 @@ use Nadybot\Modules\TIMERS_MODULE\{
 	Timer,
 	TimerController,
 };
+use Nadybot\Modules\WEBSERVER_MODULE\StatsController;
 
 /**
  * @author Equi
@@ -82,6 +83,9 @@ class GauntletBuffController extends ModuleInstance implements MessageEmitter {
 	#[NCA\Inject]
 	public TimerController $timerController;
 
+	#[NCA\Inject]
+	public StatsController $statsController;
+
 	public function getChannelName(): string {
 		return Source::SYSTEM . "(gauntlet-buff)";
 	}
@@ -124,6 +128,8 @@ class GauntletBuffController extends ModuleInstance implements MessageEmitter {
 			"gaubuff_times",
 			[$this, "validateGaubuffTimes"]
 		);
+		$this->statsController->registerProvider(new GauntletBuffStats($this, "clan"), "states");
+		$this->statsController->registerProvider(new GauntletBuffStats($this, "omni"), "states");
 	}
 
 	#[NCA\Event(
@@ -437,5 +443,10 @@ class GauntletBuffController extends ModuleInstance implements MessageEmitter {
 			return null;
 		}
 		return join("", $msgs);
+	}
+
+	public function getIsActive(string $faction): bool {
+			$timer = $this->timerController->get("Gaubuff_{$faction}");
+			return ($timer !== null && isset($timer->endtime));
 	}
 }

--- a/src/Modules/WORLDBOSS_MODULE/GauntletBuffStats.php
+++ b/src/Modules/WORLDBOSS_MODULE/GauntletBuffStats.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WORLDBOSS_MODULE;
+
+use Nadybot\Modules\WEBSERVER_MODULE\Interfaces\GaugeProvider;
+
+class GauntletBuffStats implements GaugeProvider {
+	public function __construct(
+		private GauntletBuffController $gauBuff,
+		private string $faction
+	) {
+	}
+
+	public function getValue(): float {
+		return $this->gauBuff->getIsActive($this->faction) ? 1 : 0;
+	}
+
+	public function getTags(): array {
+		return ["type" => "gaubuff-{$this->faction}"];
+	}
+}


### PR DESCRIPTION
This provides a Prometheus-compatible statistics endpoint at `/metrics` with its own authorization and authentication handling.
Implemented are:
- raid
- online
- ao-packet counters by type
- ao-data
- discord-packets
- execution-time histogram
- relay-packets per relay
- buddylist (online, offline, size)
- Various states (cloak, raid, private channel locked, gauntlet buffs)

Closes #284 