### PR TITLE
Add loot history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `!adminlist` now shows the last time the bot has seen each admin and on which alt.
 - Add new option `--strict` to make SQLite checks more strict. This is mainly for development purpose.
 - Add new prometheus metric `states{type="raid_lock"}`
+- The `LOOT_MODULE` now keeps a full history of what was rolled when, and who won what on which roll. You can search this history by using `!loot history`, `!loot history <number>|last`, `!loot search winner=Nady` and `!loot search item=leg`.
 
 ### Changed
 

--- a/src/Core/Attributes/NoSpace.php
+++ b/src/Core/Attributes/NoSpace.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class NoSpace {
+	public function __construct() {
+	}
+}

--- a/src/Core/CommandManager.php
+++ b/src/Core/CommandManager.php
@@ -30,6 +30,7 @@ use Nadybot\Core\{
 	Routing\RoutableMessage,
 	Routing\Source,
 };
+use Nadybot\Core\Attributes\NoSpace;
 
 #[
 	NCA\Instance,
@@ -1094,12 +1095,15 @@ class CommandManager implements MessageEmitter {
 						$twos = array_fill(0, substr_count($parMask, "%d"), 2);
 						$niceParam = sprintf($parMask, ...$ones) . " " . sprintf($parMask, ...$twos) . " ...";
 					}
+					if (count($params[$i]->getAttributes(NoSpace::class))) {
+						$niceParam = "\x08{$niceParam}";
+					}
 					$paramText []= $niceParam;
 				}
 				if ($j > 0 && $k === 0) {
 					$lines []= "or";
 				}
-				$lines []= "<tab><highlight>" . join(" ", $paramText) . "<end>";
+				$lines []= "<tab><highlight>" . str_replace(" \x08", "", join(" ", $paramText)) . "<end>";
 			}
 			$examples = $m->getAttributes(NCA\Help\Example::class);
 			foreach ($examples as $exAttr) {
@@ -1261,6 +1265,8 @@ class CommandManager implements MessageEmitter {
 		}
 		if (count($param->getAttributes(NCA\SpaceOptional::class))) {
 			$regexp = new CommandRegexp("\\s*{$new}");
+		} elseif (count($param->getAttributes(NCA\NoSpace::class))) {
+			$regexp = new CommandRegexp($new);
 		} else {
 			$regexp = new CommandRegexp("\\s+{$new}");
 		}

--- a/src/Modules/LOOT_MODULE/LootController.php
+++ b/src/Modules/LOOT_MODULE/LootController.php
@@ -115,6 +115,10 @@ class LootController extends ModuleInstance {
 	#[NCA\Setting\Boolean]
 	public bool $showLootPics = true;
 
+	/** Maximum number of entries for loot history and search */
+	#[NCA\Setting\Number]
+	public int $lootHistoryMaxEntries = 40;
+
 	/**
 	 * The currently rolled items
 	 * @var LootItem[]
@@ -175,7 +179,7 @@ class LootController extends ModuleInstance {
 		$items = $this->db->table(self::DB_TABLE)
 			->orderByDesc("dt")
 			->orderBy("pos")
-			->limit(40)
+			->limit($this->lootHistoryMaxEntries)
 			->asObj(LootHistory::class);
 		if ($items->isEmpty()) {
 			$context->reply("There are not rolls recorded on this bot.");
@@ -269,7 +273,7 @@ class LootController extends ModuleInstance {
 		$items = $this->db->table(self::DB_TABLE)
 			->where("winner", $winner())
 			->orderByDesc("dt")
-			->limit(40)
+			->limit($this->lootHistoryMaxEntries)
 			->asObj(LootHistory::class);
 		if ($items->isEmpty()) {
 			$context->reply("{$winner} hasn't won any items yet.");
@@ -322,7 +326,7 @@ class LootController extends ModuleInstance {
 			->whereIlike("display", "%{$search}%")
 			->orderByDesc("dt")
 			->orderBy("pos")
-			->limit(40)
+			->limit($this->lootHistoryMaxEntries)
 			->asObj(LootHistory::class);
 		if ($items->isEmpty()) {
 			$context->reply(

--- a/src/Modules/LOOT_MODULE/LootController.php
+++ b/src/Modules/LOOT_MODULE/LootController.php
@@ -163,7 +163,7 @@ class LootController extends ModuleInstance {
 	}
 
 	/**
-	 * Get a list of the last rolls
+	 * Get a list of the last loot rolls
 	 */
 	#[NCA\HandlesCommand("loot")]
 	#[NCA\Help\Group("loot")]

--- a/src/Modules/LOOT_MODULE/LootController.php
+++ b/src/Modules/LOOT_MODULE/LootController.php
@@ -16,8 +16,10 @@ use Nadybot\Core\{
 	ParamClass\PQuantity,
 	ParamClass\PRemove,
 	Text,
+	Util,
 	Modules\PLAYER_LOOKUP\PlayerManager,
 };
+use Nadybot\Core\ParamClass\PCharacter;
 use Nadybot\Modules\{
 	BASIC_CHAT_MODULE\ChatLeaderController,
 	ITEMS_MODULE\AODBEntry,
@@ -72,6 +74,7 @@ use Nadybot\Modules\{
 ]
 class LootController extends ModuleInstance {
 	public const CMD_LOOT_MANAGE = "loot add/change/delete";
+	public const DB_TABLE = "loot_history_<myname>";
 
 	#[NCA\Inject]
 	public DB $db;
@@ -93,6 +96,9 @@ class LootController extends ModuleInstance {
 
 	#[NCA\Inject]
 	public Text $text;
+
+	#[NCA\Inject]
+	public Util $util;
 
 	#[NCA\Inject]
 	public ChatLeaderController $chatLeaderController;
@@ -121,9 +127,12 @@ class LootController extends ModuleInstance {
 	 */
 	private $residual = [];
 
+	private int $roll = 1;
+
 	#[NCA\Setup]
 	public function setup(): void {
 		$this->commandAlias->register($this->moduleName, "loot addmulti", "multiloot");
+		$this->roll = (int)$this->db->table(self::DB_TABLE)->max("roll") + 1;
 	}
 
 	#[NCA\Event(
@@ -151,6 +160,225 @@ class LootController extends ModuleInstance {
 	public function lootCommand(CmdContext $context): void {
 		$msg = $this->getCurrentLootList();
 		$context->reply($msg);
+	}
+
+	/**
+	 * Search for loot won by &lt;winner&gt;
+	 */
+	#[NCA\HandlesCommand("loot")]
+	#[NCA\Help\Group("loot")]
+	public function lootSearchWinerCommand(
+		CmdContext $context,
+		#[NCA\Str("search")] string $action,
+		#[NCA\Str("winner=")] string $subAction,
+		#[NCA\NoSpace] PCharacter $winner,
+	): void {
+		$items = $this->db->table(self::DB_TABLE)
+			->where("winner", $winner())
+			->orderByDesc("dt")
+			->limit(40)
+			->asObj(LootHistory::class);
+		if ($items->isEmpty()) {
+			$context->reply("{$winner} hasn't won any items yet.");
+			return;
+		}
+		$lines = $items->map(function(LootHistory $item): string {
+			$line = "<tab>".
+				$this->util->date($item->dt).
+				" -";
+			if ($item->amount > 1) {
+				$line .= " 1/{$item->amount}";
+			}
+			$line .= " {$item->display}";
+			if (isset($item->comment) && strlen($item->comment) && strpos($item->display, $item->comment) === false) {
+				$line .= " {$item->comment}";
+			}
+			$line .= " - rolled by {$item->rolled_by}";
+			return $line;
+		});
+		$blob = "<header2>Last items won by {$winner}<end>\n".
+			$lines->join("\n");
+		$context->reply($this->text->makeBlob("Last items won by {$winner}", $blob));
+	}
+
+	/**
+	 * Search for winners of loot matching &lt;search&gt;
+	 */
+	#[NCA\HandlesCommand("loot")]
+	#[NCA\Help\Group("loot")]
+	public function lootSearchNameCommand(
+		CmdContext $context,
+		#[NCA\Str("search")] string $action,
+		#[NCA\Str("last")] ?string $lastOnly,
+		#[NCA\Str("item=")] string $subAction,
+		#[NCA\NoSpace] string $search,
+	): void {
+		$search = trim($search);
+		if (strlen($search) < 1) {
+			$context->reply("You have to give a string to search for.");
+			return;
+		}
+		$query = $this->db->table(self::DB_TABLE)
+			->whereIlike("display", "%{$search}%")
+			->orderByDesc("dt")
+			->orderBy("pos")
+			->limit(40);
+		if (isset($lastOnly)) {
+			$query->where("roll", $this->roll-1);
+		}
+		/** @var Collection<LootHistory> */
+		$items = $query->asObj(LootHistory::class);
+		if ($items->isEmpty()) {
+			$context->reply(
+				"No items were rolled matching your search <highlight>{$search}<end>."
+			);
+			return;
+		}
+
+		$compressedList = $this->compressLootHistory($items);
+
+		$lines = $compressedList->map(function(LootHistory $item): string {
+			$line = "<tab>" . $this->util->date($item->dt)  . " -";
+			if ($item->amount > 1) {
+				$line .= " {$item->amount}x";
+			}
+			$line .= " <highlight>{$item->display}<end>";
+			if (isset($item->comment) && strlen($item->comment) && strpos($item->display, $item->comment) === false) {
+				$line .= " {$item->comment}";
+			}
+			$line .= " - rolled by {$item->rolled_by}\n".
+				"<tab><tab>" . $this->getWinners(...$item->winners);
+
+			return $line;
+		});
+
+		$blob = "<header2>Last rolled items matching '{$search}'<end>\n".
+			$lines->join("\n");
+		$context->reply(
+			$this->text->makeBlob("Last rolled items matching '{$search}'", $blob)
+		);
+	}
+
+	/**
+	 * Get a list of the last rolls
+	 */
+	#[NCA\HandlesCommand("loot")]
+	#[NCA\Help\Group("loot")]
+	public function lootShowRollsCommand(
+		CmdContext $context,
+		#[NCA\Str("show")] string $action,
+	): void {
+		/** @var Collection<LootHistory> */
+		$items = $this->db->table(self::DB_TABLE)
+			->orderByDesc("dt")
+			->orderBy("pos")
+			->limit(40)
+			->asObj(LootHistory::class);
+		if ($items->isEmpty()) {
+			$context->reply("There are not rolls recorded on this bot.");
+			return;
+		}
+		$compressedList = $this->compressLootHistory($items);
+		$rolls = $compressedList->groupBy("roll");
+		$lines = $rolls->map(function (Collection $items, int $roll): string {
+			/** @var LootHistory */
+			$firstItem = $items->firstOrFail();
+			return $this->util->date($firstItem->dt) . " - ".
+				$items->count() . " items, rolled by {$firstItem->rolled_by}";
+		});
+	}
+
+	/**
+	 * View what was rolled/won in the given roll
+	 */
+	#[NCA\HandlesCommand("loot")]
+	#[NCA\Help\Group("loot")]
+	public function lootShowNumberCommand(
+		CmdContext $context,
+		#[NCA\Str("show")] string $action,
+		#[NCA\PNumber] #[NCA\Str("last")] string $number,
+	): void {
+		if (strtolower($number) === "last") {
+			$number = $this->db->table(self::DB_TABLE)->max("roll");
+			if ($number < 1) {
+				$context->reply("There is no last roll to display.");
+				return;
+			}
+		}
+		$roll = (int)$number;
+		/** @var Collection<LootHistory> */
+		$items = $this->db->table(self::DB_TABLE)
+			->where("roll", $roll)
+			->orderBy("pos")
+			->asObj(LootHistory::class);
+		if ($items->isEmpty()) {
+			$context->reply("There is no loot roll #<highlight>{$number}<end>.");
+			return;
+		}
+		$compressedList = $this->compressLootHistory($items);
+		$lines = $compressedList->map(function(LootHistory $item): string {
+			$line = "<header2>Slot #{$item->pos}:<end>";
+			if ($item->amount > 1) {
+				$line .= " {$item->amount}x";
+			}
+			$line .= " <highlight>{$item->display}<end>";
+			if (isset($item->comment) && strlen($item->comment) && strpos($item->display, $item->comment) === false) {
+				$line .= " {$item->comment}";
+			}
+			$line .= "\n<tab>" . $this->getWinners(...$item->winners);
+
+			return $line;
+		});
+		$rolledBy = $items->firstOrFail()->rolled_by;
+		$rolledTime = $this->util->date($items->firstOrFail()->dt);
+		$blob = "Loot #{$roll} was rolled <highlight>{$rolledTime}<end> by <highlight>{$rolledBy}<end>.\n\n";
+		$blob .= $lines->join("\n\n");
+		$context->reply($this->text->makeBlob(
+			"Loot roll #{$roll} (" . $lines->count() . " slots)",
+			$blob
+		));
+	}
+
+	private function getWinners(string ...$winners): string {
+		$line = "Winner";
+		if (count($winners) !== 1) {
+			$line .= "s";
+		}
+		if (count($winners) === 0) {
+			$line .= ": &lt;No one added&gt;";
+		} else {
+			$winners = $this->text->arraySprintf("<green>%s<end>", ...$winners);
+			$line .= ": " . $this->text->enumerate(...$winners);
+		}
+		return $line;
+	}
+
+	/**
+	 * @param Collection<LootHistory> $items
+	 * @return Collection<LootHistory>
+	*/
+	private function compressLootHistory(Collection $items): Collection {
+		$lastRoll = 0;
+		$lastPos = 0;
+
+		/** @var Collection<LootHistory> */
+		$compressedList = new Collection();
+		foreach ($items as $item) {
+			if ($lastRoll === $item->roll && $lastPos === $item->pos) {
+				if (!isset($item->winner)) {
+					continue;
+				}
+				$compressedList->last()->winners []= $item->winner;
+				continue;
+			}
+			if (isset($item->winner)) {
+				$item->winners = [$item->winner];
+			}
+			$compressedList->push($item);
+			$lastRoll = $item->roll;
+			$lastPos = $item->pos;
+		}
+		return $compressedList;
 	}
 
 	/**
@@ -475,18 +703,34 @@ class LootController extends ModuleInstance {
 			} else {
 				$list .= "Winners: ";
 			}
+			$lootHistory = new LootHistory();
+			$lootHistory->roll = $this->roll;
+			$lootHistory->dt = time();
+			$lootHistory->pos = $key;
+			$lootHistory->amount = $item->multiloot;
+			$lootHistory->added_by = $item->added_by;
+			$lootHistory->icon = $item->icon;
+			$lootHistory->name = $item->name;
+			$lootHistory->display = $item->display;
+			$lootHistory->comment = $item->comment;
+			$lootHistory->rolled_by = $context->char->name;
 			if ($numUsers === 0) {
 				$list .= "<highlight>No one added.<end>\n\n";
 				$this->residual[$resnum] = $item;
 				$resnum++;
+				$lootHistory->winner = null;
+				$this->db->insert(self::DB_TABLE, $lootHistory);
 			} else {
 				/** @psalm-var non-empty-array<string, bool> */
 				$users = $item->users;
 				if ($item->multiloot > 1) {
 					$arrolnum = min($item->multiloot, $numUsers);
-
 					// Get $arrolnum random values from $users
 					$winners = (array)array_rand($users, $arrolnum);
+					foreach ($winners as $winner) {
+						$lootHistory->winner = $winner;
+						$this->db->insert(self::DB_TABLE, $lootHistory);
+					}
 					$item->users = [];
 					$list .= join(
 						", ",
@@ -506,6 +750,8 @@ class LootController extends ModuleInstance {
 					}
 				} else {
 					$winner = array_rand($users, 1);
+					$lootHistory->winner = $winner;
+					$this->db->insert(self::DB_TABLE, $lootHistory);
 					$list .= "<green>$winner<end>";
 				}
 				$list .= "\n\n";
@@ -514,6 +760,7 @@ class LootController extends ModuleInstance {
 
 		//Reset loot
 		$this->loot = [];
+		$this->roll++;
 
 		//Show winner list
 		if (!empty($this->residual)) {
@@ -675,7 +922,7 @@ class LootController extends ModuleInstance {
 	/**
 	 * Add all items from a raid_loot to the loot list
 	 */
-	public function addRaidToLootList(string $raid, string $category): bool {
+	public function addRaidToLootList(string $addedBy, string $raid, string $category): bool {
 		// clear current loot list
 		$this->loot = [];
 		$count = 1;
@@ -704,6 +951,7 @@ class LootController extends ModuleInstance {
 			$lootItem->icon = $row->item->icon ?? null;
 			$lootItem->multiloot = $row->multiloot;
 			$lootItem->name = $row->name;
+			$lootItem->added_by = $addedBy;
 			$item = $row->name;
 			if (isset($row->item)) {
 				$item = $row->item->getLink($row->ql);

--- a/src/Modules/LOOT_MODULE/LootHistory.php
+++ b/src/Modules/LOOT_MODULE/LootHistory.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\LOOT_MODULE;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\DBRow;
+
+class LootHistory extends DBRow {
+	/** Artificial primary key */
+	public int $id;
+
+	/** The n-th roll on this bot */
+	public int $roll;
+
+	/** Position on the loot table (starting with 1) */
+	public int $pos;
+
+	/** Simple name (without HTML) of the item */
+	public string $name;
+
+	/** Unix timestamp when it was rolled */
+	public int $dt;
+
+	/** How many items of this in total were rolled in this slot */
+	public int $amount = 1;
+
+	/** Funcom aodb icon id */
+	public ?int $icon = null;
+
+	/** Who added this item to the loot table */
+	public string $added_by;
+
+	/** Who did the !flatroll */
+	public string $rolled_by;
+
+	/** Nice display (including item link) of the item */
+	public string $display = "";
+
+	/** Optional comment about the item */
+	public string $comment = "";
+
+	/** If someone won the item, name of the winner */
+	public ?string $winner = null;
+
+	/** @var string[] */
+	#[NCA\DB\Ignore]
+	public array $winners = [];
+}

--- a/src/Modules/LOOT_MODULE/LootListsController.php
+++ b/src/Modules/LOOT_MODULE/LootListsController.php
@@ -280,7 +280,7 @@ class LootListsController extends ModuleInstance {
 			return;
 		}
 
-		$this->addAPFLootToList(13);
+		$this->addAPFLootToList($context->char->name, 13);
 	}
 
 	/**
@@ -294,7 +294,7 @@ class LootListsController extends ModuleInstance {
 			return;
 		}
 
-		$this->addAPFLootToList(28);
+		$this->addAPFLootToList($context->char->name, 28);
 	}
 
 	/**
@@ -308,12 +308,12 @@ class LootListsController extends ModuleInstance {
 			return;
 		}
 
-		$this->addAPFLootToList(35);
+		$this->addAPFLootToList($context->char->name, 35);
 	}
 
-	public function addAPFLootToList(int $sector): void {
+	public function addAPFLootToList(string $addedBy, int $sector): void {
 		// adding apf stuff
-		$this->lootController->addRaidToLootList('APF', "Sector $sector");
+		$this->lootController->addRaidToLootList($addedBy, 'APF', "Sector $sector");
 		$msg = "Sector $sector loot table was added to the loot list.";
 		$this->chatBot->sendPrivate($msg);
 

--- a/src/Modules/LOOT_MODULE/Migrations/20220505150153_CreateLootHistoryTable.php
+++ b/src/Modules/LOOT_MODULE/Migrations/20220505150153_CreateLootHistoryTable.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\LOOT_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\DB;
+use Nadybot\Core\LoggerWrapper;
+use Nadybot\Core\SchemaMigration;
+use Nadybot\Modules\LOOT_MODULE\LootController;
+
+class CreateLootHistoryTable implements SchemaMigration {
+	public function migrate(LoggerWrapper $logger, DB $db): void {
+		$table = LootController::DB_TABLE;
+		$db->schema()->create($table, function(Blueprint $table) {
+			$table->id();
+			$table->unsignedInteger("dt")->index();
+			$table->unsignedInteger("roll")->index();
+			$table->unsignedInteger("pos");
+			$table->unsignedInteger("amount");
+			$table->string("name", 200);
+			$table->unsignedInteger("icon")->nullable();
+			$table->string("added_by", 12)->index();
+			$table->string("rolled_by", 12);
+			$table->string("display", 200);
+			$table->string("comment", 200);
+			$table->string("winner", 12)->nullable(true)->index();
+		});
+	}
+}


### PR DESCRIPTION
This adds automatic history to everything from the `LOOT_MODULE`. It provides 4 interfaces to the history:

`!loot history` to get a list of all past rolls
`!loot history <number>|last` to display the full details of a roll / the last roll
`!loot search winner=<name>` to search for items won by a specific player
`!loot search item=<name>` to search for items rolled in loot

Closes #358