### PR TITLE
Add knob to disallow custom Poll answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add new optional parameter `<dimension>` to `!whois`.
+- When creating a poll, adding `||` At the end of the options will now disallow the usage of custom options.
 
 ### Changed
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Calculation of out-of-range status fixed when restarting the bot.
 - Polls with numeric choices would not display at all.
+- When viewing a poll, it would always say that you haven't votes yet.
 
 ## [6.2.2] - 2023-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Calculation of out-of-range status fixed when restarting the bot.
 - Polls with numeric choices would not display at all.
-- When viewing a poll, it would always say that you haven't votes yet.
+- When viewing a poll, it would always say that you haven't voted yet.
 
 ## [6.2.2] - 2023-04-21
 

--- a/src/Modules/VOTE_MODULE/Migrations/20230503203710_AddAllowOtherAnswers.php
+++ b/src/Modules/VOTE_MODULE/Migrations/20230503203710_AddAllowOtherAnswers.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\VOTE_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\{DB, LoggerWrapper, SchemaMigration};
+use Nadybot\Modules\VOTE_MODULE\VoteController;
+
+class AddAllowOtherAnswers implements SchemaMigration {
+	public function migrate(LoggerWrapper $logger, DB $db): void {
+		$table = "";
+		$table = VoteController::DB_POLLS;
+		$db->schema()->table($table, function (Blueprint $table): void {
+			$table->boolean("allow_other_answers")->nullable(false)->default(true)->change();
+		});
+	}
+}

--- a/src/Modules/VOTE_MODULE/Migrations/20230503203710_AddAllowOtherAnswers.php
+++ b/src/Modules/VOTE_MODULE/Migrations/20230503203710_AddAllowOtherAnswers.php
@@ -11,7 +11,7 @@ class AddAllowOtherAnswers implements SchemaMigration {
 		$table = "";
 		$table = VoteController::DB_POLLS;
 		$db->schema()->table($table, function (Blueprint $table): void {
-			$table->boolean("allow_other_answers")->nullable(false)->default(true)->change();
+			$table->boolean("allow_other_answers")->nullable(false)->default(true);
 		});
 	}
 }

--- a/src/Modules/VOTE_MODULE/Poll.php
+++ b/src/Modules/VOTE_MODULE/Poll.php
@@ -9,6 +9,7 @@ class Poll extends DBRow {
 	public string $author;
 	public string $question;
 	public string $possible_answers;
+	public bool $allow_other_answers=true;
 
 	/** @var string[] */
 	#[NCA\DB\Ignore]

--- a/src/Modules/VOTE_MODULE/VoteController.php
+++ b/src/Modules/VOTE_MODULE/VoteController.php
@@ -346,7 +346,7 @@ class VoteController extends ModuleInstance implements MessageEmitter {
 		/** @var ?Vote */
 		$vote = $this->db->table(self::DB_VOTES)
 			->where("poll_id", $topic->id)
-			->where("author", "sender")
+			->where("author", $context->char->name)
 			->asObj(Vote::class)
 			->first();
 		$timeleft = $topic->getTimeLeft();
@@ -378,6 +378,14 @@ class VoteController extends ModuleInstance implements MessageEmitter {
 
 		if ($timeleft <= 0) {
 			$msg = "No longer accepting votes for this poll.";
+			$context->reply($msg);
+			return;
+		}
+
+		if (!$topic->allow_other_answers && !in_array($answer, $topic->answers)) {
+			$msg = "You have to pick one of the options ".
+				$this->text->enumerate(...$this->text->arraySprintf("'%s'", ...$topic->answers)) . ". ".
+				"Custom answers are not allowed for this poll.";
 			$context->reply($msg);
 			return;
 		}
@@ -423,6 +431,7 @@ class VoteController extends ModuleInstance implements MessageEmitter {
 	 * Create a new poll
 	 * The poll will be active for &lt;duration&gt;
 	 * The format of &lt;definition&gt; is &lt;topic&gt;|&lt;option1&gt;|&lt;option2&gt;...
+	 * If you finish the options with two pipes ||, then custom answers won't be allowed.
 	 */
 	#[NCA\HandlesCommand("poll")]
 	#[NCA\Help\Group("voting")]
@@ -447,9 +456,14 @@ class VoteController extends ModuleInstance implements MessageEmitter {
 			$context->reply($msg);
 			return;
 		}
+		$allowCustomAnswers = array_slice($answers, -2) !== ['', ''];
+		if ($allowCustomAnswers === false) {
+			$answers = array_slice($answers, 0, count($answers)-2);
+		}
 		$topic = new Poll();
 		$topic->question = $question;
 		$topic->author = $context->char->name;
+		$topic->allow_other_answers = $allowCustomAnswers;
 		$topic->started = time();
 		$topic->duration = $duration;
 		$topic->answers = $answers;
@@ -519,8 +533,10 @@ class VoteController extends ModuleInstance implements MessageEmitter {
 				"/tell <myname> vote remove {$topic->id}"
 			) . "\n";
 
-			$blob .="\nDon't like these choices? Add your own:\n".
-				"<tab>/tell <myname> vote {$topic->id} <highlight>your choice<end>\n";
+			if ($topic->allow_other_answers) {
+				$blob .="\nDon't like these choices? Add your own:\n".
+					"<tab>/tell <myname> vote {$topic->id} <highlight>your choice<end>\n";
+			}
 		}
 
 		if ($sender === null) {


### PR DESCRIPTION
The possible answers in a poll have always been just predefined "suggestions". It has always been possible to give any custom answer in addition to the predefined ones.
Creating a poll and adding `||` at the end of the option list, will now disallow the use of custom answers.