### PR TITLE
New command: `!orgnotes` for org-wide notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add a new property to raids, that allows to limit the maximum number of raiders. Can be set with either `!raid start <description> limit <max members>` or `!raid limit <max members>`.
+- New command `!orgnote` to manage org-wide notes that can also be shared via Nadynative protocol.
 
 ### Changed
 

--- a/src/Modules/NOTES_MODULE/Migrations/OrgNotes/20220426093429_CreateOrgNotesTable.shared.php
+++ b/src/Modules/NOTES_MODULE/Migrations/OrgNotes/20220426093429_CreateOrgNotesTable.shared.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\NOTES_MODULE\Migrations\OrgNotes;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\DB;
+use Nadybot\Core\LoggerWrapper;
+use Nadybot\Core\SchemaMigration;
+use Nadybot\Modules\NOTES_MODULE\OrgNotesController;
+
+class CreateOrgNotesTable implements SchemaMigration {
+	public function migrate(LoggerWrapper $logger, DB $db): void {
+		$table = OrgNotesController::DB_TABLE;
+		$db->schema()->create($table, function(Blueprint $table) {
+			$table->id();
+			$table->string("uuid", 36)->unique()->index();
+			$table->string("added_by", 12);
+			$table->integer("added_on");
+			$table->text("note");
+		});
+	}
+}

--- a/src/Modules/NOTES_MODULE/OrgNote.php
+++ b/src/Modules/NOTES_MODULE/OrgNote.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\NOTES_MODULE;
+
+use Nadybot\Core\DBRow;
+
+class OrgNote extends DBRow {
+	public ?int $id = null;
+	public string $uuid;
+	public string $added_by;
+	public int $added_on;
+	public string $note;
+
+	public function __construct() {
+		$this->added_on = time();
+	}
+}

--- a/src/Modules/NOTES_MODULE/OrgNotesController.php
+++ b/src/Modules/NOTES_MODULE/OrgNotesController.php
@@ -1,0 +1,237 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\NOTES_MODULE;
+
+use Illuminate\Support\Collection;
+use Nadybot\Core\{
+	AccessManager,
+	Attributes as NCA,
+	CmdContext,
+	DB,
+	EventManager,
+	InsufficientAccessException,
+	ModuleInstance,
+	Modules\ALTS\AltsController,
+	Nadybot,
+	ParamClass\PRemove,
+	Text,
+	Util,
+};
+
+/**
+ * @author Nadyita (RK5)
+ */
+#[
+	NCA\Instance,
+	NCA\HasMigrations("Migrations/OrgNotes"),
+	NCA\DefineCommand(
+		command: "orgnotes",
+		accessLevel: "guild",
+		description: "Displays, adds, or removes a note from your list",
+		alias: "orgnote"
+	),
+	NCA\ProvidesEvent(
+		event: "sync(orgnote)",
+		desc: "Triggered whenever someone creates an org note"
+	),
+	NCA\ProvidesEvent(
+		event: "sync(orgnote-delete)",
+		desc: "Triggered when deleting an org note"
+	)
+]
+class OrgNotesController extends ModuleInstance {
+	public const DB_TABLE = "org_notes";
+
+	#[NCA\Inject]
+	public DB $db;
+
+	#[NCA\Inject]
+	public Text $text;
+
+	#[NCA\Inject]
+	public Util $util;
+
+	#[NCA\Inject]
+	public Nadybot $chatBot;
+
+	#[NCA\Inject]
+	public AccessManager $accessManager;
+
+	#[NCA\Inject]
+	public EventManager $eventManager;
+
+	#[NCA\Inject]
+	public AltsController $altsController;
+
+	/** Rank required to delete other people's org notes */
+	#[NCA\Setting\Rank]
+	public string $orgnoteDeleteOtherRank = "mod";
+
+	/**
+	 * Get all org notes
+	 *
+	 * @return Collection<OrgNote>
+	 */
+	public function getOrgNotes(): Collection {
+		return $this->db->table(self::DB_TABLE)
+			->asObj(OrgNote::class);
+	}
+
+	/** Get a single org note */
+	public function getOrgNote(int $id): ?OrgNote {
+		return $this->db->table(self::DB_TABLE)
+			->where("id", $id)
+			->asObj(OrgNote::class)
+			->first();
+	}
+
+	public function createOrgNote(string $creator, string $text, bool $forceSync=false): OrgNote {
+		$note = new OrgNote();
+		$note->added_by = $creator;
+		$note->uuid = $this->util->createUUID();
+		$note->note = $text;
+		$note->id = $this->db->insert(self::DB_TABLE, $note);
+
+		$event = SyncOrgNoteEvent::fromOrgNote($note);
+		$event->forceSync = $forceSync;
+		$this->eventManager->fireEvent($event);
+		return $note;
+	}
+
+	/** Delete an org note form the DB and return success status */
+	public function removeOrgNote(OrgNote $note, bool $forceSync=false): bool {
+		$success = $this->db->table(self::DB_TABLE)->delete($note->id) > 0;
+		if (!$success) {
+			return false;
+		}
+		$event = new SyncOrgNoteDeleteEvent();
+		$event->forceSync = $forceSync;
+		$event->uuid = $note->uuid;
+		$this->eventManager->fireEvent($event);
+		return true;
+	}
+
+	/**
+	 * Delete the given org note with the rights of $actor
+	 *
+	 * @throws InsufficientAccessException if no right to delete note
+	 */
+	public function removeOrgNoteId(int $noteId, string $actor, bool $forceSync=false): bool {
+		$note = $this->getOrgNote($noteId);
+		if (!isset($note)) {
+			return false;
+		}
+		if (!$this->canDeleteOrgNote($note, $actor)) {
+			throw new InsufficientAccessException(
+				"Only {$this->orgnoteDeleteOtherRank} or higher can delete other ".
+				"members' notes."
+			);
+		}
+		return $this->removeOrgNote($note, $forceSync);
+	}
+
+	/** Check if $actor has sufficient rights to delete $note */
+	protected function canDeleteOrgNote(OrgNote $note, string $actor): bool {
+		$isAdmin = $this->accessManager->checkSingleAccess(
+			$actor,
+			$this->orgnoteDeleteOtherRank
+		);
+		if ($isAdmin) {
+			return true;
+		}
+		$actorMain = $this->altsController->getMainOf($actor);
+		$noteMain = $this->altsController->getMainOf($note->added_by);
+		return $actorMain === $noteMain;
+	}
+
+	/** List all organization-wide notes */
+	#[NCA\HandlesCommand("orgnotes")]
+	public function cmdShowOrgNotes(CmdContext $context): void {
+		$notes = $this->getOrgNotes();
+		if ($notes->isEmpty()) {
+			$context->reply("Org notes (0)");
+			return;
+		}
+		$chunks = [];
+		foreach ($notes as $note) {
+			$removeLink = "";
+			if ($this->canDeleteOrgNote($note, $context->char->name)) {
+				$removeLink = " [" . $this->text->makeChatcmd(
+					"remove",
+					"/tell <myname> orgnote rem {$note->id}"
+				) . "]";
+			}
+			$chunks []= "<tab>{$note->added_by} on ".
+				$this->util->date($note->added_on).
+				"\n<tab>- <highlight>{$note->note}<end>{$removeLink}";
+		}
+		$blob = "<header2>Notes in your org/alliance<end>\n\n".
+			join("\n\n", $chunks);
+		$msg = $this->text->makeBlob("Org notes (" . $notes->count() . ")", $blob);
+		$context->reply($msg);
+	}
+
+	/** Create a new, organization-wide notes */
+	#[NCA\HandlesCommand("orgnotes")]
+	public function cmdAddOrgNote(
+		CmdContext $context,
+		#[NCA\Str("add", "new", "create")] string $action,
+		string $text
+	): void {
+		$note = $this->createOrgNote($context->char->name, $text, $context->forceSync);
+		$context->reply("Note <highlight>#{$note->id}<end> created.");
+	}
+
+	/** Remove an organization-wide note */
+	#[NCA\HandlesCommand("orgnotes")]
+	public function cmdRemOrgNote(
+		CmdContext $context,
+		PRemove $action,
+		int $id
+	): void {
+		try {
+			$removed = $this->removeOrgNoteId($id, $context->char->name, $context->forceSync);
+		} catch (InsufficientAccessException $e) {
+			$context->reply($e->getMessage());
+			return;
+		}
+		if ($removed) {
+			$context->reply("Org note <highlight>#{$id}<end> deleted.");
+			return;
+		}
+		$context->reply("No org note <highlight>#{$id}<end> found.");
+	}
+
+	#[NCA\Event(
+		name: "sync(orgnote)",
+		description: "Sync externally created org notes"
+	)]
+	public function processOrgNoteSyncEvent(SyncOrgNoteEvent $event): void {
+		if ($event->isLocal()) {
+			return;
+		}
+		$note = $event->toOrgNote();
+		$note->id = $this->db->table(self::DB_TABLE)
+			->where("uuid", $event->uuid)
+			->pluckAs("id", "integer")
+			->first();
+		if (isset($note->id)) {
+			$this->db->update(self::DB_TABLE, "id", $note);
+		} else {
+			$this->db->insert(self::DB_TABLE, $note);
+		}
+	}
+
+	#[NCA\Event(
+		name: "sync(orgnote-delete)",
+		description: "Sync externally deleted org notes"
+	)]
+	public function processNewsDeleteSyncEvent(SyncOrgNoteDeleteEvent $event): void {
+		if ($event->isLocal()) {
+			return;
+		}
+		$this->db->table(self::DB_TABLE)
+			->where("uuid", $event->uuid)
+			->delete();
+	}
+}

--- a/src/Modules/NOTES_MODULE/SyncOrgNoteDeleteEvent.php
+++ b/src/Modules/NOTES_MODULE/SyncOrgNoteDeleteEvent.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\NOTES_MODULE;
+
+use Nadybot\Core\SyncEvent;
+
+class SyncOrgNoteDeleteEvent extends SyncEvent {
+	public string $type = "sync(orgnote-delete)";
+
+	/** UUID of this note */
+	public string $uuid;
+}

--- a/src/Modules/NOTES_MODULE/SyncOrgNoteEvent.php
+++ b/src/Modules/NOTES_MODULE/SyncOrgNoteEvent.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\NOTES_MODULE;
+
+use Nadybot\Core\SyncEvent;
+
+class SyncOrgNoteEvent extends SyncEvent {
+	public string $type = "sync(orgnote)";
+
+	/** Unix timestamp when this was created */
+	public int $time;
+
+	/** Name of the character who created the entry */
+	public string $name;
+
+	/** Text of these note */
+	public string $note;
+
+	/** UUID of this note */
+	public string $uuid;
+
+	public static function fromOrgNote(OrgNote $note): self {
+		$event = new self();
+		$event->time = $note->added_on;
+		$event->name = $note->added_by;
+		$event->note = $note->note;
+		$event->uuid = $note->uuid;
+		return $event;
+	}
+
+	public function toOrgNote(): OrgNote {
+		$note = new OrgNote();
+		$note->added_by = $this->name;
+		$note->added_on = $this->time;
+		$note->uuid = $this->uuid;
+		$note->note = $this->note;
+		return $note;
+	}
+}


### PR DESCRIPTION
This works the same as a basic `!notes`-command, just notes are shared for everyone on the bot. They can also be shared via Nadynative protocol to other orgs. The rank to delete others' notes is configurable.

Closes #315