### PR TITLE
Configurable rank names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The name of every access-level-rank can now be changed freely.
+
 ### Changed
 
 - The `!track online`-command got a real parser now and supports filtering by level (ranges), title level (ranges), faction(s) and profession(s).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The name of every access-level-rank can now be changed freely.
+- The `!leaders`-command can now be configured to also show the admins and mods.
 
 ### Changed
 

--- a/src/Core/AccessManager.php
+++ b/src/Core/AccessManager.php
@@ -8,6 +8,7 @@ use Nadybot\Core\{
 	DBSchema\Audit,
 	Modules\ALTS\AltsController,
 	Modules\SECURITY\AuditController,
+	Modules\SYSTEM\SystemController,
 };
 use SplObjectStorage;
 
@@ -76,6 +77,9 @@ class AccessManager {
 
 	#[NCA\Inject]
 	public AltsController $altsController;
+
+	#[NCA\Inject]
+	public SystemController $systemController;
 
 	#[NCA\Inject]
 	public ConfigFile $config;
@@ -178,11 +182,19 @@ class AccessManager {
 		$displayName = $this->getAccessLevel($accessLevel);
 		switch ($displayName) {
 			case "rl":
-				return "raidleader";
+				return $this->systemController->rankNameRL;
+			case "guest":
+				return $this->systemController->rankNameGuest;
+			case "member":
+				return $this->systemController->rankNameMember;
+			case "guild":
+				return $this->systemController->rankNameGuild;
 			case "mod":
-				return "moderator";
+				return $this->systemController->rankNameMod;
 			case "admin":
-				return "administrator";
+				return $this->systemController->rankNameAdmin;
+			case "superadmin":
+				return $this->systemController->rankNameSuperadmin;
 		}
 		if (substr($displayName, 0, 5) === "raid_") {
 			$setName = $this->settingManager->getString("name_{$displayName}");
@@ -277,14 +289,29 @@ class AccessManager {
 	public function getAccessLevel(string $accessLevel): string {
 		$accessLevel = strtolower($accessLevel);
 		switch ($accessLevel) {
+			case $this->systemController->rankNameRL:
 			case "raidleader":
 				$accessLevel = "rl";
 				break;
+			case $this->systemController->rankNameMod:
 			case "moderator":
 				$accessLevel = "mod";
 				break;
+			case $this->systemController->rankNameAdmin:
 			case "administrator":
 				$accessLevel = "admin";
+				break;
+			case $this->systemController->rankNameSuperadmin:
+				$accessLevel = "superadmin";
+				break;
+			case $this->systemController->rankNameMember:
+				$accessLevel = "member";
+				break;
+			case $this->systemController->rankNameGuest:
+				$accessLevel = "guest";
+				break;
+			case $this->systemController->rankNameGuild:
+				$accessLevel = "guild";
 				break;
 		}
 

--- a/src/Core/Modules/ADMIN/AdminController.php
+++ b/src/Core/Modules/ADMIN/AdminController.php
@@ -157,7 +157,14 @@ class AdminController extends ModuleInstance {
 	#[NCA\HandlesCommand("adminlist")]
 	#[NCA\Help\Group("ranks")]
 	public function adminlistCommand(CmdContext $context, #[NCA\Str("all")] ?string $all): void {
-		$showOfflineAlts = isset($all);
+		$blobs = $this->getLeaderList(isset($all));
+
+		$link = $this->text->makeBlob('Bot administrators', join("\n", $blobs));
+		$context->reply($link);
+	}
+
+	/** @return string[] */
+	public function getLeaderList(bool $showOfflineAlts): array {
 		$admins = [];
 		$mods = [];
 		$blobs = [];
@@ -191,9 +198,7 @@ class AdminController extends ModuleInstance {
 				"s<end>\n".
 				join("", $mods);
 		}
-
-		$link = $this->text->makeBlob('Bot administrators', join("\n", $blobs));
-		$context->reply($link);
+		return $blobs;
 	}
 
 	#[NCA\Event(

--- a/src/Core/Modules/ADMIN/AdminController.php
+++ b/src/Core/Modules/ADMIN/AdminController.php
@@ -92,6 +92,12 @@ class AdminController extends ModuleInstance {
 		$this->commandAlias->register($this->moduleName, "mod rem", "remmod");
 	}
 
+	private function addArticle(string $rank): string {
+		return in_array(substr($rank, 0, 1), ["a", "e", "i", "o", "u"])
+			? "an {$rank}"
+			: "a {$rank}";
+	}
+
 	/** Make &lt;who&gt; an administrator */
 	#[NCA\HandlesCommand("admin")]
 	#[NCA\Help\Group("ranks")]
@@ -101,7 +107,8 @@ class AdminController extends ModuleInstance {
 		PCharacter $who
 	): void {
 		$intlevel = 4;
-		$rank = 'an administrator';
+		$rankName = $this->accessManager->getDisplayName("admin");
+		$rank = $this->addArticle($rankName);
 
 		$this->add($who(), $context->char->name, $context, $intlevel, $rank);
 	}
@@ -115,7 +122,8 @@ class AdminController extends ModuleInstance {
 		PCharacter $who
 	): void {
 		$intlevel = 3;
-		$rank = 'a moderator';
+		$rankName = $this->accessManager->getDisplayName("mod");
+		$rank = $this->addArticle($rankName);
 
 		$this->add($who(), $context->char->name, $context, $intlevel, $rank);
 	}
@@ -125,7 +133,8 @@ class AdminController extends ModuleInstance {
 	#[NCA\Help\Group("ranks")]
 	public function adminRemoveCommand(CmdContext $context, PRemove $rem, PCharacter $who): void {
 		$intlevel = 4;
-		$rank = 'an administrator';
+		$rankName = $this->accessManager->getDisplayName("admin");
+		$rank = $this->addArticle($rankName);
 
 		$this->remove($who(), $context->char->name, $context, $intlevel, $rank);
 	}
@@ -135,7 +144,8 @@ class AdminController extends ModuleInstance {
 	#[NCA\Help\Group("ranks")]
 	public function modRemoveCommand(CmdContext $context, PRemove $rem, PCharacter $who): void {
 		$intlevel = 3;
-		$rank = 'a moderator';
+		$rankName = $this->accessManager->getDisplayName("mod");
+		$rank = $this->addArticle($rankName);
 
 		$this->remove($who(), $context->char->name, $context, $intlevel, $rank);
 	}
@@ -157,7 +167,9 @@ class AdminController extends ModuleInstance {
 			}
 			$line = "<tab>$who";
 			if ($this->accessManager->checkAccess($who, 'superadmin')) {
-				$line .= " (<highlight>Super-administrator<end>)";
+				$line .= " (<highlight>".
+					ucfirst($this->accessManager->getDisplayName("superadmin")).
+					"<end>)";
 			}
 			$line .= $this->getOnlineStatus($who, true) . "\n".
 				$this->getAltAdminInfo($who, $showOfflineAlts);
@@ -168,11 +180,15 @@ class AdminController extends ModuleInstance {
 			}
 		}
 		if (count($admins)) {
-			$blobs []= "<header2>Administrators<end>\n".
+			$blobs []= "<header2>".
+				ucfirst($this->accessManager->getDisplayName("admin")).
+				"s<end>\n".
 				join("", $admins);
 		}
 		if (count($mods)) {
-			$blobs []= "<header2>Moderators<end>\n".
+			$blobs []= "<header2>".
+				ucfirst($this->accessManager->getDisplayName("mod")).
+				"s<end>\n".
 				join("", $mods);
 		}
 

--- a/src/Core/Modules/SYSTEM/SystemController.php
+++ b/src/Core/Modules/SYSTEM/SystemController.php
@@ -4,6 +4,7 @@ namespace Nadybot\Core\Modules\SYSTEM;
 
 use function Safe\unpack;
 
+use Exception;
 use Illuminate\Support\Collection;
 use Nadybot\Core\{
 	AccessManager,
@@ -177,6 +178,57 @@ class SystemController extends ModuleInstance implements MessageEmitter {
 	/** When using the proxy, always send multi-page replies via one worker */
 	#[NCA\Setting\Boolean]
 	public bool $pagingOnSameWorker = true;
+
+	/** Display name for the rank "superadmin" */
+	#[NCA\Setting\Text]
+	public string $rankNameSuperadmin = "superadmin";
+
+	/** Display name for the rank "admin" */
+	#[NCA\Setting\Text]
+	public string $rankNameAdmin = "administrator";
+
+	/** Display name for the rank "moderator" */
+	#[NCA\Setting\Text]
+	public string $rankNameMod = "moderator";
+
+	/** Display name for the rank "guild" */
+	#[NCA\Setting\Text]
+	public string $rankNameGuild = "guild";
+
+	/** Display name for the rank "member" */
+	#[NCA\Setting\Text]
+	public string $rankNameMember = "member";
+
+	/** Display name for the rank "guest" */
+	#[NCA\Setting\Text]
+	public string $rankNameGuest = "guest";
+
+	/** Display name for the temporary rank "raidleader" */
+	#[NCA\Setting\Text]
+	public string $rankNameRL = "raidleader";
+
+	#[
+		NCA\SettingChangeHandler("rank_name_superadmin"),
+		NCA\SettingChangeHandler("rank_name_admin"),
+		NCA\SettingChangeHandler("rank_name_mod"),
+		NCA\SettingChangeHandler("rank_name_guild"),
+		NCA\SettingChangeHandler("rank_name_member"),
+		NCA\SettingChangeHandler("rank_name_guest"),
+		NCA\SettingChangeHandler("rank_name_rl"),
+	]
+	public function preventRankNameDupes(string $setting, string $old, string $new): void {
+		$new = strtolower($new);
+		if (strtolower($this->rankNameSuperadmin) === $new
+			|| strtolower($this->rankNameAdmin) === $new
+			|| strtolower($this->rankNameMod) === $new
+			|| strtolower($this->rankNameGuild) === $new
+			|| strtolower($this->rankNameMember) === $new
+			|| strtolower($this->rankNameGuest) === $new
+			|| strtolower($this->rankNameRL) === $new
+		) {
+			throw new Exception("The display name <highlight>{$new}<end> is already used for another rank.");
+		}
+	}
 
 	#[NCA\Setup]
 	public function setup(): void {

--- a/src/Modules/ONLINE_MODULE/OnlineController.php
+++ b/src/Modules/ONLINE_MODULE/OnlineController.php
@@ -902,21 +902,19 @@ class OnlineController extends ModuleInstance {
 		}
 
 		$accessLevel = $this->accessManager->getAccessLevelForCharacter($name);
+		$displayName = ucfirst($this->accessManager->getDisplayName($accessLevel));
 		switch ($accessLevel) {
 			case 'superadmin':
-				return " $fancyColon <red>SuperAdmin<end>";
+				return " $fancyColon <red>{$displayName}<end>";
 			case 'admin':
-				return " $fancyColon <red>Admin<end>";
+				return " $fancyColon <red>{$displayName}<end>";
 			case 'mod':
-				return " $fancyColon <green>Mod<end>";
+				return " $fancyColon <green>{$displayName}<end>";
 			case 'rl':
-				return " $fancyColon <orange>RL<end>";
+				return " $fancyColon <orange>{$displayName}<end>";
 		}
 		if (substr($accessLevel, 0, 5) === "raid_") {
-			$setName = $this->settingManager->getString("name_{$accessLevel}");
-			if ($setName !== null) {
-				return " $fancyColon <orange>$setName<end>";
-			}
+			return " $fancyColon <orange>{$displayName}<end>";
 		}
 		return "";
 	}


### PR DESCRIPTION
- Allow all names of all ranks to be changed in the `SYSTEM` module
- Ad an option for the `!leaders`-command to also include the admins