### PR TITLE
Move from AutoInc to UUID v7

### DIFF
--- a/.github/workflows/test_migrations.yml
+++ b/.github/workflows/test_migrations.yml
@@ -41,7 +41,7 @@ jobs:
     name: Test MySQL migrations
     services:
       mysql:
-        image: mysql:5.7
+        image: ghcr.io/rblaine95/mysql:5.7
         env:
           MYSQL_ROOT_PASSWORD: 123456
           MYSQL_USER: budabot
@@ -141,7 +141,7 @@ jobs:
     name: Test PostgreSQL migrations
     services:
       postgres:
-        image: postgres:9
+        image: ghcr.io/rblaine95/postgres:9
         env:
           POSTGRES_PASSWORD: 123456
           POSTGRES_USER: budabot

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -95,4 +95,8 @@
     "phpstan.initialAnalysis": true,
     "phpstan.memoryLimit": "-1",
     "phpstan.path": "./vendor/phpstan/phpstan/phpstan.phar",
+    "phpstan.binCommand": [
+        "./vendor/phpstan/phpstan/phpstan.phar"
+    ],
+    "phpstan.checkValidity": true,
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Results of `!flatroll` are now using standard color theme and the text to show on items where no one added is configurable, defaulting to `-` in order to easier spot actual winners.
 - The default file format of the configuration file has changed from php to toml.
 - Don't show links to `!config` if you cannot run it anyway.
+- The `!verify`-command will now show the results of the last 3 rolls, because it would be impossible to guess the previous UUID
 
 ### Coding
 
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove all redundant libraries and only keep a single one for each type
 - Profession, Faction, and Playfield are now Enums
 - No uninitialized properties anymore. All non-injected properties without default are now part of the constructor
+- Switched from auto incrementing columns to UUID7 IDs
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
 		"amphp/parallel": "^2.2",
 		"amphp/http-server": "^3.3.0",
 		"amphp/websocket-server": "^4.0.0",
-		"doctrine/dbal": "^3"
+		"doctrine/dbal": "^3",
+		"ramsey/uuid": "^4.7"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "31409bf206e198b552886b785d9fe820",
+    "content-hash": "4c697556f1f7a92b3ee1a3500c9d74bf",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3909,6 +3909,187 @@
                 "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
             },
             "time": "2021-10-29T13:26:27+00:00"
+        },
+        {
+            "name": "ramsey/collection",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/collection.git",
+                "reference": "a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5",
+                "reference": "a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "captainhook/plugin-composer": "^5.3",
+                "ergebnis/composer-normalize": "^2.28.3",
+                "fakerphp/faker": "^1.21",
+                "hamcrest/hamcrest-php": "^2.0",
+                "jangregor/phpstan-prophecy": "^1.0",
+                "mockery/mockery": "^1.5",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpcsstandards/phpcsutils": "^1.0.0-rc1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5",
+                "psalm/plugin-mockery": "^1.1",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "ramsey/coding-standard": "^2.0.3",
+                "ramsey/conventional-commits": "^1.3",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "extra": {
+                "captainhook": {
+                    "force-install": true
+                },
+                "ramsey/conventional-commits": {
+                    "configFile": "conventional-commits.json"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Collection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "A PHP library for representing and manipulating collections.",
+            "keywords": [
+                "array",
+                "collection",
+                "hash",
+                "map",
+                "queue",
+                "set"
+            ],
+            "support": {
+                "issues": "https://github.com/ramsey/collection/issues",
+                "source": "https://github.com/ramsey/collection/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ramsey",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ramsey/collection",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-31T21:50:55+00:00"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "4.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "91039bc1faa45ba123c4328958e620d382ec7088"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/91039bc1faa45ba123c4328958e620d382ec7088",
+                "reference": "91039bc1faa45ba123c4328958e620d382ec7088",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12",
+                "ext-json": "*",
+                "php": "^8.0",
+                "ramsey/collection": "^1.2 || ^2.0"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "captainhook/captainhook": "^5.10",
+                "captainhook/plugin-composer": "^5.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "doctrine/annotations": "^1.8",
+                "ergebnis/composer-normalize": "^2.15",
+                "mockery/mockery": "^1.3",
+                "paragonie/random-lib": "^2",
+                "php-mock/php-mock": "^2.2",
+                "php-mock/php-mock-mockery": "^1.3",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpbench/phpbench": "^1.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9",
+                "ramsey/composer-repl": "^1.4",
+                "slevomat/coding-standard": "^8.4",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.9"
+            },
+            "suggest": {
+                "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
+                "ext-gmp": "Enables faster math with arbitrary-precision integers using GMP.",
+                "ext-uuid": "Enables the use of PeclUuidTimeGenerator and PeclUuidRandomGenerator.",
+                "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "captainhook": {
+                    "force-install": true
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP library for generating and working with universally unique identifiers (UUIDs).",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "support": {
+                "issues": "https://github.com/ramsey/uuid/issues",
+                "source": "https://github.com/ramsey/uuid/tree/4.7.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ramsey",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ramsey/uuid",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-27T21:32:50+00:00"
         },
         {
             "name": "revolt/event-loop",

--- a/src/Core/CommandManager.php
+++ b/src/Core/CommandManager.php
@@ -37,6 +37,7 @@ use Nadybot\Core\{
 	Types\MessageEmitter,
 };
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
@@ -1704,7 +1705,7 @@ class CommandManager implements MessageEmitter {
 		}
 		$inserts = [];
 		foreach ($perms as $perm) {
-			$perm->id = null;
+			$perm->id = Uuid::uuid7();
 			$perm->permission_set = $name;
 			$inserts []= (array)$perm;
 		}

--- a/src/Core/CommandManager.php
+++ b/src/Core/CommandManager.php
@@ -239,6 +239,7 @@ class CommandManager implements MessageEmitter {
 						'access_level' => $accessLevel,
 						'cmd' => $command,
 						'enabled' => (bool)$status,
+						'id' => Uuid::uuid7(),
 					]
 				);
 		}

--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -30,10 +30,11 @@ use Nadybot\Core\{
 use PDO;
 use PDOException;
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\{Uuid, UuidInterface};
 use ReflectionClass;
 use ReflectionProperty;
 use Revolt\EventLoop;
-
+use Safe\DateTimeImmutable;
 use Throwable;
 
 #[NCA\Instance]
@@ -295,6 +296,8 @@ class DB {
 				$data[$colName] = $data[$colName]->getTimestamp();
 			} elseif ($data[$colName] instanceof BackedEnum) {
 				$data[$colName] = $data[$colName]->value;
+			} elseif ($data[$colName] instanceof UuidInterface) {
+				$data[$colName] = $data[$colName]->toString();
 			}
 		}
 		$table = $this->formatSql($table);
@@ -343,6 +346,8 @@ class DB {
 				$data[$colName] = $data[$colName]->getTimestamp();
 			} elseif ($data[$colName] instanceof BackedEnum) {
 				$data[$colName] = $data[$colName]->value;
+			} elseif ($data[$colName] instanceof UuidInterface) {
+				$data[$colName] = $data[$colName]->toString();
 			}
 		}
 		$table = $this->formatSql($table);
@@ -393,6 +398,8 @@ class DB {
 				$updates[$colName] = $updates[$colName]->getTimestamp();
 			} elseif ($updates[$colName] instanceof BackedEnum) {
 				$updates[$colName] = $updates[$colName]->value;
+			} elseif ($updates[$colName] instanceof UuidInterface) {
+				$updates[$colName] = $updates[$colName]->toString();
 			}
 		}
 		$query = $this->table($table);
@@ -415,6 +422,35 @@ class DB {
 		Registry::injectDependencies($logger);
 		$builder = new SchemaBuilder($schema, $this);
 		return $builder;
+	}
+
+	/** @return array<int,UuidInterface> */
+	public function migrateIdToUuid(string $table, string $column='id', ?string $timeColumn=null): array {
+		$entries = $this->table($table)->orderBy($column)->get();
+		$this->table($table)->truncate();
+		$this->schema()->dropColumns($table, $column);
+		$this->schema()->table($table, static function (Blueprint $table) use ($column): void {
+			$table->uuid($column)->nullable(false)->primary();
+		});
+
+		$result = [];
+
+		/** @return array<string,mixed> */
+		$entries = $entries->map(static function (\stdClass $entry) use ($column, $timeColumn, &$result): array {
+			$time = null;
+			if (isset($timeColumn)) {
+				$time = $entry->{$timeColumn} ?? null;
+			}
+			if (isset($time)) {
+				$time = (new DateTimeImmutable())->setTimestamp($time);
+			}
+			$uuid = Uuid::uuid7($time);
+			$result[(int)$entry->{$column}] = $uuid;
+			$entry->{$column} = $uuid->toString();
+			return (array)$entry;
+		})->toList();
+		$this->table($table)->chunkInsert($entries);
+		return $result;
 	}
 
 	/**

--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -591,6 +591,7 @@ class DB {
 		}
 		$version = $this->fs->getModificationTime($file);
 		$handle = $this->fs->openFile($file, 'r');
+		$uuidCol = null;
 		foreach (splitLines($handle) as $line) {
 			if (substr($line, 0, 1) !== '#') {
 				break;
@@ -606,6 +607,9 @@ class DB {
 					break;
 				case 'version':
 					$version = $value;
+					break;
+				case 'uuid':
+					$uuidCol = $value;
 					break;
 				case 'table':
 					$table = $value;
@@ -654,6 +658,9 @@ class DB {
 				$this->table($table)->delete();
 			}
 			foreach ($csv->items() as $item) {
+				if (isset($uuidCol)) {
+					$item[$uuidCol] ??= Uuid::uuid7();
+				}
 				$itemCount++;
 				$items []= $item;
 				if ((count($items)+1) * count($item) > $this->maxPlaceholders) {

--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -503,10 +503,13 @@ class DB {
 				$table->integer('applied_at');
 			};
 			if ($this->schema()->hasTable($table)) {
-				if (!str_starts_with(strtolower($this->schema()->getColumnType($table, 'id')), 'int')) {
-					continue;
+				$colType = strtolower($this->schema()->getColumnType($table, 'id'));
+				if (str_starts_with($colType, 'int')
+					|| str_ends_with($colType, 'int')
+					|| str_ends_with($colType, 'integer')
+				) {
+					$this->migrateIdToUuid($table, $newSchema, 'id', 'applied_at');
 				}
-				$this->migrateIdToUuid($table, $newSchema, 'id', 'applied_at');
 				continue;
 			}
 			$this->schema()->create($table, $newSchema);

--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -425,13 +425,9 @@ class DB {
 	}
 
 	/** @return array<int,UuidInterface> */
-	public function migrateIdToUuid(string $table, string $column='id', ?string $timeColumn=null): array {
+	public function migrateIdToUuid(string $table, \Closure $callback, string $column='id', ?string $timeColumn=null): array {
+		$this->schema()->create($table . '_tmp', $callback);
 		$entries = $this->table($table)->orderBy($column)->get();
-		$this->table($table)->truncate();
-		$this->schema()->dropColumns($table, $column);
-		$this->schema()->table($table, static function (Blueprint $table) use ($column): void {
-			$table->uuid($column)->nullable(false)->primary();
-		});
 
 		$result = [];
 
@@ -449,7 +445,12 @@ class DB {
 			$entry->{$column} = $uuid->toString();
 			return (array)$entry;
 		})->toList();
-		$this->table($table)->chunkInsert($entries);
+		$this->table($table . '_tmp')->chunkInsert($entries);
+		$this->schema()->drop($table);
+		$this->schema()->rename(
+			$this->formatSql($table . '_tmp'),
+			$this->formatSql($table)
+		);
 		return $result;
 	}
 

--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -496,15 +496,20 @@ class DB {
 
 	public function createMigrationTables(): void {
 		foreach (['migrations', 'migrations_<myname>'] as $table) {
-			if ($this->schema()->hasTable($table)) {
-				continue;
-			}
-			$this->schema()->create($table, static function (Blueprint $table): void {
-				$table->id();
+			$newSchema = static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
 				$table->string('module');
 				$table->string('migration');
 				$table->integer('applied_at');
-			});
+			};
+			if ($this->schema()->hasTable($table)) {
+				if (!str_starts_with(strtolower($this->schema()->getColumnType($table, 'id')), 'int')) {
+					continue;
+				}
+				$this->migrateIdToUuid($table, $newSchema, 'id', 'applied_at');
+				continue;
+			}
+			$this->schema()->create($table, $newSchema);
 		}
 	}
 
@@ -1047,6 +1052,7 @@ class DB {
 			'module' => $mig->module,
 			'migration' => $mig->baseName,
 			'applied_at' => time(),
+			'id' => Uuid::uuid7(),
 		]);
 	}
 }

--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -426,8 +426,9 @@ class DB {
 
 	/** @return array<int,UuidInterface> */
 	public function migrateIdToUuid(string $table, \Closure $callback, string $column='id', ?string $timeColumn=null): array {
-		$this->schema()->create($table . '_tmp', $callback);
 		$entries = $this->table($table)->orderBy($column)->get();
+		$this->schema()->drop($table);
+		$this->schema()->create($table, $callback);
 
 		$result = [];
 
@@ -445,12 +446,7 @@ class DB {
 			$entry->{$column} = $uuid->toString();
 			return (array)$entry;
 		})->toList();
-		$this->table($table . '_tmp')->chunkInsert($entries);
-		$this->schema()->drop($table);
-		$this->schema()->rename(
-			$this->formatSql($table . '_tmp'),
-			$this->formatSql($table)
-		);
+		$this->table($table)->chunkInsert($entries);
 		return $result;
 	}
 

--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -15,7 +15,7 @@ use Illuminate\Database\{
 	Connection,
 	Schema\Blueprint,
 };
-use Illuminate\Support\Collection;
+use Illuminate\Support\{Collection, Fluent};
 use InvalidArgumentException;
 use Nadybot\Core\Attributes\Migration as AttributesMigration;
 use Nadybot\Core\{
@@ -837,6 +837,11 @@ class DB {
 			// @phpstan-ignore-next-line
 			protected function typeFloat(\Illuminate\Support\Fluent $column) {
 				return 'real';
+			}
+
+			// @phpstan-ignore-next-line
+			protected function typeUuid(\Illuminate\Support\Fluent $column) {
+				return 'text';
 			}
 
 			// @phpstan-ignore-next-line

--- a/src/Core/DBSchema/Audit.php
+++ b/src/Core/DBSchema/Audit.php
@@ -4,17 +4,20 @@ namespace Nadybot\Core\DBSchema;
 
 use Nadybot\Core\Attributes\DB\Table;
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 use Safe\DateTimeImmutable;
 
 #[Table(name: 'audit')]
 class Audit extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/**
 	 * @param string            $actor  The person doing something
 	 * @param string            $action What did the actor do
 	 * @param ?string           $actee  The person the actor is interacting with. Not set if not applicable
 	 * @param ?string           $value  Optional value for the action
 	 * @param DateTimeImmutable $time   time when it happened
-	 * @param ?int              $id     ID of this audit entry, or null if not determined yet
+	 * @param ?UuidInterface    $id     ID of this audit entry (if known)
 	 */
 	public function __construct(
 		public string $actor,
@@ -22,7 +25,8 @@ class Audit extends DBTable {
 		public ?string $actee=null,
 		public ?string $value=null,
 		public DateTimeImmutable $time=new DateTimeImmutable(),
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Core/DBSchema/CmdPermSetMapping.php
+++ b/src/Core/DBSchema/CmdPermSetMapping.php
@@ -3,9 +3,12 @@
 namespace Nadybot\Core\DBSchema;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'cmd_permission_set_mapping')]
 class CmdPermSetMapping extends DBTable {
+	#[NCA\JSON\Ignore] #[NCA\DB\PK] public UuidInterface $id;
+
 	/**
 	 * @param string $permission_set  The permission set to map $source to
 	 * @param string $source          The command source to map
@@ -19,7 +22,8 @@ class CmdPermSetMapping extends DBTable {
 		public string $symbol,
 		public bool $symbol_optional=false,
 		public bool $feedback=true,
-		#[NCA\JSON\Ignore] #[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Core/DBSchema/CmdPermission.php
+++ b/src/Core/DBSchema/CmdPermission.php
@@ -3,9 +3,12 @@
 namespace Nadybot\Core\DBSchema;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'cmd_permission')]
 class CmdPermission extends DBTable {
+	#[NCA\JSON\Ignore] #[NCA\DB\PK] public UuidInterface $id;
+
 	/**
 	 * @param string $permission_set The name of the permission-set
 	 * @param string $access_level   The access-level (member,admin,guest,all,etc)
@@ -16,7 +19,8 @@ class CmdPermission extends DBTable {
 		#[NCA\JSON\Ignore] public string $cmd,
 		public string $access_level,
 		public bool $enabled,
-		#[NCA\JSON\Ignore] #[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Core/DBSchema/Migration.php
+++ b/src/Core/DBSchema/Migration.php
@@ -4,15 +4,19 @@ namespace Nadybot\Core\DBSchema;
 
 use Nadybot\Core\Attributes\DB\Shared;
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 use Safe\DateTimeImmutable;
 
 #[NCA\DB\Table(name: 'migrations', shared: Shared::Both)]
 class Migration extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	public function __construct(
 		public string $module,
 		public string $migration,
 		public DateTimeImmutable $applied_at,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7($applied_at);
 	}
 }

--- a/src/Core/DBSchema/Route.php
+++ b/src/Core/DBSchema/Route.php
@@ -3,15 +3,19 @@
 namespace Nadybot\Core\DBSchema;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'route')]
 class Route extends DBTable {
+	/** The unique ID of this route */
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/**
 	 * @param string              $source         The source channel for this route
 	 * @param string              $destination    The destination channel for this route
 	 * @param bool                $two_way        Set to true if this route is also the other way around
 	 * @param ?int                $disabled_until If set, the route is disabled until the set timestamp
-	 * @param ?int                $id             The unique ID of this route
+	 * @param ?UuidInterface      $id             The unique ID of this route (if known)
 	 * @param list<RouteModifier> $modifiers      The modifiers for this route
 	 */
 	public function __construct(
@@ -19,8 +23,9 @@ class Route extends DBTable {
 		public string $destination,
 		public bool $two_way=false,
 		public ?int $disabled_until=null,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 		#[NCA\DB\Ignore] public array $modifiers=[],
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Core/DBSchema/RouteHopColor.php
+++ b/src/Core/DBSchema/RouteHopColor.php
@@ -3,16 +3,19 @@
 namespace Nadybot\Core\DBSchema;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'route_hop_color')]
 class RouteHopColor extends DBTable {
+	#[NCA\JSON\Ignore] #[NCA\DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param string  $hop        The hop mask (discord, *, aopriv, ...)
-	 * @param ?string $where      The channel for which to apply these colors or null for all
-	 * @param ?string $via        Only apply this color if the event was routed via this hop
-	 * @param ?string $tag_color  The 6 hex digits of the tag color, like FFFFFF
-	 * @param ?string $text_color The 6 hex digits of the text color, like FFFFFF
-	 * @param ?int    $id         Internal primary key
+	 * @param string         $hop        The hop mask (discord, *, aopriv, ...)
+	 * @param ?string        $where      The channel for which to apply these colors or null for all
+	 * @param ?string        $via        Only apply this color if the event was routed via this hop
+	 * @param ?string        $tag_color  The 6 hex digits of the tag color, like FFFFFF
+	 * @param ?string        $text_color The 6 hex digits of the text color, like FFFFFF
+	 * @param ?UuidInterface $id         Internal primary key
 	 */
 	public function __construct(
 		public string $hop,
@@ -20,7 +23,8 @@ class RouteHopColor extends DBTable {
 		public ?string $via=null,
 		public ?string $tag_color=null,
 		public ?string $text_color=null,
-		#[NCA\JSON\Ignore] #[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id  ?? Uuid::uuid7();
 	}
 }

--- a/src/Core/DBSchema/RouteHopFormat.php
+++ b/src/Core/DBSchema/RouteHopFormat.php
@@ -3,16 +3,19 @@
 namespace Nadybot\Core\DBSchema;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'route_hop_format')]
 class RouteHopFormat extends DBTable {
+	#[NCA\JSON\Ignore] #[NCA\DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param string  $hop    The hop mask (discord, *, aopriv, ...)
-	 * @param ?string $where  The channel for which to apply these, or null for all
-	 * @param ?string $via    Only apply these settings if the event was routed via this hop
-	 * @param bool    $render Whether to render this tag or not
-	 * @param string  $format The format what the text of the tag should look like
-	 * @param ?int    $id     Internal primary key
+	 * @param string         $hop    The hop mask (discord, *, aopriv, ...)
+	 * @param ?string        $where  The channel for which to apply these, or null for all
+	 * @param ?string        $via    Only apply these settings if the event was routed via this hop
+	 * @param bool           $render Whether to render this tag or not
+	 * @param string         $format The format what the text of the tag should look like
+	 * @param ?UuidInterface $id     Internal primary key
 	 */
 	public function __construct(
 		public string $hop,
@@ -20,7 +23,8 @@ class RouteHopFormat extends DBTable {
 		public ?string $via=null,
 		public bool $render=true,
 		public string $format='%s',
-		#[NCA\JSON\Ignore] #[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Core/DBSchema/RouteModifier.php
+++ b/src/Core/DBSchema/RouteModifier.php
@@ -3,22 +3,26 @@
 namespace Nadybot\Core\DBSchema;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
-use Ramsey\Uuid\UuidInterface;
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'route_modifier')]
 class RouteModifier extends DBTable {
+	/** The id of the route modifier. Lower id means higher priority */
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/**
 	 * @param string                      $modifier  The name of the modifier
-	 * @param ?int                        $id        The id of the route modifier. Lower id means higher priority
-	 * @param ?UuidInterface              $route_id  The id of the route where this modifier belongs to
+	 * @param UuidInterface               $route_id  The id of the route where this modifier belongs to
+	 * @param ?UuidInterface              $id        The id of the route modifier. Lower id means higher priority
 	 * @param list<RouteModifierArgument> $arguments
 	 */
 	public function __construct(
 		public string $modifier,
-		#[NCA\DB\AutoInc] public ?int $id=null,
-		public ?UuidInterface $route_id=null,
+		public UuidInterface $route_id,
+		?UuidInterface $id=null,
 		#[NCA\DB\Ignore] public array $arguments=[],
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 
 	public function toString(bool $asLink=false): string {

--- a/src/Core/DBSchema/RouteModifier.php
+++ b/src/Core/DBSchema/RouteModifier.php
@@ -3,19 +3,20 @@
 namespace Nadybot\Core\DBSchema;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\UuidInterface;
 
 #[NCA\DB\Table(name: 'route_modifier')]
 class RouteModifier extends DBTable {
 	/**
 	 * @param string                      $modifier  The name of the modifier
 	 * @param ?int                        $id        The id of the route modifier. Lower id means higher priority
-	 * @param ?int                        $route_id  The id of the route where this modifier belongs to
+	 * @param ?UuidInterface              $route_id  The id of the route where this modifier belongs to
 	 * @param list<RouteModifierArgument> $arguments
 	 */
 	public function __construct(
 		public string $modifier,
 		#[NCA\DB\AutoInc] public ?int $id=null,
-		public ?int $route_id=null,
+		public ?UuidInterface $route_id=null,
 		#[NCA\DB\Ignore] public array $arguments=[],
 	) {
 	}

--- a/src/Core/DBSchema/RouteModifierArgument.php
+++ b/src/Core/DBSchema/RouteModifierArgument.php
@@ -4,21 +4,25 @@ namespace Nadybot\Core\DBSchema;
 
 use function Safe\{json_encode, preg_match};
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'route_modifier_argument')]
 class RouteModifierArgument extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param string $name              The name of the argument
-	 * @param string $value             The value of the argument
-	 * @param ?int   $route_modifier_id The id of the route modifier where this argument belongs to
-	 * @param ?int   $id                The id of the argument
+	 * @param string         $name              The name of the argument
+	 * @param string         $value             The value of the argument
+	 * @param UuidInterface  $route_modifier_id The id of the route modifier where this argument belongs to
+	 * @param ?UuidInterface $id                The id of the argument
 	 */
 	public function __construct(
 		public string $name,
 		public string $value,
-		public ?int $route_modifier_id=null,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		public UuidInterface $route_modifier_id,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 
 	public function toString(): string {

--- a/src/Core/MessageHub.php
+++ b/src/Core/MessageHub.php
@@ -601,7 +601,7 @@ class MessageHub {
 		foreach ($this->routes as $source => $destData) {
 			foreach ($destData as $dest => $routes) {
 				foreach ($routes as $route) {
-					$allRoutes [$route->getID()] = $route;
+					$allRoutes [$route->getID()->toString()] = $route;
 				}
 			}
 		}
@@ -632,13 +632,14 @@ class MessageHub {
 		}, $routes);
 	}
 
-	public function deleteRouteID(int $id): ?MessageRoute {
+	public function deleteRouteID(\Stringable|string $id): ?MessageRoute {
+		$id = (string)$id;
 		$result = null;
 		foreach ($this->routes as $source => $destData) {
 			foreach ($destData as $dest => $routes) {
 				for ($i = 0; $i < count($routes); $i++) {
 					$route = $routes[0];
-					if ($route->getID() !== $id) {
+					if ((string)$route->getID() !== $id) {
 						continue;
 					}
 					$result = $route;

--- a/src/Core/MessageRoute.php
+++ b/src/Core/MessageRoute.php
@@ -2,12 +2,12 @@
 
 namespace Nadybot\Core;
 
-use InvalidArgumentException;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\DBSchema\Route;
 use Nadybot\Core\Routing\RoutableEvent;
 use Nadybot\Core\Types\EventModifier;
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\UuidInterface;
 use Throwable;
 
 class MessageRoute {
@@ -18,13 +18,9 @@ class MessageRoute {
 	private LoggerInterface $logger;
 
 	public function __construct(private Route $route) {
-		if (!isset($route->id)) {
-			throw new InvalidArgumentException(__CLASS__ . '(): Argument #1 ($route) must have an id');
-		}
 	}
 
-	public function getID(): int {
-		assert(isset($this->route->id));
+	public function getID(): UuidInterface {
 		return $this->route->id;
 	}
 

--- a/src/Core/Migrations/MigrateAuditToUuids.php
+++ b/src/Core/Migrations/MigrateAuditToUuids.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core\Migrations;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\DBSchema\Audit;
+use Nadybot\Core\{DB, SchemaMigration};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_09_07_01)]
+class MigrateAuditToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$table = Audit::getTable();
+		$db->migrateIdToUuid($table, 'id', 'time');
+	}
+}

--- a/src/Core/Migrations/MigrateAuditToUuids.php
+++ b/src/Core/Migrations/MigrateAuditToUuids.php
@@ -2,6 +2,7 @@
 
 namespace Nadybot\Core\Migrations;
 
+use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\DBSchema\Audit;
 use Nadybot\Core\{DB, SchemaMigration};
@@ -10,7 +11,18 @@ use Psr\Log\LoggerInterface;
 #[NCA\Migration(order: 2024_08_01_09_07_01)]
 class MigrateAuditToUuids implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$table = Audit::getTable();
-		$db->migrateIdToUuid($table, 'id', 'time');
+		$db->migrateIdToUuid(
+			Audit::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('actor', 12)->index();
+				$table->string('actee', 12)->nullable()->index();
+				$table->string('action', 20)->index();
+				$table->text('value')->nullable();
+				$table->integer('time')->index();
+			},
+			'id',
+			'time'
+		);
 	}
 }

--- a/src/Core/Migrations/MigrateCmdPermissionToUuids.php
+++ b/src/Core/Migrations/MigrateCmdPermissionToUuids.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\DBSchema\CmdPermission;
+use Nadybot\Core\{DB, SchemaMigration};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_15_15_00)]
+class MigrateCmdPermissionToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			CmdPermission::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('permission_set', 50)->index();
+				$table->string('cmd', 50)->index();
+				$table->boolean('enabled')->default(false);
+				$table->string('access_level', 30);
+				$table->unique(['cmd', 'permission_set']);
+			},
+			'id'
+		);
+	}
+}

--- a/src/Core/Migrations/MigratePermissionSetMappingToUuids.php
+++ b/src/Core/Migrations/MigratePermissionSetMappingToUuids.php
@@ -2,6 +2,7 @@
 
 namespace Nadybot\Core\Migrations;
 
+use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\DBSchema\{CmdPermSetMapping};
 use Nadybot\Core\{DB, SchemaMigration};
@@ -10,7 +11,17 @@ use Psr\Log\LoggerInterface;
 #[NCA\Migration(order: 2024_08_01_10_44_17)]
 class MigratePermissionSetMappingToUuids implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$table = CmdPermSetMapping::getTable();
-		$db->migrateIdToUuid($table, 'id');
+		$db->migrateIdToUuid(
+			CmdPermSetMapping::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('permission_set', 50);
+				$table->string('source', 100)->unique();
+				$table->string('symbol', 1)->default('!');
+				$table->boolean('symbol_optional')->default(false);
+				$table->boolean('feedback')->default(true);
+			},
+			'id',
+		);
 	}
 }

--- a/src/Core/Migrations/MigratePermissionSetMappingToUuids.php
+++ b/src/Core/Migrations/MigratePermissionSetMappingToUuids.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core\Migrations;
+
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\DBSchema\{CmdPermSetMapping};
+use Nadybot\Core\{DB, SchemaMigration};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_10_44_17)]
+class MigratePermissionSetMappingToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$table = CmdPermSetMapping::getTable();
+		$db->migrateIdToUuid($table, 'id');
+	}
+}

--- a/src/Core/Migrations/MigrateRouteHopColorToUuids.php
+++ b/src/Core/Migrations/MigrateRouteHopColorToUuids.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\DBSchema\RouteHopColor;
+use Nadybot\Core\{DB, SchemaMigration};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_15_35_00)]
+class MigrateRouteHopColorToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			RouteHopColor::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('hop', 50)->default('*');
+				$table->string('where', 50)->nullable(true);
+				$table->string('via', 50)->nullable(true);
+				$table->string('tag_color', 6)->nullable(true);
+				$table->string('text_color', 6)->nullable(true);
+				$table->unique(['hop', 'where', 'via']);
+			}
+		);
+	}
+}

--- a/src/Core/Migrations/MigrateRouteHopFormatToUuids.php
+++ b/src/Core/Migrations/MigrateRouteHopFormatToUuids.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\DBSchema\RouteHopFormat;
+use Nadybot\Core\{DB, SchemaMigration};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_15_55_00)]
+class MigrateRouteHopFormatToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			RouteHopFormat::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('hop', 50);
+				$table->string('where', 50)->nullable(true);
+				$table->string('via', 50)->nullable(true);
+				$table->boolean('render')->default(true);
+				$table->string('format', 50)->default('%s');
+				$table->unique(['hop', 'where', 'via']);
+			},
+			'id'
+		);
+	}
+}

--- a/src/Core/Migrations/MigrateRouteTableToUuids.php
+++ b/src/Core/Migrations/MigrateRouteTableToUuids.php
@@ -11,7 +11,16 @@ use Psr\Log\LoggerInterface;
 #[NCA\Migration(order: 2024_08_01_11_05_00)]
 class MigrateRouteTableToUuids implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$idMapping = $db->migrateIdToUuid(Route::getTable(), 'id');
+		$idMapping = $db->migrateIdToUuid(
+			Route::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('source', 100);
+				$table->string('destination', 100);
+				$table->boolean('two_way')->default(false);
+				$table->unsignedInteger('disabled_until')->nullable(true);
+			}
+		);
 
 		$table = RouteModifier::getTable();
 		$entries = $db->table($table)->get();

--- a/src/Core/Migrations/MigrateRouteTableToUuids.php
+++ b/src/Core/Migrations/MigrateRouteTableToUuids.php
@@ -4,13 +4,19 @@ namespace Nadybot\Core\Migrations;
 
 use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
-use Nadybot\Core\DBSchema\{Route, RouteModifier};
+use Nadybot\Core\DBSchema\{Route, RouteModifier, RouteModifierArgument};
 use Nadybot\Core\{DB, SchemaMigration};
 use Psr\Log\LoggerInterface;
 
 #[NCA\Migration(order: 2024_08_01_11_05_00)]
 class MigrateRouteTableToUuids implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
+		$this->migrateRouteTable($logger, $db);
+		$this->migrateRouteModifierTable($logger, $db);
+		$this->migrateRouteModifierArgumentTable($logger, $db);
+	}
+
+	public function migrateRouteTable(LoggerInterface $logger, DB $db): void {
 		$idMapping = $db->migrateIdToUuid(
 			Route::getTable(),
 			static function (Blueprint $table): void {
@@ -36,5 +42,43 @@ class MigrateRouteTableToUuids implements SchemaMigration {
 			return (array)$entry;
 		})->toList();
 		$db->table($table)->chunkInsert($entries);
+	}
+
+	public function migrateRouteModifierTable(LoggerInterface $logger, DB $db): void {
+		$idMapping = $db->migrateIdToUuid(
+			RouteModifier::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->uuid('route_id')->index();
+				$table->string('modifier', 100);
+			},
+		);
+
+		$table = RouteModifierArgument::getTable();
+		$entries = $db->table($table)->get();
+		$db->table($table)->truncate();
+		$db->schema()->dropColumns($table, 'route_modifier_id');
+		$db->schema()->table($table, static function (Blueprint $table): void {
+			$table->uuid('route_modifier_id')->nullable(false)->index();
+		});
+
+		/** @return array<string,mixed> */
+		$entries = $entries->map(static function (\stdClass $entry) use ($idMapping): array {
+			$entry->route_modifier_id = $idMapping[(int)$entry->route_modifier_id];
+			return (array)$entry;
+		})->toList();
+		$db->table($table)->chunkInsert($entries);
+	}
+
+	public function migrateRouteModifierArgumentTable(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			RouteModifierArgument::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->uuid('route_modifier_id')->index();
+				$table->string('name', 100);
+				$table->string('value', 200);
+			}
+		);
 	}
 }

--- a/src/Core/Migrations/MigrateRouteTableToUuids.php
+++ b/src/Core/Migrations/MigrateRouteTableToUuids.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\DBSchema\{Route, RouteModifier};
+use Nadybot\Core\{DB, SchemaMigration};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_11_05_00)]
+class MigrateRouteTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$idMapping = $db->migrateIdToUuid(Route::getTable(), 'id');
+
+		$table = RouteModifier::getTable();
+		$entries = $db->table($table)->get();
+		$db->table($table)->truncate();
+		$db->schema()->dropColumns($table, 'route_id');
+		$db->schema()->table($table, static function (Blueprint $table): void {
+			$table->uuid('route_id')->nullable(false)->index();
+		});
+
+		/** @return array<string,mixed> */
+		$entries = $entries->map(static function (\stdClass $entry) use ($idMapping): array {
+			$entry->route_id = $idMapping[(int)$entry->route_id];
+			return (array)$entry;
+		})->toList();
+		$db->table($table)->chunkInsert($entries);
+	}
+}

--- a/src/Core/Modules/COLORS/ColorsController.php
+++ b/src/Core/Modules/COLORS/ColorsController.php
@@ -286,8 +286,7 @@ class ColorsController extends ModuleInstance {
 			if (isset($colorDef->id)) {
 				$success = $this->db->update($colorDef) > 0;
 			} else {
-				$colorDef->id = $this->db->insert($colorDef);
-				$success = $colorDef->id > 0;
+				$success = $this->db->insert($colorDef) > 0;
 			}
 			$this->msgHub->loadTagColor();
 		} catch (Exception) {

--- a/src/Core/Modules/CONFIG/ConfigApiController.php
+++ b/src/Core/Modules/CONFIG/ConfigApiController.php
@@ -769,7 +769,7 @@ class ConfigApiController extends ModuleInstance {
 			}
 			$map = $decoded->toPermSetMapping();
 			try {
-				$map->id = $this->db->insert($map);
+				$this->db->insert($map);
 			} catch (SQLException $e) {
 				return new Response(
 					HttpStatus::INTERNAL_SERVER_ERROR,
@@ -819,7 +819,7 @@ class ConfigApiController extends ModuleInstance {
 			$map = $decoded->toPermSetMapping();
 			$map->id = $old->id;
 			try {
-				$map->id = $this->db->update($map);
+				$this->db->update($map);
 			} catch (SQLException $e) {
 				return new Response(
 					HttpStatus::INTERNAL_SERVER_ERROR,

--- a/src/Core/Modules/CONFIG/PermissionSetMappingController.php
+++ b/src/Core/Modules/CONFIG/PermissionSetMappingController.php
@@ -119,7 +119,7 @@ class PermissionSetMappingController extends ModuleInstance {
 			symbol: $this->settingManager->getString('symbol') ?? '!',
 		);
 		try {
-			$map->id = $this->db->insert($map);
+			$this->db->insert($map);
 		} catch (SQLException) {
 			$context->reply('There was an error saving your mapping into the database.');
 			return;

--- a/src/Core/Modules/MESSAGES/MessageHubController.php
+++ b/src/Core/Modules/MESSAGES/MessageHubController.php
@@ -32,6 +32,7 @@ use Nadybot\Core\{
 	Util,
 };
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\UuidInterface;
 use ReflectionClass;
 use ReflectionException;
 use Safe\Exceptions\JsonException;
@@ -106,10 +107,8 @@ class MessageHubController extends ModuleInstance {
 			->orderBy('id')
 			->asObj(Route::class)
 			->each(function (Route $route) use ($modifiers): void {
-				assert(isset($route->id));
-
 				/** @var list<RouteModifier> */
-				$routeModifiers = $modifiers->get($route->id, new Collection())->toList();
+				$routeModifiers = $modifiers->get($route->id->toString(), new Collection())->toList();
 				$route->modifiers = $routeModifiers;
 				try {
 					$msgRoute = $this->messageHub->createMessageRoute($route);
@@ -133,12 +132,12 @@ class MessageHubController extends ModuleInstance {
 	public function routeMuteIdCommand(
 		CmdContext $context,
 		#[NCA\Str('mute', 'disable')] string $action,
-		int $id,
+		string $id,
 		#[NCA\PDuration] #[NCA\Str('off')] string $duration
 	): void {
 		$route = $this->getMsgRoute($id);
 		if (!isset($route)) {
-			$context->reply("No route <highlight>#{$id}<end> found.");
+			$context->reply("No route <highlight>{$id}<end> found.");
 			return;
 		}
 		$from = $route->getSource();
@@ -174,11 +173,11 @@ class MessageHubController extends ModuleInstance {
 	public function routeMuteCommand(
 		CmdContext $context,
 		#[NCA\Str('mute', 'disable')] string $action,
-		int $id,
+		string $id,
 	): void {
 		$route = $this->getMsgRoute($id);
 		if (!isset($route)) {
-			$context->reply("No route <highlight>#{$id}<end> found.");
+			$context->reply("No route <highlight>{$id}<end> found.");
 			return;
 		}
 		$durations = [60, 300, 600, 1_800, 3_600, 6*3_600, 24*3_600];
@@ -282,7 +281,7 @@ class MessageHubController extends ModuleInstance {
 
 		/** @var ?list<RouteModifier> $modifiers */
 		try {
-			$route->id = $this->db->insert($route);
+			$this->db->insert($route);
 			foreach ($modifiers??[] as $modifier) {
 				$modifier->route_id = $route->id;
 				$modifier->id = $this->db->insert($modifier);
@@ -439,10 +438,10 @@ class MessageHubController extends ModuleInstance {
 
 	/** Delete a route by its ID */
 	#[NCA\HandlesCommand('route')]
-	public function routeDel(CmdContext $context, PRemove $action, int $id): void {
+	public function routeDel(CmdContext $context, PRemove $action, string $id): void {
 		$route = $this->getRoute($id);
 		if (!isset($route)) {
-			$context->reply("No route <highlight>#{$id}<end> found.");
+			$context->reply("No route <highlight>{$id}<end> found.");
 			return;
 		}
 
@@ -472,7 +471,7 @@ class MessageHubController extends ModuleInstance {
 				"Route #{$id} (" . trim($this->renderRoute($deleted)) . ') deleted.'
 			);
 		} else {
-			$context->reply("Route <highlight>#{$id}<end> deleted.");
+			$context->reply("Route <highlight>{$id}<end> deleted.");
 		}
 	}
 
@@ -1057,10 +1056,10 @@ class MessageHubController extends ModuleInstance {
 			});
 	}
 
-	public function getRoute(int $id): ?Route {
+	public function getRoute(\Stringable|string $id): ?Route {
 		/** @var Route|null */
 		$route = $this->db->table(Route::getTable())
-			->where('id', $id)
+			->where('id', (string)$id)
 			->limit(1)
 			->asObj(Route::class)
 			->first();
@@ -1068,7 +1067,7 @@ class MessageHubController extends ModuleInstance {
 			return null;
 		}
 		$route->modifiers = $this->db->table(RouteModifier::getTable())
-		->where('route_id', $id)
+		->where('route_id', (string)$id)
 		->orderBy('id')
 		->asObjArr(RouteModifier::class);
 		foreach ($route->modifiers as $modifier) {
@@ -1080,10 +1079,10 @@ class MessageHubController extends ModuleInstance {
 		return $route;
 	}
 
-	public function getMsgRoute(int $id): ?MessageRoute {
+	public function getMsgRoute(UuidInterface|string $id): ?MessageRoute {
 		$routes = $this->messageHub->getRoutes();
 		foreach ($routes as $route) {
-			if ($route->getID() === $id) {
+			if ((string)$route->getID() === (string)$id) {
 				return $route;
 			}
 		}

--- a/src/Core/Modules/MESSAGES/MessageHubController.php
+++ b/src/Core/Modules/MESSAGES/MessageHubController.php
@@ -448,7 +448,8 @@ class MessageHubController extends ModuleInstance {
 
 	/** Delete a route by its ID */
 	#[NCA\HandlesCommand('route')]
-	public function routeDel(CmdContext $context, PRemove $action, string $id): void {
+	public function routeDel(CmdContext $context, PRemove $action, PUuid $id): void {
+		$id = $id();
 		$route = $this->getRoute($id);
 		if (!isset($route)) {
 			$context->reply("No route <highlight>{$id}<end> found.");

--- a/src/Core/Modules/MESSAGES/MessageHubController.php
+++ b/src/Core/Modules/MESSAGES/MessageHubController.php
@@ -787,7 +787,7 @@ class MessageHubController extends ModuleInstance {
 		if (isset($colorDef->id)) {
 			$this->db->update($colorDef);
 		} else {
-			$colorDef->id = $this->db->insert($colorDef);
+			$this->db->insert($colorDef);
 			$this->messageHub->loadTagColor();
 		}
 		$context->reply(
@@ -997,12 +997,8 @@ class MessageHubController extends ModuleInstance {
 			);
 		}
 		$format->render = $state;
-		if (isset($format->id)) {
-			$this->db->update($format);
-		} else {
-			$format->id = $this->db->insert($format);
-			$this->messageHub->loadTagFormat();
-		}
+		$this->db->upsert($format);
+		$this->messageHub->loadTagFormat();
 	}
 
 	/** Define how to render a specific hop */
@@ -1016,12 +1012,8 @@ class MessageHubController extends ModuleInstance {
 			$spec = new RouteHopFormat(hop: $hop);
 		}
 		$spec->format = $format;
-		if (isset($spec->id)) {
-			$this->db->update($spec);
-		} else {
-			$spec->id = $this->db->insert($spec);
-			$this->messageHub->loadTagFormat();
-		}
+		$this->db->upsert($spec);
+		$this->messageHub->loadTagFormat();
 	}
 
 	public function clearHopFormat(string $hop): bool {

--- a/src/Core/Modules/MESSAGES/MessageHubController.php
+++ b/src/Core/Modules/MESSAGES/MessageHubController.php
@@ -96,10 +96,8 @@ class MessageHubController extends ModuleInstance {
 			->orderBy('id')
 			->asObj(RouteModifier::class)
 			->each(static function (RouteModifier $mod) use ($arguments): void {
-				assert(isset($mod->id));
-
 				/** @var list<RouteModifierArgument> */
-				$modArguments = $arguments->get($mod->id, new Collection())->toList();
+				$modArguments = $arguments->get($mod->id->toString(), new Collection())->toList();
 				$mod->arguments = $modArguments;
 			})
 			->groupBy('route_id');
@@ -272,7 +270,7 @@ class MessageHubController extends ModuleInstance {
 		if (isset($modifiers)) {
 			$parser = new ModifierExpressionParser();
 			try {
-				$modifiers = $parser->parse($modifiers);
+				$modifiers = $parser->parse($route, $modifiers);
 			} catch (ModifierParserException $e) {
 				$context->reply($e->getMessage());
 				return;
@@ -280,14 +278,13 @@ class MessageHubController extends ModuleInstance {
 		}
 
 		/** @var ?list<RouteModifier> $modifiers */
+		$this->db->awaitBeginTransaction();
 		try {
 			$this->db->insert($route);
 			foreach ($modifiers??[] as $modifier) {
-				$modifier->route_id = $route->id;
-				$modifier->id = $this->db->insert($modifier);
+				$this->db->insert($modifier);
 				foreach ($modifier->arguments as $argument) {
-					$argument->route_modifier_id = $modifier->id;
-					$argument->id = $this->db->insert($argument);
+					$this->db->insert($argument);
 				}
 				$route->modifiers []= $modifier;
 			}

--- a/src/Core/Modules/MESSAGES/MessageHubController.php
+++ b/src/Core/Modules/MESSAGES/MessageHubController.php
@@ -8,6 +8,7 @@ use function Safe\{json_encode, preg_match};
 use Exception;
 use Illuminate\Support\Collection;
 use Monolog\Logger;
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	Attributes as NCA,
 	Channels\DiscordChannel,
@@ -130,9 +131,10 @@ class MessageHubController extends ModuleInstance {
 	public function routeMuteIdCommand(
 		CmdContext $context,
 		#[NCA\Str('mute', 'disable')] string $action,
-		string $id,
+		PUuid $id,
 		#[NCA\PDuration] #[NCA\Str('off')] string $duration
 	): void {
+		$id = $id();
 		$route = $this->getMsgRoute($id);
 		if (!isset($route)) {
 			$context->reply("No route <highlight>{$id}<end> found.");
@@ -171,8 +173,9 @@ class MessageHubController extends ModuleInstance {
 	public function routeMuteCommand(
 		CmdContext $context,
 		#[NCA\Str('mute', 'disable')] string $action,
-		string $id,
+		PUuid $id,
 	): void {
+		$id = $id();
 		$route = $this->getMsgRoute($id);
 		if (!isset($route)) {
 			$context->reply("No route <highlight>{$id}<end> found.");

--- a/src/Core/Modules/MESSAGES/MessageHubController.php
+++ b/src/Core/Modules/MESSAGES/MessageHubController.php
@@ -280,8 +280,12 @@ class MessageHubController extends ModuleInstance {
 			}
 		}
 
+		$inTransaction = $this->db->inTransaction();
+
 		/** @var ?list<RouteModifier> $modifiers */
-		$this->db->awaitBeginTransaction();
+		if (!$inTransaction) {
+			$this->db->awaitBeginTransaction();
+		}
 		try {
 			$this->db->insert($route);
 			foreach ($modifiers??[] as $modifier) {
@@ -292,7 +296,9 @@ class MessageHubController extends ModuleInstance {
 				$route->modifiers []= $modifier;
 			}
 		} catch (Throwable $e) {
-			$this->db->rollback();
+			if (!$inTransaction) {
+				$this->db->rollback();
+			}
 			$context->reply('Error saving the route: ' . $e->getMessage());
 			return;
 		}
@@ -303,11 +309,15 @@ class MessageHubController extends ModuleInstance {
 		try {
 			$msgRoute = $this->messageHub->createMessageRoute($route);
 		} catch (Exception $e) {
-			$this->db->rollback();
+			if (!$inTransaction) {
+				$this->db->rollback();
+			}
 			$context->reply($e->getMessage());
 			return;
 		}
-		$this->db->commit();
+		if (!$inTransaction) {
+			$this->db->commit();
+		}
 		$this->messageHub->addRoute($msgRoute);
 		$context->reply(
 			"Route added from <highlight>{$from}<end> ".

--- a/src/Core/Modules/PROFILE/ProfileController.php
+++ b/src/Core/Modules/PROFILE/ProfileController.php
@@ -467,7 +467,7 @@ class ProfileController extends ModuleInstance {
 			foreach ($set->mappings as $mapping) {
 				$map = new CmdPermSetMapping(...get_object_vars($mapping));
 				$map->permission_set = $set->name;
-				$map->id = $this->db->insert($map);
+				$this->db->insert($map);
 				$reply->reply(
 					"Mapped <highlight>{$map->source}<end> ".
 					"to <highlight>{$map->permission_set}<end> ".

--- a/src/Core/Modules/PROFILE/ProfileController.php
+++ b/src/Core/Modules/PROFILE/ProfileController.php
@@ -36,6 +36,7 @@ use Nadybot\Core\{
 };
 use Nadybot\Modules\RELAY_MODULE\RelayController;
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @author Tyrence (RK2)
@@ -465,6 +466,9 @@ class ProfileController extends ModuleInstance {
 				"with letter <highlight>{$set->letter}<end>."
 			);
 			foreach ($set->mappings as $mapping) {
+				/** @var string */
+				$id = $mapping->id;
+				$mapping->id = Uuid::fromString($id);
 				$map = new CmdPermSetMapping(...get_object_vars($mapping));
 				$map->permission_set = $set->name;
 				$this->db->insert($map);

--- a/src/Core/ParamClass/PUuid.php
+++ b/src/Core/ParamClass/PUuid.php
@@ -2,8 +2,12 @@
 
 namespace Nadybot\Core\ParamClass;
 
+use function Safe\preg_match;
+
+use Nadybot\Core\Exceptions\UserException;
+
 class PUuid extends Base {
-	protected static string $regExp = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+	protected static string $regExp = '[0-9a-fA-F-]+';
 	protected string $value;
 
 	public function __construct(string $value) {
@@ -11,10 +15,13 @@ class PUuid extends Base {
 	}
 
 	public function __invoke(): string {
-		return $this->value;
+		return (string)$this;
 	}
 
 	public function __toString(): string {
+		if (!preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $this->value)) {
+			throw new UserException("<highlight>{$this->value}<end> is not a valid UUID.");
+		}
 		return $this->value;
 	}
 }

--- a/src/Core/ParamClass/PUuid.php
+++ b/src/Core/ParamClass/PUuid.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core\ParamClass;
+
+class PUuid extends Base {
+	protected static string $regExp = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+	protected string $value;
+
+	public function __construct(string $value) {
+		$this->value = strtolower($value);
+	}
+
+	public function __invoke(): string {
+		return $this->value;
+	}
+
+	public function __toString(): string {
+		return $this->value;
+	}
+}

--- a/src/Core/QueryBuilder.php
+++ b/src/Core/QueryBuilder.php
@@ -36,8 +36,20 @@ class QueryBuilder extends Builder {
 	 * @return Collection<int,T>
 	 */
 	public function asObj(string $class): Collection {
-		/** @var list<T> */
-		$result = $this->fetchAll($class, $this->toSql(), ...$this->getBindings());
+		try {
+			/** @var list<T> */
+			$result = $this->fetchAll($class, $this->toSql(), ...$this->getBindings());
+		} catch (SQLException $e) {
+			$errorInfo = $e->getPrevious()?->errorInfo ?? [''];
+			if ($errorInfo[0] === '22003') { // Numeric value out of range
+				$this->logger->notice('{message}', [
+					'message' => str_replace('ERROR:  ', '', $e->getMessage()),
+					'exception' => $e,
+				]);
+				return Collection::make([]);
+			}
+			throw $e;
+		}
 
 		/** @var Collection<int,T> $x */
 		$x = collect($result);
@@ -395,7 +407,7 @@ class QueryBuilder extends Builder {
 				$conn->reconnect();
 				return $this->executeQuery(...func_get_args());
 			}
-			throw new SQLException("Error: {$e->errorInfo[2]}\nQuery: {$sql}\nParams: " . json_encode($params, \JSON_PRETTY_PRINT|\JSON_UNESCAPED_SLASHES), 0, $e);
+			throw new SQLException("{$e->errorInfo[2]}\nQuery: {$sql}\nParams: " . json_encode($params, \JSON_PRETTY_PRINT|\JSON_UNESCAPED_SLASHES), 0, $e);
 		}
 	}
 

--- a/src/Core/QueryBuilder.php
+++ b/src/Core/QueryBuilder.php
@@ -14,6 +14,7 @@ use PDO;
 use PDOException;
 use PDOStatement;
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\{Uuid, UuidInterface};
 use ReflectionClass;
 use ReflectionException;
 use ReflectionNamedType;
@@ -289,6 +290,8 @@ class QueryBuilder extends Builder {
 						$row[$colName] = (new DateTimeImmutable())->setTimestamp((int)$values[$col]);
 					} elseif ($type === \DateTimeInterface::class) {
 						$row[$colName] = (new DateTimeImmutable())->setTimestamp((int)$values[$col]);
+					} elseif ($type === UuidInterface::class) {
+						$row[$colName] = Uuid::fromString($values[$col]);
 					} elseif (is_a($type, \BackedEnum::class, true)) {
 						$row[$colName] = $type::from($values[$col]);
 					} else {

--- a/src/Core/SubcommandManager.php
+++ b/src/Core/SubcommandManager.php
@@ -11,6 +11,7 @@ use Nadybot\Core\{
 	DBSchema\CmdPermission,
 };
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
 
 #[NCA\Instance]
 class SubcommandManager {
@@ -99,6 +100,7 @@ class SubcommandManager {
 						'access_level' => $accessLevel,
 						'cmd' => $command,
 						'enabled' => (bool)$status,
+						'id' => Uuid::uuid7(),
 					],
 				);
 		}

--- a/src/Modules/BANK_MODULE/Migrations/MigrateWishlistsToUuids.php
+++ b/src/Modules/BANK_MODULE/Migrations/MigrateWishlistsToUuids.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\BANK_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\BANK_MODULE\{Wish, WishFulfilment};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_16_54_21, shared: true)]
+class MigrateWishlistsToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$idMapping = $db->migrateIdToUuid(
+			Wish::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->unsignedInteger('created_on');
+				$table->unsignedInteger('expires_on')->nullable(true);
+				$table->string('created_by', 12)->index();
+				$table->string('item', 200);
+				$table->unsignedInteger('amount')->default(1);
+				$table->string('from', 12)->nullable(true)->index();
+				$table->boolean('fulfilled')->default(false)->index();
+			}
+		);
+
+		$table = WishFulfilment::getTable();
+		$entries = $db->table($table)->get();
+		$db->table($table)->truncate();
+		$db->schema()->dropColumns($table, 'wish_id');
+		$db->schema()->table($table, static function (Blueprint $table): void {
+			$table->uuid('wish_id')->index();
+		});
+
+		/** @return array<string,mixed> */
+		$entries = $entries->map(static function (\stdClass $entry) use ($idMapping): array {
+			$entry->wish_id = $idMapping[(int)$entry->wish_id];
+			return (array)$entry;
+		})->toList();
+		$db->table($table)->chunkInsert($entries);
+
+		$db->migrateIdToUuid(
+			WishFulfilment::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->uuid('wish_id')->index();
+				$table->unsignedInteger('amount')->default(1);
+				$table->unsignedInteger('fulfilled_on');
+				$table->string('fulfilled_by', 12);
+			},
+			'id',
+			'fulfilled_on',
+		);
+	}
+}

--- a/src/Modules/BANK_MODULE/Wish.php
+++ b/src/Modules/BANK_MODULE/Wish.php
@@ -4,10 +4,13 @@ namespace Nadybot\Modules\BANK_MODULE;
 
 use Illuminate\Support\Collection;
 use Nadybot\Core\{Attributes\DB, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[DB\Table(name: 'wishlist', shared: DB\Shared::Yes)]
 class Wish extends DBTable {
 	public int $created_on;
+	#[DB\PK] public UuidInterface $id;
 
 	/** @var Collection<int,WishFulfilment> */
 	#[DB\Ignore]
@@ -21,10 +24,15 @@ class Wish extends DBTable {
 		public int $amount=1,
 		public ?string $from=null,
 		public bool $fulfilled=false,
-		#[DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
 		$this->created_on = $created_on ?? time();
+		$dt = null;
+		if (isset($created_on) && !isset($id)) {
+			$dt = (new DateTimeImmutable())->setTimestamp($created_on);
+		}
 		$this->fulfilments = new Collection();
+		$this->id = $id ?? Uuid::uuid7($dt);
 	}
 
 	/** Get how many items are still needed */

--- a/src/Modules/BANK_MODULE/WishFulfilment.php
+++ b/src/Modules/BANK_MODULE/WishFulfilment.php
@@ -3,18 +3,26 @@
 namespace Nadybot\Modules\BANK_MODULE;
 
 use Nadybot\Core\{Attributes\DB, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable as SafeDateTimeImmutable;
 
 #[DB\Table(name: 'wishlist_fulfilment', shared: DB\Shared::Yes)]
 class WishFulfilment extends DBTable {
+	#[DB\PK] public UuidInterface $id;
 	public int $fulfilled_on;
 
 	public function __construct(
-		public int $wish_id,
+		public UuidInterface $wish_id,
 		public string $fulfilled_by,
 		public int $amount=1,
 		?int $fulfilled_on=null,
-		#[DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
 		$this->fulfilled_on = $fulfilled_on ?? time();
+		$dt = null;
+		if (isset($fulfilled_on) && !isset($id)) {
+			$dt = (new SafeDateTimeImmutable())->setTimestamp($fulfilled_on);
+		}
+		$this->id = $id ?? Uuid::uuid7($dt);
 	}
 }

--- a/src/Modules/BANK_MODULE/WishlistController.php
+++ b/src/Modules/BANK_MODULE/WishlistController.php
@@ -4,7 +4,7 @@ namespace Nadybot\Modules\BANK_MODULE;
 
 use Illuminate\Support\Collection;
 use Nadybot\Core\Modules\ALTS\AltsController;
-use Nadybot\Core\ParamClass\{PCharacter, PDuration, PQuantity, PRemove};
+use Nadybot\Core\ParamClass\{PCharacter, PDuration, PQuantity, PRemove, PUuid};
 use Nadybot\Core\{
 	Attributes as NCA,
 	BuddylistManager,
@@ -518,8 +518,9 @@ class WishlistController extends ModuleInstance {
 	public function removeFromWishlistCommand(
 		CmdContext $context,
 		PRemove $action,
-		string $id,
+		PUuid $id,
 	): void {
+		$id = $id();
 		$mainChar = $this->altsController->getMainOf($context->char->name);
 		$alts = $this->altsController->getAltsOf($mainChar);
 
@@ -628,8 +629,9 @@ class WishlistController extends ModuleInstance {
 		CmdContext $context,
 		#[NCA\Str('fulfil', 'fulfill', 'fullfil', 'fullfill')] string $action,
 		?PQuantity $amount,
-		string $id,
+		PUuid $id,
 	): void {
+		$id = $id();
 		$mainChar = $this->altsController->getMainOf($context->char->name);
 		$alts = $this->altsController->getAltsOf($mainChar);
 
@@ -695,8 +697,9 @@ class WishlistController extends ModuleInstance {
 	public function denyWishCommand(
 		CmdContext $context,
 		#[NCA\Str('deny')] string $action,
-		string $id,
+		PUuid $id,
 	): void {
+		$id = $id();
 		$mainChar = $this->altsController->getMainOf($context->char->name);
 		$alts = $this->altsController->getAltsOf($mainChar);
 

--- a/src/Modules/BANK_MODULE/WishlistController.php
+++ b/src/Modules/BANK_MODULE/WishlistController.php
@@ -443,8 +443,8 @@ class WishlistController extends ModuleInstance {
 			item: $item,
 			amount: isset($amount) ? $amount() : 1,
 		);
-		$entry->id = $this->db->insert($entry);
-		$context->reply("Item added to your wishlist as #{$entry->id}.");
+		$this->db->insert($entry);
+		$context->reply("Item added to your wishlist as {$entry->id}.");
 		if (!in_array($entry->from, $fromChars, true)) {
 			$this->buddylistManager->addName($character(), 'wishlist');
 		}
@@ -471,8 +471,8 @@ class WishlistController extends ModuleInstance {
 			amount: isset($amount) ? $amount() : 1,
 			expires_on: isset($expireDuration) ? time() + $expireDuration : null,
 		);
-		$entry->id = $this->db->insert($entry);
-		$context->reply("Item added to your wishlist as #{$entry->id}.");
+		$this->db->insert($entry);
+		$context->reply("Item added to your wishlist as {$entry->id}.");
 	}
 
 	/** Delete all your, and optionally all your alts', wishlists */
@@ -518,7 +518,7 @@ class WishlistController extends ModuleInstance {
 	public function removeFromWishlistCommand(
 		CmdContext $context,
 		PRemove $action,
-		int $id,
+		string $id,
 	): void {
 		$mainChar = $this->altsController->getMainOf($context->char->name);
 		$alts = $this->altsController->getAltsOf($mainChar);
@@ -628,7 +628,7 @@ class WishlistController extends ModuleInstance {
 		CmdContext $context,
 		#[NCA\Str('fulfil', 'fulfill', 'fullfil', 'fullfill')] string $action,
 		?PQuantity $amount,
-		int $id,
+		string $id,
 	): void {
 		$mainChar = $this->altsController->getMainOf($context->char->name);
 		$alts = $this->altsController->getAltsOf($mainChar);
@@ -667,7 +667,7 @@ class WishlistController extends ModuleInstance {
 		$oldFrom = $this->getActiveFroms();
 		$this->db->awaitBeginTransaction();
 		try {
-			$fulfilment->id = $this->db->insert($fulfilment);
+			$this->db->insert($fulfilment);
 			if ($numFulfilled + $fulfilment->amount >= $entry->amount) {
 				$this->db->table(Wish::getTable())
 					->where('id', $entry->id)
@@ -695,7 +695,7 @@ class WishlistController extends ModuleInstance {
 	public function denyWishCommand(
 		CmdContext $context,
 		#[NCA\Str('deny')] string $action,
-		int $id,
+		string $id,
 	): void {
 		$mainChar = $this->altsController->getMainOf($context->char->name);
 		$alts = $this->altsController->getAltsOf($mainChar);
@@ -765,7 +765,7 @@ class WishlistController extends ModuleInstance {
 				});
 		}
 
-		$ids = $query->pluckInts('id')->toList();
+		$ids = $query->pluckStrings('id')->toList();
 		if (count($ids) === 0) {
 			if ($includeActive) {
 				throw new UserException('Your wishlist is empty.');

--- a/src/Modules/CITY_MODULE/CityWaveController.php
+++ b/src/Modules/CITY_MODULE/CityWaveController.php
@@ -201,11 +201,11 @@ class CityWaveController extends ModuleInstance implements MessageEmitter {
 		}
 		$this->timerController->remove(self::TIMER_NAME);
 		$this->timerController->add(
-			self::TIMER_NAME,
-			$this->config->main->character,
-			'none',
-			$alerts,
-			'citywavecontroller.timerCallback'
+			name: self::TIMER_NAME,
+			owner: $this->config->main->character,
+			mode: 'none',
+			alerts: $alerts,
+			callback: 'citywavecontroller.timerCallback',
 		);
 	}
 

--- a/src/Modules/COMMENT_MODULE/Comment.php
+++ b/src/Modules/COMMENT_MODULE/Comment.php
@@ -3,19 +3,24 @@
 namespace Nadybot\Modules\COMMENT_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[NCA\DB\Table(name: '<table:comments>')]
 class Comment extends DBTable {
 	/** Unix timestamp when the comment was created */
 	public int $created_at;
 
+	/** The internal id of the comment */
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param string $character  About whom the comment is
-	 * @param string $created_by Who created the comment?
-	 * @param string $category   Category of the comment
-	 * @param ?int   $created_at Unix timestamp when the comment was created
-	 * @param string $comment    The actual comment
-	 * @param ?int   $id         The internal id of the comment
+	 * @param string         $character  About whom the comment is
+	 * @param string         $created_by Who created the comment?
+	 * @param string         $category   Category of the comment
+	 * @param ?int           $created_at Unix timestamp when the comment was created
+	 * @param string         $comment    The actual comment
+	 * @param ?UuidInterface $id         The internal id of the comment
 	 */
 	public function __construct(
 		public string $character,
@@ -23,8 +28,13 @@ class Comment extends DBTable {
 		public string $category,
 		?int $created_at=null,
 		public string $comment='',
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
 		$this->created_at = $created_at ?? time();
+		$dt = null;
+		if (isset($created_at) && !isset($id)) {
+			$dt = (new DateTimeImmutable())->setTimestamp($created_at);
+		}
+		$this->id = $id ?? Uuid::uuid7($dt);
 	}
 }

--- a/src/Modules/COMMENT_MODULE/CommentController.php
+++ b/src/Modules/COMMENT_MODULE/CommentController.php
@@ -115,7 +115,7 @@ class CommentController extends ModuleInstance {
 				if (!$this->db->schema()->hasTable('comments')) {
 					$this->logger->notice('Creating table comments');
 					$this->db->schema()->create('comments', static function (Blueprint $table): void {
-						$table->id();
+						$table->uuid('id')->primary();
 						$table->string('character', 15)->index();
 						$table->string('created_by', 15);
 						$table->integer('created_at');

--- a/src/Modules/COMMENT_MODULE/CommentController.php
+++ b/src/Modules/COMMENT_MODULE/CommentController.php
@@ -5,6 +5,7 @@ namespace Nadybot\Modules\COMMENT_MODULE;
 use Exception;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Collection;
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	AccessManager,
 	Attributes as NCA,
@@ -589,8 +590,10 @@ class CommentController extends ModuleInstance {
 	public function deleteCommentCommand(
 		CmdContext $context,
 		PRemove $action,
-		string $id
+		PUuid $id
 	): void {
+		$id = $id();
+
 		/** @var ?Comment */
 		$comment = $this->db->table(Comment::getTable())
 			->where('id', $id)

--- a/src/Modules/COMMENT_MODULE/CommentController.php
+++ b/src/Modules/COMMENT_MODULE/CommentController.php
@@ -165,7 +165,6 @@ class CommentController extends ModuleInstance {
 					->where('comment', $comment->comment)
 					->exists();
 				if (!$exists) {
-					$comment->id = null;
 					$this->db->insert($comment);
 				}
 			}
@@ -590,7 +589,7 @@ class CommentController extends ModuleInstance {
 	public function deleteCommentCommand(
 		CmdContext $context,
 		PRemove $action,
-		int $id
+		string $id
 	): void {
 		/** @var ?Comment */
 		$comment = $this->db->table(Comment::getTable())

--- a/src/Modules/COMMENT_MODULE/Migrations/MigrateCommentsTableToUuid.php
+++ b/src/Modules/COMMENT_MODULE/Migrations/MigrateCommentsTableToUuid.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\COMMENT_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\DBSchema\Setting;
+use Nadybot\Core\{DB, SchemaMigration};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_19_47_43)]
+class MigrateCommentsTableToUuid implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$table = $this->getSetting($db, 'table_name_comments')?->value ?? 'comments_<myname>';
+		$db->migrateIdToUuid(
+			$table,
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('character', 15)->index();
+				$table->string('created_by', 15);
+				$table->integer('created_at');
+				$table->string('category', 20)->index();
+				$table->text('comment');
+			},
+			'id',
+			'created_at'
+		);
+	}
+
+	private function getSetting(DB $db, string $name): ?Setting {
+		return $db->table(Setting::getTable())
+			->where('name', $name)
+			->asObj(Setting::class)
+			->first();
+	}
+}

--- a/src/Modules/DEV_MODULE/TestController.php
+++ b/src/Modules/DEV_MODULE/TestController.php
@@ -90,6 +90,24 @@ class TestController extends ModuleInstance {
 
 	/** @param string[] $commands */
 	public function runTests(array $commands, CmdContext $context, string $logFile): void {
+		foreach ($commands as $line) {
+			if ($line[0] !== '!') {
+				continue;
+			}
+			$testContext = clone $context;
+			if ($this->showTestCommands) {
+				$this->chatBot->sendTell($line, $context->char->name);
+			} else {
+				$this->logger->notice('{line}', ['line' => $line]);
+				if (!$this->showTestResults) {
+					$testContext->sendto = new MockCommandReply($line, $logFile);
+					Registry::injectDependencies($testContext->sendto);
+				}
+			}
+			$testContext->message = substr($line, 1);
+			$this->commandManager->processCmd($testContext);
+		}
+/*
 		do {
 			$line = array_shift($commands);
 		} while (isset($line) && $line[0] !== '!');
@@ -109,6 +127,7 @@ class TestController extends ModuleInstance {
 		$testContext->message = substr($line, 1);
 		$this->commandManager->processCmd($testContext);
 		$this->runTests($commands, $context, $logFile);
+*/
 	}
 
 	/** Pretend that &lt;char&gt; joins your org */

--- a/src/Modules/DEV_MODULE/TestController.php
+++ b/src/Modules/DEV_MODULE/TestController.php
@@ -107,27 +107,6 @@ class TestController extends ModuleInstance {
 			$testContext->message = substr($line, 1);
 			$this->commandManager->processCmd($testContext);
 		}
-/*
-		do {
-			$line = array_shift($commands);
-		} while (isset($line) && $line[0] !== '!');
-		if (!isset($line)) {
-			return;
-		}
-		$testContext = clone $context;
-		if ($this->showTestCommands) {
-			$this->chatBot->sendTell($line, $context->char->name);
-		} else {
-			$this->logger->notice('{line}', ['line' => $line]);
-			if (!$this->showTestResults) {
-				$testContext->sendto = new MockCommandReply($line, $logFile);
-				Registry::injectDependencies($testContext->sendto);
-			}
-		}
-		$testContext->message = substr($line, 1);
-		$this->commandManager->processCmd($testContext);
-		$this->runTests($commands, $context, $logFile);
-*/
 	}
 
 	/** Pretend that &lt;char&gt; joins your org */

--- a/src/Modules/DISCORD_GATEWAY_MODULE/DBDiscordInvite.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/DBDiscordInvite.php
@@ -3,14 +3,18 @@
 namespace Nadybot\Modules\DISCORD_GATEWAY_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'discord_invite')]
 class DBDiscordInvite extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	public function __construct(
 		public string $character,
 		public string $token,
 		public ?int $expires=null,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Modules/DISCORD_GATEWAY_MODULE/DBEmoji.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/DBEmoji.php
@@ -3,16 +3,20 @@
 namespace Nadybot\Modules\DISCORD_GATEWAY_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'discord_emoji')]
 class DBEmoji extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	public function __construct(
 		public string $name,
 		public string $guild_id,
 		public string $emoji_id,
 		public int $registered,
 		public int $version,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Modules/DISCORD_GATEWAY_MODULE/DiscordSlashCommand.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/DiscordSlashCommand.php
@@ -3,12 +3,16 @@
 namespace Nadybot\Modules\DISCORD_GATEWAY_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'discord_slash_command')]
 class DiscordSlashCommand extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	public function __construct(
 		public string $cmd,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/DefineDiscordRouteFormat.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/DefineDiscordRouteFormat.php
@@ -11,24 +11,21 @@ use Psr\Log\LoggerInterface;
 #[NCA\Migration(order: 2023_05_15_14_37_04)]
 class DefineDiscordRouteFormat implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$rhf = new RouteHopFormat(
-			hop: 'discord',
-			render: false,
-			format: 'DISCORD',
-		);
-		$db->insert($rhf);
+		$db->table(RouteHopFormat::getTable())->insert([
+			'hop' => 'discord',
+			'render' => false,
+			'format' => 'DISCORD',
+		]);
 
-		$rhc = new RouteHopColor(
-			hop: 'discord',
-			tag_color: 'C3C3C3',
-		);
-		$db->insert($rhc);
+		$db->table(RouteHopColor::getTable())->insert([
+			'hop' => 'discord',
+			'tag_color' => 'C3C3C3',
+		]);
 
-		$route = [
+		$db->table(Route::getTable())->insert([
 			'source' => 'discord(*)',
 			'destination' => Source::ORG,
 			'two_way' => false,
-		];
-		$db->table(Route::getTable())->insert($route);
+		]);
 	}
 }

--- a/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/MigrateDiscordInviteTableToUuids.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/MigrateDiscordInviteTableToUuids.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\DISCORD_GATEWAY_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\DISCORD_GATEWAY_MODULE\{DBDiscordInvite};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_21_04_00)]
+class MigrateDiscordInviteTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			DBDiscordInvite::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('token', 10)->unique();
+				$table->string('character', 12);
+				$table->unsignedInteger('expires')->nullable()->index();
+			},
+		);
+	}
+}

--- a/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/MigrateEmojisTableToUuids.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/MigrateEmojisTableToUuids.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\DISCORD_GATEWAY_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\DISCORD_GATEWAY_MODULE\{DBEmoji};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_21_12_00)]
+class MigrateEmojisTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			DBEmoji::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('name', 20)->index();
+				$table->unsignedInteger('registered');
+				$table->unsignedInteger('version');
+				$table->string('emoji_id', 24);
+				$table->string('guild_id', 24);
+			}
+		);
+	}
+}

--- a/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/MigrateSlashCommandTableToUuids.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/MigrateSlashCommandTableToUuids.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\DISCORD_GATEWAY_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\DISCORD_GATEWAY_MODULE\{DiscordSlashCommand};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_21_18_00)]
+class MigrateSlashCommandTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			DiscordSlashCommand::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('cmd', 50)->unique();
+			}
+		);
+	}
+}

--- a/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/MigrateToRoutes.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/MigrateToRoutes.php
@@ -114,19 +114,18 @@ class MigrateToRoutes implements SchemaMigration {
 			destination: $to,
 			two_way: true,
 		);
-		$db->table(Route::getTable())->insert([
+		$routeId = $db->table(Route::getTable())->insertGetId([
 			'source' => $route->source,
 			'destination' => $route->destination,
 			'two_way' => $route->two_way,
-			'id' => $route->id->toString(),
 		]);
 		if (!$relayCommands) {
 			$mod = new RouteModifier(
 				route_id: $route->id,
 				modifier: 'if-not-command',
 			);
-			$mod->id = $db->table(RouteModifier::getTable())->insertGetId([
-				'route_id' => $mod->route_id,
+			$db->table(RouteModifier::getTable())->insert([
+				'route_id' => $routeId,
 				'modifier' => $mod->modifier,
 			]);
 			$route->modifiers []= $mod;

--- a/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/MigrateToRoutes.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/Migrations/MigrateToRoutes.php
@@ -114,10 +114,11 @@ class MigrateToRoutes implements SchemaMigration {
 			destination: $to,
 			two_way: true,
 		);
-		$route->id = $db->table(Route::getTable())->insertGetId([
+		$db->table(Route::getTable())->insert([
 			'source' => $route->source,
 			'destination' => $route->destination,
 			'two_way' => $route->two_way,
+			'id' => $route->id->toString(),
 		]);
 		if (!$relayCommands) {
 			$mod = new RouteModifier(

--- a/src/Modules/EVENTS_MODULE/EventModel.php
+++ b/src/Modules/EVENTS_MODULE/EventModel.php
@@ -4,9 +4,12 @@ namespace Nadybot\Modules\EVENTS_MODULE;
 
 use Nadybot\Core\Attributes\DB\{Shared, Table};
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[Table(name: 'events', shared: Shared::Yes)]
 class EventModel extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	public function __construct(
 		public int $time_submitted,
 		public string $submitter_name,
@@ -14,8 +17,9 @@ class EventModel extends DBTable {
 		public ?int $event_date=null,
 		public ?string $event_desc=null,
 		public ?string $event_attendees=null,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 
 	/** @return list<string> */

--- a/src/Modules/EVENTS_MODULE/EventsController.php
+++ b/src/Modules/EVENTS_MODULE/EventsController.php
@@ -91,20 +91,20 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 	 */
 	#[NCA\HandlesCommand(self::CMD_EVENT_MANAGE)]
 	public function eventsAddCommand(CmdContext $context, #[NCA\Str('add')] string $action, string $eventName): void {
-		$eventId = $this->db->table(EventModel::getTable())
-			->insertGetId([
-				'time_submitted' => time(),
-				'submitter_name' => $context->char->name,
-				'event_name' => $eventName,
-				'event_date' => null,
-			]);
-		$msg = "Event: '{$eventName}' was added [Event ID {$eventId}].";
+		$event = new EventModel(
+			time_submitted: time(),
+			submitter_name: $context->char->name,
+			event_name: $eventName,
+			event_date: null,
+		);
+		$this->db->insert($event);
+		$msg = "Event: '{$eventName}' was added [Event ID {$event->id}].";
 		$context->reply($msg);
 	}
 
 	/** Delete an event */
 	#[NCA\HandlesCommand(self::CMD_EVENT_MANAGE)]
-	public function eventsRemoveCommand(CmdContext $context, PRemove $action, int $id): void {
+	public function eventsRemoveCommand(CmdContext $context, PRemove $action, string $id): void {
 		$row = $this->getEvent($id);
 		if ($row === null) {
 			$msg = "Could not find an event with id {$id}.";
@@ -117,7 +117,7 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 
 	/** Change the description of an event */
 	#[NCA\HandlesCommand(self::CMD_EVENT_MANAGE)]
-	public function eventsSetDescCommand(CmdContext $context, #[NCA\Str('setdesc')] string $action, int $id, string $description): void {
+	public function eventsSetDescCommand(CmdContext $context, #[NCA\Str('setdesc')] string $action, string $id, string $description): void {
 		$row = $this->getEvent($id);
 		if ($row === null) {
 			$msg = "Could not find an event with id {$id}.";
@@ -135,7 +135,7 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 	public function eventsSetDateCommand(
 		CmdContext $context,
 		#[NCA\Str('setdate')] string $action,
-		int $id,
+		string $id,
 		string $date,
 	): void {
 		$row = $this->getEvent($id);
@@ -156,16 +156,16 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 		$context->reply($msg);
 	}
 
-	public function getEvent(int $id): ?EventModel {
+	public function getEvent(\Stringable|string $id): ?EventModel {
 		return $this->db->table(EventModel::getTable())
-			->where('id', $id)
+			->where('id', (string)$id)
 			->asObj(EventModel::class)
 			->first();
 	}
 
 	/** Join event #id */
 	#[NCA\HandlesCommand('events')]
-	public function eventsJoinCommand(CmdContext $context, #[NCA\Str('join')] string $action, int $id): void {
+	public function eventsJoinCommand(CmdContext $context, #[NCA\Str('join')] string $action, string $id): void {
 		$row = $this->getEvent($id);
 		if ($row === null) {
 			$msg = "There is no event with id <highlight>{$id}<end>.";
@@ -194,7 +194,7 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 
 	/** Leave event #id */
 	#[NCA\HandlesCommand('events')]
-	public function eventsLeaveCommand(CmdContext $context, #[NCA\Str('leave')] string $action, int $id): void {
+	public function eventsLeaveCommand(CmdContext $context, #[NCA\Str('leave')] string $action, string $id): void {
 		$row = $this->getEvent($id);
 		if ($row === null) {
 			$msg = "There is no event with id <highlight>{$id}<end>.";
@@ -222,7 +222,7 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 
 	/** List all characters marked as joining event #id */
 	#[NCA\HandlesCommand('events')]
-	public function eventsListCommand(CmdContext $context, #[NCA\Str('list')] string $action, int $id): void {
+	public function eventsListCommand(CmdContext $context, #[NCA\Str('list')] string $action, string $id): void {
 		$row = $this->getEvent($id);
 		if ($row === null) {
 			$msg = "Could not find event with id <highlight>{$id}<end>.";

--- a/src/Modules/EVENTS_MODULE/EventsController.php
+++ b/src/Modules/EVENTS_MODULE/EventsController.php
@@ -6,6 +6,7 @@ use function Safe\strtotime;
 
 use InvalidArgumentException;
 use Nadybot\Core\Config\BotConfig;
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
@@ -104,7 +105,8 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 
 	/** Delete an event */
 	#[NCA\HandlesCommand(self::CMD_EVENT_MANAGE)]
-	public function eventsRemoveCommand(CmdContext $context, PRemove $action, string $id): void {
+	public function eventsRemoveCommand(CmdContext $context, PRemove $action, PUuid $id): void {
+		$id = $id();
 		$row = $this->getEvent($id);
 		if ($row === null) {
 			$msg = "Could not find an event with id {$id}.";
@@ -117,7 +119,8 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 
 	/** Change the description of an event */
 	#[NCA\HandlesCommand(self::CMD_EVENT_MANAGE)]
-	public function eventsSetDescCommand(CmdContext $context, #[NCA\Str('setdesc')] string $action, string $id, string $description): void {
+	public function eventsSetDescCommand(CmdContext $context, #[NCA\Str('setdesc')] string $action, PUuid $id, string $description): void {
+		$id = $id();
 		$row = $this->getEvent($id);
 		if ($row === null) {
 			$msg = "Could not find an event with id {$id}.";
@@ -135,9 +138,10 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 	public function eventsSetDateCommand(
 		CmdContext $context,
 		#[NCA\Str('setdate')] string $action,
-		string $id,
+		PUuid $id,
 		string $date,
 	): void {
+		$id = $id();
 		$row = $this->getEvent($id);
 		if ($row === null) {
 			$msg = "Could not find an event with id {$id}.";
@@ -165,7 +169,8 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 
 	/** Join event #id */
 	#[NCA\HandlesCommand('events')]
-	public function eventsJoinCommand(CmdContext $context, #[NCA\Str('join')] string $action, string $id): void {
+	public function eventsJoinCommand(CmdContext $context, #[NCA\Str('join')] string $action, PUuid $id): void {
+		$id = $id();
 		$row = $this->getEvent($id);
 		if ($row === null) {
 			$msg = "There is no event with id <highlight>{$id}<end>.";
@@ -194,7 +199,8 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 
 	/** Leave event #id */
 	#[NCA\HandlesCommand('events')]
-	public function eventsLeaveCommand(CmdContext $context, #[NCA\Str('leave')] string $action, string $id): void {
+	public function eventsLeaveCommand(CmdContext $context, #[NCA\Str('leave')] string $action, PUuid $id): void {
+		$id = $id();
 		$row = $this->getEvent($id);
 		if ($row === null) {
 			$msg = "There is no event with id <highlight>{$id}<end>.";
@@ -222,7 +228,8 @@ class EventsController extends ModuleInstance implements ImporterInterface, Expo
 
 	/** List all characters marked as joining event #id */
 	#[NCA\HandlesCommand('events')]
-	public function eventsListCommand(CmdContext $context, #[NCA\Str('list')] string $action, string $id): void {
+	public function eventsListCommand(CmdContext $context, #[NCA\Str('list')] string $action, PUuid $id): void {
+		$id = $id();
 		$row = $this->getEvent($id);
 		if ($row === null) {
 			$msg = "Could not find event with id <highlight>{$id}<end>.";

--- a/src/Modules/EVENTS_MODULE/Migrations/MigrateCreateEventsTableToUuids.php
+++ b/src/Modules/EVENTS_MODULE/Migrations/MigrateCreateEventsTableToUuids.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\EVENTS_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\EVENTS_MODULE\EventModel;
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_21_24_00, shared: true)]
+class MigrateCreateEventsTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			EventModel::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->integer('time_submitted');
+				$table->string('submitter_name', 25);
+				$table->string('event_name', 255);
+				$table->integer('event_date')->nullable();
+				$table->text('event_desc')->nullable();
+				$table->text('event_attendees')->nullable();
+			},
+			'id',
+			'time_submitted',
+		);
+	}
+}

--- a/src/Modules/FUN_MODULE/Fun.php
+++ b/src/Modules/FUN_MODULE/Fun.php
@@ -7,7 +7,7 @@ use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'fun', shared: NCA\DB\Shared::Yes)]
 class Fun extends DBTable {
-	#[NCA\DB\AutoInc] public UuidInterface $id;
+	#[NCA\DB\PK] public UuidInterface $id;
 
 	public function __construct(
 		public string $type,

--- a/src/Modules/FUN_MODULE/Fun.php
+++ b/src/Modules/FUN_MODULE/Fun.php
@@ -3,13 +3,17 @@
 namespace Nadybot\Modules\FUN_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'fun', shared: NCA\DB\Shared::Yes)]
 class Fun extends DBTable {
+	#[NCA\DB\AutoInc] public UuidInterface $id;
+
 	public function __construct(
 		public string $type,
 		public string $content,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Modules/FUN_MODULE/GreetController.php
+++ b/src/Modules/FUN_MODULE/GreetController.php
@@ -197,7 +197,6 @@ class GreetController extends ModuleInstance {
 			->where('type', self::TYPE_CUSTOM)
 			->asObj(Fun::class)
 			->map(static function (Fun $entry) use ($context): string {
-				assert(isset($entry->id));
 				$delLink = Text::makeChatcmd(
 					'remove',
 					'/tell <myname> ' . $context->getCommand() . ' rem ' . $entry->id
@@ -237,8 +236,8 @@ class GreetController extends ModuleInstance {
 			type: self::TYPE_CUSTOM,
 			content: $greeting,
 		);
-		$id = $this->db->insert($fun);
-		$context->reply("New greeting added as <highlight>#{$id}<end>.");
+		$this->db->insert($fun);
+		$context->reply("New greeting added as <highlight>{$fun->id}<end>.");
 	}
 
 	#[NCA\HandlesCommand('greeting')]
@@ -246,17 +245,17 @@ class GreetController extends ModuleInstance {
 	public function delGreeting(
 		CmdContext $context,
 		PRemove $action,
-		int $id,
+		string $id,
 	): void {
 		$deleted = $this->db->table(Fun::getTable())
 			->where('type', self::TYPE_CUSTOM)
 			->where('id', $id)
 			->delete();
 		if (!$deleted) {
-			$context->reply("The greeting <highlight>#{$id}<end> doesn't exist.");
+			$context->reply("The greeting <highlight>{$id}<end> doesn't exist.");
 			return;
 		}
-		$context->reply("Greeting <highlight>#{$id}<end> deleted successfully.");
+		$context->reply("Greeting <highlight>{$id}<end> deleted successfully.");
 	}
 
 	#[NCA\HandlesCommand('greeting on/off')]

--- a/src/Modules/FUN_MODULE/GreetController.php
+++ b/src/Modules/FUN_MODULE/GreetController.php
@@ -8,7 +8,7 @@ use Nadybot\Core\Modules\ALTS\{AltNewMainEvent, AltsController};
 
 use Nadybot\Core\Modules\PLAYER_LOOKUP\PlayerManager;
 use Nadybot\Core\Modules\PREFERENCES\Preferences;
-use Nadybot\Core\ParamClass\PRemove;
+use Nadybot\Core\ParamClass\{PRemove, PUuid};
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
@@ -245,8 +245,9 @@ class GreetController extends ModuleInstance {
 	public function delGreeting(
 		CmdContext $context,
 		PRemove $action,
-		string $id,
+		PUuid $id,
 	): void {
+		$id = $id();
 		$deleted = $this->db->table(Fun::getTable())
 			->where('type', self::TYPE_CUSTOM)
 			->where('id', $id)

--- a/src/Modules/FUN_MODULE/Migrations/CreateFunTable.php
+++ b/src/Modules/FUN_MODULE/Migrations/CreateFunTable.php
@@ -5,12 +5,13 @@ namespace Nadybot\Modules\FUN_MODULE\Migrations;
 use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\FUN_MODULE\Fun;
 use Psr\Log\LoggerInterface;
 
 #[NCA\Migration(order: 2023_08_23_05_00_54, shared: true)]
 class CreateFunTable implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$table = 'fun';
+		$table = Fun::getTable();
 		if ($db->schema()->hasTable($table)) {
 			$db->schema()->drop($table);
 		}

--- a/src/Modules/FUN_MODULE/Migrations/MigrateFunTableToUuids.php
+++ b/src/Modules/FUN_MODULE/Migrations/MigrateFunTableToUuids.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\FUN_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\FUN_MODULE\Fun;
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_20_12_00, shared: true)]
+class MigrateFunTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			Fun::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('type', 15)->index();
+				$table->text('content');
+			}
+		);
+	}
+}

--- a/src/Modules/FUN_MODULE/beer.csv
+++ b/src/Modules/FUN_MODULE/beer.csv
@@ -1,5 +1,6 @@
 # Table: fun
 # Replaces: type=beer
+# uuid: id
 type,content
 beer,"*name* are you buying?"
 beer,"Beer! lets get this party started *name*!!"

--- a/src/Modules/FUN_MODULE/brain.csv
+++ b/src/Modules/FUN_MODULE/brain.csv
@@ -1,5 +1,6 @@
 # Table: fun
 # Replaces: type=brain
+# uuid: id
 type,content
 brain,"Brain: It must be inordinately taxing to be such a boob.<br> Pinky:  You have no idea."
 brain,"Brain: Pinky, are you pondering what I'm pondering?<br> Pinky: Uh, I think so, Brain, but where will we find a duck and a hose at this hour?"

--- a/src/Modules/FUN_MODULE/chuck.csv
+++ b/src/Modules/FUN_MODULE/chuck.csv
@@ -1,5 +1,6 @@
 # Table: fun
 # Replaces: type=chuck
+# uuid: id
 type,content
 chuck,"Chuck Norris counted to infinity - twice."
 chuck,"Some kids piss their name in the snow. Chuck Norris can piss his name into concrete."

--- a/src/Modules/FUN_MODULE/compliment.csv
+++ b/src/Modules/FUN_MODULE/compliment.csv
@@ -1,5 +1,6 @@
 # Table: fun
 # Replaces: type=compliment
+# uuid: id
 type,content
 compliment,"You're the only person I want to come back to when it feels like the rest of the world has become too much."
 compliment,"Your bellybutton is kind of adorable."

--- a/src/Modules/FUN_MODULE/cybor.csv
+++ b/src/Modules/FUN_MODULE/cybor.csv
@@ -1,5 +1,6 @@
 # Table: fun
 # Replaces: type=cybor
+# uuid: id
 type,content
 cybor,"I touch you on your lettuce, you massage my spinach... sexily."
 cybor,"Don't worry about it. I'm wearing a lacy black bra.My soft breasts are rising and falling, as I breath harder and harder."

--- a/src/Modules/FUN_MODULE/dwight.csv
+++ b/src/Modules/FUN_MODULE/dwight.csv
@@ -1,5 +1,6 @@
 # Table: fun
 # Replaces: type=dwight
+# uuid: id
 type,content
 dwight,"I am faster than 80% of all snakes."
 dwight,"Reject a woman, and she will never let it go. One of the many defects of their kind. Also, weak arms."

--- a/src/Modules/FUN_MODULE/fact.csv
+++ b/src/Modules/FUN_MODULE/fact.csv
@@ -1,5 +1,6 @@
 # Table: fun
 # Replaces: type=fact
+# uuid: id
 type,content
 fact,"It is impossible to lick your elbow."
 fact,"Intelligent people have more zinc and copper in their hair."

--- a/src/Modules/FUN_MODULE/fc.csv
+++ b/src/Modules/FUN_MODULE/fc.csv
@@ -1,5 +1,6 @@
 # Table: fun
 # Replaces: type=fc
+# uuid: id
 type,content
 fc,"[in the same thread that topics got deleted for not agreeing with how moderation was happening] This is what I hate - This prevalant attitude that we restrict or otherwise take issue with people having differing opinions from us. --Kintaii"
 fc,"We're more open and honest than probably pretty much any other game development team out there. --Kintaii"

--- a/src/Modules/FUN_MODULE/greeting.csv
+++ b/src/Modules/FUN_MODULE/greeting.csv
@@ -1,5 +1,6 @@
 # Table: fun
 # Replaces: type=greeting
+# uuid: id
 type,content
 greeting,"Welcome, *name*! Nice to see you."
 greeting,"You're like a breath of fresh air, *name*."
@@ -9,6 +10,6 @@ greeting,"Now that you're here, everything will be better, *name*."
 greeting,"Welcome to that chat!"
 greeting,"Uh oh! Shhhh, trouble's here! Oh! Hi *name*!"
 greeting,"Hi, *name*"
-greeting,"Hey, *name*! How's you?" 
+greeting,"Hey, *name*! How's you?"
 greeting,"Hey *name*! Welcome to the party!"
 

--- a/src/Modules/FUN_MODULE/homer.csv
+++ b/src/Modules/FUN_MODULE/homer.csv
@@ -1,5 +1,6 @@
 # Table: fun
 # Replaces: type=homer
+# uuid: id
 type,content
 homer,"Your mom asked me to give you an apple instead"
 homer,"Internet! Is that thing still around?"

--- a/src/Modules/FUN_MODULE/pirates.csv
+++ b/src/Modules/FUN_MODULE/pirates.csv
@@ -1,5 +1,6 @@
 # Table: fun
 # Replaces: type=pirates
+# uuid: id
 type,content
 pirates,"Lord Beckett: You're mad!<br>Jack Sparrow: well that's good cause If I wasn't, this'd probably never work."
 pirates,"Barbossa: There's not been a gathering like this in our lifetime.<br>Jack Sparrow: And I owe them all money."

--- a/src/Modules/GUILD_MODULE/Migrations/History/CreateOrgHistoryTable.php
+++ b/src/Modules/GUILD_MODULE/Migrations/History/CreateOrgHistoryTable.php
@@ -5,12 +5,13 @@ namespace Nadybot\Modules\GUILD_MODULE\Migrations\History;
 use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\GUILD_MODULE\OrgHistory;
 use Psr\Log\LoggerInterface;
 
 #[NCA\Migration(order: 2021_04_26_05_03_03, shared: true)]
 class CreateOrgHistoryTable implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$table = 'org_history';
+		$table = OrgHistory::getTable();
 		if ($db->schema()->hasTable($table)) {
 			$db->schema()->table($table, static function (Blueprint $table): void {
 				$table->id('id')->change();

--- a/src/Modules/GUILD_MODULE/Migrations/History/MigrateOrgHistoryTableToUuids.php
+++ b/src/Modules/GUILD_MODULE/Migrations/History/MigrateOrgHistoryTableToUuids.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\GUILD_MODULE\Migrations\History;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\GUILD_MODULE\OrgHistory;
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_11_41_00, shared: true)]
+class MigrateOrgHistoryTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			OrgHistory::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->text('actor')->nullable();
+				$table->text('actee')->nullable();
+				$table->text('action')->nullable();
+				$table->text('organization')->nullable();
+				$table->integer('time')->nullable();
+			},
+			'id',
+			'time'
+		);
+	}
+}

--- a/src/Modules/GUILD_MODULE/OrgHistory.php
+++ b/src/Modules/GUILD_MODULE/OrgHistory.php
@@ -2,18 +2,23 @@
 
 namespace Nadybot\Modules\GUILD_MODULE;
 
-use Nadybot\Core\Attributes\DB\{AutoInc, Shared, Table};
+use Nadybot\Core\Attributes\DB\{PK, Shared, Table};
 use Nadybot\Core\DBTable;
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[Table(name: 'org_history', shared: Shared::Yes)]
 class OrgHistory extends DBTable {
+	/** Internal ID of this history entry */
+	#[PK] public UuidInterface $id;
+
 	/**
-	 * @param ?string $actor        The person doing the action
-	 * @param ?string $actee        Optional, the person the actor is acting on
-	 * @param ?string $action       The action the actor is doing
-	 * @param ?string $organization Name of the organization this action was done in
-	 * @param ?int    $time         Timestamp when the action happened
-	 * @param ?int    $id           Internal ID of this history entry
+	 * @param ?string        $actor        The person doing the action
+	 * @param ?string        $actee        Optional, the person the actor is acting on
+	 * @param ?string        $action       The action the actor is doing
+	 * @param ?string        $organization Name of the organization this action was done in
+	 * @param ?int           $time         Timestamp when the action happened
+	 * @param ?UuidInterface $id           Internal ID of this history entry
 	 */
 	public function __construct(
 		public ?string $actor,
@@ -21,7 +26,12 @@ class OrgHistory extends DBTable {
 		public ?string $action,
 		public ?string $organization,
 		public ?int $time,
-		#[AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$dt = null;
+		if (isset($time) && !isset($id)) {
+			$dt = (new DateTimeImmutable())->setTimestamp($time);
+		}
+		$this->id = $id ?? Uuid::uuid7($dt);
 	}
 }

--- a/src/Modules/HELPBOT_MODULE/ICCArbiter.php
+++ b/src/Modules/HELPBOT_MODULE/ICCArbiter.php
@@ -4,14 +4,18 @@ namespace Nadybot\Modules\HELPBOT_MODULE;
 
 use DateTimeInterface;
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'icc_arbiter', shared: NCA\DB\Shared::Yes)]
 class ICCArbiter extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	public function __construct(
 		public string $type,
 		public DateTimeInterface $start,
 		public DateTimeInterface $end,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Modules/HELPBOT_MODULE/Migrations/Arbiter/MigrateArbiterTableToUuids.php
+++ b/src/Modules/HELPBOT_MODULE/Migrations/Arbiter/MigrateArbiterTableToUuids.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\HELPBOT_MODULE\Migrations\Arbiter;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{
+	DB,
+	SchemaMigration,
+};
+use Nadybot\Modules\HELPBOT_MODULE\{ICCArbiter};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_12_25_00, shared: true)]
+class MigrateArbiterTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			ICCArbiter::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('type', 3)->unique();
+				$table->unsignedInteger('start')->index();
+				$table->unsignedInteger('end')->index();
+			}
+		);
+	}
+}

--- a/src/Modules/HELPBOT_MODULE/Migrations/Roll/MigrateRollTableToUuids.php
+++ b/src/Modules/HELPBOT_MODULE/Migrations/Roll/MigrateRollTableToUuids.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\HELPBOT_MODULE\Migrations\Roll;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\HELPBOT_MODULE\Roll;
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_04_07_08_00, shared: true)]
+class MigrateRollTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			Roll::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->integer('time')->nullable();
+				$table->string('name', 255)->nullable();
+				$table->text('options')->nullable();
+				$table->string('result', 255)->nullable();
+			},
+			'id',
+			'time'
+		);
+	}
+}

--- a/src/Modules/HELPBOT_MODULE/RandomController.php
+++ b/src/Modules/HELPBOT_MODULE/RandomController.php
@@ -4,7 +4,7 @@ namespace Nadybot\Modules\HELPBOT_MODULE;
 
 use function Safe\{preg_match_all, preg_split};
 use InvalidArgumentException;
-use Nadybot\Core\ParamClass\PItem;
+use Nadybot\Core\ParamClass\{PItem, PUuid};
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
@@ -218,7 +218,8 @@ class RandomController extends ModuleInstance {
 
 	/** Verify a roll */
 	#[NCA\HandlesCommand('verify')]
-	public function verifyCommand(CmdContext $context, string $rollId): void {
+	public function verifyCommand(CmdContext $context, PUuid $rollId): void {
+		$rollId = $rollId();
 		$roll = $this->db->table(Roll::getTable())
 			->where('id', $rollId)
 			->asObj(Roll::class)

--- a/src/Modules/HELPBOT_MODULE/RandomController.php
+++ b/src/Modules/HELPBOT_MODULE/RandomController.php
@@ -5,7 +5,6 @@ namespace Nadybot\Modules\HELPBOT_MODULE;
 use function Safe\{preg_match_all, preg_split};
 use InvalidArgumentException;
 use Nadybot\Core\ParamClass\PItem;
-
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
@@ -219,25 +218,31 @@ class RandomController extends ModuleInstance {
 
 	/** Verify a roll */
 	#[NCA\HandlesCommand('verify')]
-	public function verifyCommand(CmdContext $context, int $rollId): void {
-		/** @var ?Roll */
-		$row = $this->db->table(Roll::getTable())
+	public function verifyCommand(CmdContext $context, string $rollId): void {
+		$roll = $this->db->table(Roll::getTable())
 			->where('id', $rollId)
 			->asObj(Roll::class)
 			->first();
-		if ($row === null) {
+		if ($roll === null) {
 			$msg = "Roll number <highlight>{$rollId}<end> does not exist.";
 		} else {
-			$options = isset($row->options) ? explode('|', $row->options) : ['&lt;none&gt;'];
-			$result = isset($row->result) ? explode('|', $row->result) : ['&lt;none&gt;'];
-			$time = 'an unknown time';
-			if (isset($row->time)) {
-				$time = Util::unixtimeToReadable(time() - $row->time);
+			$msg = $this->renderRollVerify($roll);
+			$lines = $this->db->table(Roll::getTable())
+				->where('id', '<', $rollId)
+				->orderByDesc('id')
+				->limit(3)
+				->asObj(Roll::class)
+				->map(function (Roll $roll): string {
+					return $this->renderRollVerify($roll);
+				});
+			if ($lines->isNotEmpty()) {
+				$blob = $this->text->makeBlob(
+					'previous rolls',
+					$lines->join("\n\n"),
+					'Results of previous rolls'
+				);
+				$msg = Text::blobWrap($msg . ' [', $blob, ']');
 			}
-			$msg = $this->joinOptions($result, 'highlight').
-				" rolled by <highlight>{$row->name}<end> {$time} ago.\n".
-				'Possible options were: '.
-				$this->joinOptions($options, 'highlight') . '.';
 		}
 
 		$context->reply($msg);
@@ -251,7 +256,7 @@ class RandomController extends ModuleInstance {
 	 *
 	 * @return array An array with the roll number and the chosen option
 	 *
-	 * @psalm-return array{0:int, 1:string}
+	 * @psalm-return array{0:\Ramsey\Uuid\UuidInterface, 1:string}
 	 *
 	 * @throws SQLException on SQL errors
 	 */
@@ -263,14 +268,12 @@ class RandomController extends ModuleInstance {
 		mt_srand();
 		$result = (array)array_rand($revOptions, $amount);
 		$result = implode('|', $result);
-		$id = $this->db->table(Roll::getTable())
-			->insertGetId([
-				'time' => time(),
-				'name' => $sender,
-				'options' => implode('|', $options),
-				'result' => $result,
-			]);
-		return [$id, $result];
+		$this->db->insert($roll = new Roll(
+			name : $sender,
+			options : implode('|', $options),
+			result : $result,
+		));
+		return [$roll->id, $result];
 	}
 
 	/**
@@ -293,5 +296,18 @@ class RandomController extends ModuleInstance {
 			$options = [implode("{$endTag}, {$startTag}", $options)];
 		}
 		return "{$startTag}" . implode("{$endTag} and {$startTag}", [...$options, $lastOption]) . "{$endTag}";
+	}
+
+	private function renderRollVerify(Roll $roll): string {
+		$options = isset($roll->options) ? explode('|', $roll->options) : ['&lt;none&gt;'];
+		$result = isset($roll->result) ? explode('|', $roll->result) : ['&lt;none&gt;'];
+		$time = 'an unknown time';
+		if (isset($roll->time)) {
+			$time = Util::unixtimeToReadable(time() - $roll->time);
+		}
+		return $this->joinOptions($result, 'highlight').
+			" rolled by <highlight>{$roll->name}<end> {$time} ago.\n".
+			'Possible options were: '.
+			$this->joinOptions($options, 'highlight') . '.';
 	}
 }

--- a/src/Modules/HELPBOT_MODULE/Roll.php
+++ b/src/Modules/HELPBOT_MODULE/Roll.php
@@ -3,15 +3,25 @@
 namespace Nadybot\Modules\HELPBOT_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[NCA\DB\Table(name: 'roll', shared: NCA\DB\Shared::Yes)]
 class Roll extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	public function __construct(
-		public ?int $time,
 		public ?string $name,
 		public ?string $options,
 		public ?string $result,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		public ?int $time=null,
+		?UuidInterface $id=null,
 	) {
+		$dt = null;
+		if (isset($time) && !isset($id)) {
+			$dt = (new DateTimeImmutable())->setTimestamp($time);
+		}
+		$this->id = $id ?? Uuid::uuid7($dt);
+		$this->time ??= time();
 	}
 }

--- a/src/Modules/HIGHNET_MODULE/FilterEntry.php
+++ b/src/Modules/HIGHNET_MODULE/FilterEntry.php
@@ -3,12 +3,15 @@
 namespace Nadybot\Modules\HIGHNET_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'highnet_filter')]
 class FilterEntry extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	public function __construct(
 		public string $creator,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 		public ?string $sender_name=null,
 		public ?int $sender_uid=null,
 		public ?string $bot_name=null,
@@ -17,6 +20,7 @@ class FilterEntry extends DBTable {
 		public ?int $dimension=null,
 		public ?int $expires=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 
 	public function matches(Message $message): bool {

--- a/src/Modules/HIGHNET_MODULE/HighnetController.php
+++ b/src/Modules/HIGHNET_MODULE/HighnetController.php
@@ -645,7 +645,7 @@ class HighnetController extends ModuleInstance implements EventFeedHandler {
 		CmdContext $context,
 		#[NCA\Str('filter')] string $filter,
 		PRemove $action,
-		int $id
+		string $id
 	): void {
 		/** @var ?FilterEntry */
 		$filter = $this->db
@@ -654,7 +654,7 @@ class HighnetController extends ModuleInstance implements EventFeedHandler {
 			->asObj(FilterEntry::class)
 			->first();
 		if (!isset($filter)) {
-			$context->reply("Highnet filter <highlight>#{$id}<end> does not exist.");
+			$context->reply("Highnet filter <highlight>{$id}<end> does not exist.");
 			return;
 		}
 		if (!isset($filter->expires)) {
@@ -1017,7 +1017,7 @@ class HighnetController extends ModuleInstance implements EventFeedHandler {
 			}
 			$entry->expires = time() + $secDuration;
 		}
-		$entry->id = $this->db->insert($entry);
+		$this->db->insert($entry);
 		$this->reloadFilters();
 		$context->reply('Filter ' . $this->getFilterDescr($entry) . ' added.');
 	}

--- a/src/Modules/HIGHNET_MODULE/HighnetController.php
+++ b/src/Modules/HIGHNET_MODULE/HighnetController.php
@@ -13,7 +13,7 @@ use Exception;
 use Illuminate\Support\Collection;
 use Nadybot\Core\DBSchema\{Route, RouteHopColor, RouteHopFormat};
 use Nadybot\Core\Modules\ALTS\{AltsController, NickController};
-use Nadybot\Core\ParamClass\{PCharacter, PDuration, PRemove, PWord};
+use Nadybot\Core\ParamClass\{PCharacter, PDuration, PRemove, PUuid, PWord};
 use Nadybot\Core\Routing\{Character, RoutableEvent, RoutableMessage, Source};
 
 use Nadybot\Core\{
@@ -645,8 +645,10 @@ class HighnetController extends ModuleInstance implements EventFeedHandler {
 		CmdContext $context,
 		#[NCA\Str('filter')] string $filter,
 		PRemove $action,
-		string $id
+		PUuid $id
 	): void {
+		$id = $id();
+
 		/** @var ?FilterEntry */
 		$filter = $this->db
 			->table(FilterEntry::getTable())

--- a/src/Modules/HIGHNET_MODULE/HighnetController.php
+++ b/src/Modules/HIGHNET_MODULE/HighnetController.php
@@ -500,7 +500,7 @@ class HighnetController extends ModuleInstance implements EventFeedHandler {
 			$this->db->insert($rhc);
 			$this->db->insert($rhf);
 			foreach ($routes as $route) {
-				$route->id = $this->db->insert($route);
+				$this->db->insert($route);
 				$msgRoutes []= $this->msgHub->createMessageRoute($route);
 			}
 		} catch (Exception $e) {

--- a/src/Modules/HIGHNET_MODULE/Migrations/InitializeRouting.php
+++ b/src/Modules/HIGHNET_MODULE/Migrations/InitializeRouting.php
@@ -29,16 +29,16 @@ class InitializeRouting implements SchemaMigration {
 			$db->table(Route::getTable())->insert($route);
 		}
 
-		$db->insert(new RouteHopFormat(
-			hop: 'highnet',
-			render: true,
-			format: '@%s',
-		));
+		$db->table(RouteHopFormat::getTable())->insert([
+			'hop' => 'highnet',
+			'render' => true,
+			'format' => '@%s',
+		]);
 
-		$db->insert(new RouteHopColor(
-			hop: 'highnet',
-			tag_color: '00EFFF',
-			text_color: '00BFFF',
-		));
+		$db->table(RouteHopColor::getTable())->insert([
+			'hop' => 'highnet',
+			'tag_color' => '00EFFF',
+			'text_color' => '00BFFF',
+		]);
 	}
 }

--- a/src/Modules/HIGHNET_MODULE/Migrations/MigrateFilterTableToUuids.php
+++ b/src/Modules/HIGHNET_MODULE/Migrations/MigrateFilterTableToUuids.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\HIGHNET_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\HIGHNET_MODULE\{FilterEntry};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_02_17_54_00)]
+class MigrateFilterTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			FilterEntry::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('creator', 12)->nullable(false);
+				$table->string('sender_name', 12)->nullable(true);
+				$table->unsignedInteger('sender_uid')->nullable(true);
+				$table->string('bot_name', 12)->nullable(true);
+				$table->unsignedInteger('bot_uid')->nullable(true);
+				$table->string('channel', 25)->nullable(true);
+				$table->unsignedSmallInteger('dimension')->nullable(true);
+				$table->unsignedInteger('expires')->nullable(true);
+			},
+			'id'
+		);
+	}
+}

--- a/src/Modules/IMPLANT_MODULE/ImplantDesignerController.php
+++ b/src/Modules/IMPLANT_MODULE/ImplantDesignerController.php
@@ -97,14 +97,14 @@ class ImplantDesignerController extends ModuleInstance {
 			if (property_exists($slotObj, 'symb') && $slotObj->symb !== null) {
 				continue;
 			}
-			$ql = !count($slotObj->ql) ? 300 : (int)$slotObj->ql;
+			$ql = (int)($slotObj->ql ?? 300);
 			$addImp = false;
 			$refined = '';
 			if ($ql > 200) {
 				$refined = 'Refined ';
 			}
 			foreach (['shiny', 'bright', 'faded'] as $grade) {
-				if (!count($slotObj->{$grade})) {
+				if (!isset($slotObj->{$grade})) {
 					continue;
 				}
 				$name = $lookup[$slotObj->{$grade}];
@@ -208,7 +208,7 @@ class ImplantDesignerController extends ModuleInstance {
 			}
 			$blob .= "\n\n";
 		} else {
-			$ql = !count($design->{$slot}->ql) ? 300 : (int)$design->{$slot}->ql;
+			$ql = (int)($design->{$slot}?->ql ?? 300);
 			$blob .= "<header2>QL<end> {$ql}";
 			$implant = $this->getImplantInfo($ql, $design->{$slot}->shiny, $design->{$slot}->bright, $design->{$slot}->faded);
 			if ($implant !== null) {
@@ -380,13 +380,13 @@ class ImplantDesignerController extends ModuleInstance {
 
 		$design = $this->getDesign($context->char->name, '@');
 		$slotObj = $design->{$slot->designSlotName()};
-		if (!count($slotObj)) {
+		if (!isset($slotObj)) {
 			$msg = 'You must have at least one cluster filled to require an ability.';
-		} elseif (count($slotObj->symb) > 0) {
+		} elseif (isset($slotObj->symb)) {
 			$msg = 'You cannot require an ability for a symbiant.';
-		} elseif (!count($slotObj->shiny) && !count($slotObj->bright) && !count($slotObj->faded)) {
+		} elseif (!isset($slotObj->shiny) && !isset($slotObj->bright) && !isset($slotObj->faded)) {
 			$msg = 'You must have at least one cluster filled to require an ability.';
-		} elseif (count($slotObj->shiny) > 0 && count($slotObj->bright) > 0 && count($slotObj->faded) > 0) {
+		} elseif (isset($slotObj->shiny) && isset($slotObj->bright) && isset($slotObj->faded) > 0) {
 			$msg = 'You must have at least one empty cluster to require an ability.';
 		} else {
 			$blob  = '[' . Text::makeChatcmd('See Build', '/tell <myname> implantdesigner');
@@ -423,13 +423,13 @@ class ImplantDesignerController extends ModuleInstance {
 
 		$design = $this->getDesign($context->char->name, '@');
 		$slotObj = $design->{$slot->designSlotName()};
-		if (!count($slotObj)) {
+		if (!isset($slotObj)) {
 			$msg = 'You must have at least one cluster filled to require an ability.';
-		} elseif (count($slotObj->symb) > 0) {
+		} elseif (isset($slotObj->symb)) {
 			$msg = 'You cannot require an ability for a symbiant.';
-		} elseif (!count($slotObj->shiny) && !count($slotObj->bright) && !count($slotObj->faded)) {
+		} elseif (!isset($slotObj->shiny) && !isset($slotObj->bright) && !isset($slotObj->faded)) {
 			$msg = 'You must have at least one cluster filled to require an ability.';
-		} elseif (count($slotObj->shiny) > 0 && count($slotObj->bright) > 0 && count($slotObj->faded) > 0) {
+		} elseif (isset($slotObj->shiny) && isset($slotObj->bright) && isset($slotObj->faded)) {
 			$msg = 'You must have at least one empty cluster to require an ability.';
 		} else {
 			$blob  = '[' . Text::makeChatcmd('See Build', '/tell <myname> implantdesigner');
@@ -458,13 +458,13 @@ class ImplantDesignerController extends ModuleInstance {
 				->orderBy('c2.LongName')
 				->orderBy('c3.LongName');
 
-			if (count($slotObj->shiny) > 0) {
+			if (isset($slotObj->shiny)) {
 				$query->where('c1.LongName', $slotObj->shiny);
 			}
-			if (count($slotObj->bright) > 0) {
+			if (isset($slotObj->bright)) {
 				$query->where('c2.LongName', $slotObj->bright);
 			}
-			if (count($slotObj->faded) > 0) {
+			if (isset($slotObj->faded)) {
 				$query->where('c3.LongName', $slotObj->faded);
 			}
 
@@ -472,13 +472,13 @@ class ImplantDesignerController extends ModuleInstance {
 			$primary = null;
 			foreach ($data as $row) {
 				$results = [];
-				if (!count($slotObj->shiny)) {
+				if (!isset($slotObj->shiny)) {
 					$results []= ['shiny', $row->ShinyEffect];
 				}
-				if (!count($slotObj->bright)) {
+				if (!isset($slotObj->bright)) {
 					$results []= ['bright', $row->BrightEffect];
 				}
-				if (!count($slotObj->faded)) {
+				if (!isset($slotObj->faded)) {
 					$results []= ['faded', $row->FadedEffect];
 				}
 
@@ -532,11 +532,11 @@ class ImplantDesignerController extends ModuleInstance {
 			$slotObj = $design->{$slot};
 
 			// skip empty slots
-			if (!count($slotObj)) {
+			if (!isset($slotObj)) {
 				continue;
 			}
 
-			if (count($slotObj->symb) > 0) {
+			if (isset($slotObj->symb)) {
 				$symb = $slotObj->symb;
 
 				// add reqs
@@ -558,7 +558,7 @@ class ImplantDesignerController extends ModuleInstance {
 				}
 			} else {
 				$ql = 300;
-				if (count($slotObj->ql) > 0) {
+				if (isset($slotObj->ql)) {
 					$ql = (int)$slotObj->ql;
 				}
 
@@ -579,7 +579,7 @@ class ImplantDesignerController extends ModuleInstance {
 
 				// add mods
 				foreach ($this->grades as $grade) {
-					if (count($slotObj->{$grade}) > 0) {
+					if (isset($slotObj->{$grade})) {
 						$effectTypeIdName = ucfirst(strtolower($grade)) . 'EffectTypeID';
 						$effectId = $implant->{$effectTypeIdName};
 						$mods[$slotObj->{$grade}] += $this->getClusterModAmount($ql, $grade, $effectId);
@@ -758,7 +758,7 @@ class ImplantDesignerController extends ModuleInstance {
 
 		foreach ($this->slots as $slot) {
 			$blob .= Text::makeChatcmd($slot, "/tell <myname> implantdesigner {$slot}");
-			if (count($design->{$slot}) > 0) {
+			if (isset($design->{$slot})) {
 				$blob .= $this->getImplantSummary($design->{$slot});
 			} else {
 				$blob .= "\n";
@@ -774,7 +774,7 @@ class ImplantDesignerController extends ModuleInstance {
 			$msg = ' ' . $slotObj->symb->name . "\n";
 			return $msg;
 		}
-		$ql = !count($slotObj->ql) ? 300 : (int)$slotObj->ql;
+		$ql = (int)($slotObj->ql ?? 300);
 		$implant = $this->getImplantInfo($ql, $slotObj->shiny, $slotObj->bright, $slotObj->faded);
 		$msg = ' QL' . $ql;
 		if ($implant !== null) {
@@ -783,7 +783,7 @@ class ImplantDesignerController extends ModuleInstance {
 		$msg .= "\n";
 
 		foreach ($this->grades as $grade) {
-			if (!count($slotObj->{$grade})) {
+			if (!isset($slotObj->{$grade})) {
 				$msg .= "<tab><highlight>-Empty-<end>\n";
 			} else {
 				$effectTypeIdName = ucfirst(strtolower($grade)) . 'EffectTypeID';
@@ -833,7 +833,7 @@ class ImplantDesignerController extends ModuleInstance {
 
 	private function showClusterChoices(object $design, string $slot, string $grade): string {
 		$msg = '';
-		if (count($design->{$slot}->{$grade}) > 0) {
+		if (isset($design->{$slot}->{$grade})) {
 			$msg .= " - {$design->{$slot}->{$grade}}";
 		}
 		$msg .= "\n";

--- a/src/Modules/ITEMS_MODULE/ItemGroup.php
+++ b/src/Modules/ITEMS_MODULE/ItemGroup.php
@@ -2,13 +2,13 @@
 
 namespace Nadybot\Modules\ITEMS_MODULE;
 
-use Nadybot\Core\Attributes\DB\{AutoInc, Shared, Table};
+use Nadybot\Core\Attributes\DB\{Shared, Table};
 use Nadybot\Core\DBTable;
 
 #[Table(name: 'item_groups', shared: Shared::Yes)]
 class ItemGroup extends DBTable {
 	public function __construct(
-		#[AutoInc] public int $id,
+		public int $id,
 		public int $group_id,
 		public int $item_id,
 	) {

--- a/src/Modules/ITEMS_MODULE/ItemsController.php
+++ b/src/Modules/ITEMS_MODULE/ItemsController.php
@@ -274,9 +274,20 @@ class ItemsController extends ModuleInstance {
 				->where('a.highql', '>=', $ql);
 		}
 		$innerQuery->groupByRaw($innerQuery->colFunc('COALESCE', ['g.group_id', 'a.lowid']))
-			->groupBy('a.lowid', 'a.highid', 'a.lowql', 'a.highql', 'a.name')
-			->groupBy('a.icon', 'a.froob_friendly', 'a.slot', 'a.flags', 'g.group_id', 'a.in_game')
-			->orderBy('a.name')
+			->groupBy(
+				'a.lowid',
+				'a.highid',
+				'a.lowql',
+				'a.highql',
+				'a.name',
+				'a.icon',
+				'a.froob_friendly',
+				'a.slot',
+				'a.flags',
+				'g.group_id',
+				'a.in_game',
+				'a.type'
+			)->orderBy('a.name')
 			->orderByDesc('a.highql')
 			->limit($this->maxitems)
 			->select(['a.*', 'g.group_id']);

--- a/src/Modules/ITEMS_MODULE/WhatBuffsController.php
+++ b/src/Modules/ITEMS_MODULE/WhatBuffsController.php
@@ -468,7 +468,7 @@ class WhatBuffsController extends ModuleInstance {
 				})->groupBy([
 					'a.name', 'a.lowql', 'a.highql', 'b.amount', 'b2.amount', 'a.lowid',
 					'a.highid', 'a.icon', 'a.froob_friendly', 'a.slot', 'a.flags', 's.unit',
-					'a.in_game',
+					'a.in_game', 'a.type',
 				])->orderByDesc($query->raw($query->colFunc('ABS', 'b.amount')))
 				->orderByDesc('name')
 				->select([

--- a/src/Modules/LOOT_MODULE/LootHistory.php
+++ b/src/Modules/LOOT_MODULE/LootHistory.php
@@ -3,23 +3,28 @@
 namespace Nadybot\Modules\LOOT_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[NCA\DB\Table(name: 'loot_history')]
 class LootHistory extends DBTable {
+	/** Artificial primary key */
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param int      $roll      The n-th roll on this bot
-	 * @param int      $pos       Position on the loot table (starting with 1)
-	 * @param string   $name      Simple name (without HTML) of the item
-	 * @param int      $dt        Unix timestamp when it was rolled
-	 * @param string   $added_by  Who added this item to the loot table
-	 * @param string   $rolled_by Who did the !flatroll
-	 * @param int      $amount    How many items of this in total were rolled in this slot
-	 * @param ?int     $icon      Funcom aodb icon id
-	 * @param string   $display   Nice display (including item link) of the item
-	 * @param string   $comment   Optional comment about the item
-	 * @param ?string  $winner    If someone won the item, name of the winner
-	 * @param ?int     $id        Artificial primary key
-	 * @param string[] $winners
+	 * @param int            $roll      The n-th roll on this bot
+	 * @param int            $pos       Position on the loot table (starting with 1)
+	 * @param string         $name      Simple name (without HTML) of the item
+	 * @param int            $dt        Unix timestamp when it was rolled
+	 * @param string         $added_by  Who added this item to the loot table
+	 * @param string         $rolled_by Who did the !flatroll
+	 * @param int            $amount    How many items of this in total were rolled in this slot
+	 * @param ?int           $icon      Funcom aodb icon id
+	 * @param string         $display   Nice display (including item link) of the item
+	 * @param string         $comment   Optional comment about the item
+	 * @param ?string        $winner    If someone won the item, name of the winner
+	 * @param ?UuidInterface $id        Artificial primary key
+	 * @param string[]       $winners
 	 *
 	 * @psalm-param list<string> $winners
 	 */
@@ -35,8 +40,9 @@ class LootHistory extends DBTable {
 		public string $display='',
 		public string $comment='',
 		public ?string $winner=null,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 		#[NCA\DB\Ignore] public array $winners=[],
 	) {
+		$this->id = $id ?? Uuid::uuid7((new DateTimeImmutable())->setTimestamp($dt));
 	}
 }

--- a/src/Modules/LOOT_MODULE/Migrations/MigrateLootHistoryTableToUuid.php
+++ b/src/Modules/LOOT_MODULE/Migrations/MigrateLootHistoryTableToUuid.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\LOOT_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\LOOT_MODULE\LootHistory;
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_12_38_00)]
+class MigrateLootHistoryTableToUuid implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			LootHistory::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->unsignedInteger('dt')->index();
+				$table->unsignedInteger('roll')->index();
+				$table->unsignedInteger('pos');
+				$table->unsignedInteger('amount');
+				$table->string('name', 200);
+				$table->unsignedInteger('icon')->nullable();
+				$table->string('added_by', 12)->index();
+				$table->string('rolled_by', 12);
+				$table->string('display', 200);
+				$table->string('comment', 200);
+				$table->string('winner', 12)->nullable(true)->index();
+			},
+			'id',
+			'dt'
+		);
+	}
+}

--- a/src/Modules/MOB_MODULE/Migrations/SetRouteFormat.php
+++ b/src/Modules/MOB_MODULE/Migrations/SetRouteFormat.php
@@ -10,15 +10,15 @@ use Psr\Log\LoggerInterface;
 #[NCA\Migration(order: 2023_03_31_21_14_36)]
 class SetRouteFormat implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$db->insert(new RouteHopFormat(
-			hop: 'mobs',
-			render: false,
-			format: 'MOBS',
-		));
+		$db->table(RouteHopFormat::getTable())->insert([
+			'hop' => 'mobs',
+			'render' => false,
+			'format' => 'MOBS',
+		]);
 
-		$db->insert(new RouteHopColor(
-			hop: 'mobs',
-			tag_color: '00A9B5',
-		));
+		$db->table(RouteHopColor::getTable())->insert([
+			'hop' => 'mobs',
+			'tag_color' => '00A9B5',
+		]);
 	}
 }

--- a/src/Modules/NEWS_MODULE/INews.php
+++ b/src/Modules/NEWS_MODULE/INews.php
@@ -2,15 +2,16 @@
 
 namespace Nadybot\Modules\NEWS_MODULE;
 
+use Ramsey\Uuid\UuidInterface;
+
 class INews extends News {
 	/**
-	 * @param int     $time    Unix timestamp when this was created
-	 * @param string  $name    Name of the character who created the entry
-	 * @param string  $news    Text of these news
-	 * @param bool    $sticky  Set to true if this is pinned above all unpinned news
-	 * @param bool    $deleted Set to true if this is actually deleted
-	 * @param ?string $uuid    The UUID of this news entry
-	 * @param ?int    $id      The internal ID of this news entry
+	 * @param int            $time    Unix timestamp when this was created
+	 * @param string         $name    Name of the character who created the entry
+	 * @param string         $news    Text of these news
+	 * @param bool           $sticky  Set to true if this is pinned above all unpinned news
+	 * @param bool           $deleted Set to true if this is actually deleted
+	 * @param ?UuidInterface $id      The internal ID of this news entry
 	 */
 	public function __construct(
 		int $time,
@@ -18,8 +19,7 @@ class INews extends News {
 		string $news,
 		bool $sticky,
 		bool $deleted,
-		?string $uuid=null,
-		?int $id=null,
+		?UuidInterface $id=null,
 		public bool $confirmed=false,
 	) {
 		parent::__construct(
@@ -28,7 +28,6 @@ class INews extends News {
 			news: $news,
 			sticky: $sticky,
 			deleted: $deleted,
-			uuid: $uuid,
 			id: $id,
 		);
 	}

--- a/src/Modules/NEWS_MODULE/Migrations/MigrateNewsTableToUuid.php
+++ b/src/Modules/NEWS_MODULE/Migrations/MigrateNewsTableToUuid.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\NEWS_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\NEWS_MODULE\{News, NewsConfirmed};
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+use Safe\DateTimeImmutable;
+
+#[NCA\Migration(order: 2024_08_02_14_08_00, shared: true)]
+class MigrateNewsTableToUuid implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$column = 'id';
+		$table = News::getTable();
+		$entries = $db->table($table)->orderBy($column)->get();
+		$db->schema()->drop($table);
+		$db->schema()->create(
+			$table,
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->integer('time');
+				$table->string('name', 30)->nullable();
+				$table->text('news')->nullable();
+				$table->tinyInteger('sticky');
+				$table->tinyInteger('deleted');
+			},
+		);
+
+		$idToUuid = [];
+
+		/** @return array<string,mixed> */
+		$entries = $entries->map(static function (\stdClass $entry) use (&$idToUuid): array {
+			$time = $entry->{'time'} ?? null;
+			if (isset($time)) {
+				$time = (new DateTimeImmutable())->setTimestamp($time);
+			}
+			$uuid = isset($entry->uuid) ? Uuid::fromString($entry->uuid) : Uuid::uuid7($time);
+			$idToUuid[(int)$entry->id] = $uuid;
+			$entry->id = $uuid->toString();
+			$array = (array)$entry;
+			unset($array['uuid']);
+			return $array;
+		})->toList();
+		$db->table($table)->chunkInsert($entries);
+
+		$table = NewsConfirmed::getTable();
+		$confirmed = $db->table($table)->get();
+		$db->schema()->drop($table);
+		$db->schema()->create(
+			$table,
+			static function (Blueprint $table): void {
+				$table->uuid('id')->index();
+				$table->string('player', 20)->index();
+				$table->integer('time');
+				$table->unique(['id', 'player']);
+			}
+		);
+
+		$entries = $confirmed->map(static function (\stdClass $entry) use ($idToUuid): array {
+			$entry->id = $idToUuid[$entry->id];
+			return (array)$entry;
+		})->toList();
+		$db->table($table)->chunkInsert($entries);
+	}
+}

--- a/src/Modules/NEWS_MODULE/News.php
+++ b/src/Modules/NEWS_MODULE/News.php
@@ -2,20 +2,22 @@
 
 namespace Nadybot\Modules\NEWS_MODULE;
 
-use Nadybot\Core\{Attributes as NCA, DBTable, Util};
+use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[NCA\DB\Table(name: 'news', shared: NCA\DB\Shared::Yes)]
 class News extends DBTable {
-	public string $uuid;
+	/** The internal ID of this news entry */
+	#[NCA\DB\PK] public UuidInterface $id;
 
 	/**
-	 * @param int     $time    Unix timestamp when this was created
-	 * @param string  $name    Name of the character who created the entry
-	 * @param string  $news    Text of these news
-	 * @param bool    $sticky  Set to true if this is pinned above all unpinned news
-	 * @param bool    $deleted Set to true if this is actually deleted
-	 * @param ?string $uuid    The UUID of this news entry
-	 * @param ?int    $id      The internal ID of this news entry
+	 * @param int            $time    Unix timestamp when this was created
+	 * @param string         $name    Name of the character who created the entry
+	 * @param string         $news    Text of these news
+	 * @param bool           $sticky  Set to true if this is pinned above all unpinned news
+	 * @param bool           $deleted Set to true if this is actually deleted
+	 * @param ?UuidInterface $id      The internal ID of this news entry
 	 */
 	public function __construct(
 		public int $time,
@@ -23,9 +25,8 @@ class News extends DBTable {
 		public string $news,
 		public bool $sticky,
 		public bool $deleted,
-		?string $uuid=null,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
-		$this->uuid = $uuid ?? Util::createUUID();
+		$this->id = $id ?? Uuid::uuid7((new DateTimeImmutable())->setTimestamp($time));
 	}
 }

--- a/src/Modules/NEWS_MODULE/NewsConfirmed.php
+++ b/src/Modules/NEWS_MODULE/NewsConfirmed.php
@@ -3,12 +3,13 @@
 namespace Nadybot\Modules\NEWS_MODULE;
 
 use Nadybot\Core\{Attributes\DB, DBTable};
+use Ramsey\Uuid\UuidInterface;
 
 #[DB\Table(name: 'news_confirmed', shared: DB\Shared::Yes)]
 class NewsConfirmed extends DBTable {
-	/** @param int $id The confirmed news entry */
+	/** @param UuidInterface $id The confirmed news entry */
 	public function __construct(
-		#[DB\PK] public int $id,
+		#[DB\PK] public UuidInterface $id,
 		#[DB\PK] public string $player,
 		public int $time,
 	) {

--- a/src/Modules/NEWS_MODULE/NewsController.php
+++ b/src/Modules/NEWS_MODULE/NewsController.php
@@ -9,6 +9,7 @@ use Amp\Http\Server\{Request, Response};
 use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion, ObjectMapperUsingReflection};
 use Exception;
 use Illuminate\Support\Collection;
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
@@ -236,8 +237,9 @@ class NewsController extends ModuleInstance {
 	public function newsconfirmCommand(
 		CmdContext $context,
 		#[NCA\Str('confirm')] string $action,
-		string $id
+		PUuid $id
 	): void {
+		$id = $id();
 		$row = $this->getNewsItem($id);
 		if ($row === null) {
 			$msg = "No news entry found with the ID <highlight>{$id}<end>.";
@@ -301,8 +303,9 @@ class NewsController extends ModuleInstance {
 	public function newsRemCommand(
 		CmdContext $context,
 		PRemove $action,
-		string $id
+		PUuid $id
 	): void {
+		$id = $id();
 		$row = $this->getNewsItem($id);
 		if ($row === null) {
 			$msg = "No news entry found with the ID <highlight>{$id}<end>.";
@@ -326,8 +329,9 @@ class NewsController extends ModuleInstance {
 	public function newsPinCommand(
 		CmdContext $context,
 		#[NCA\Str('pin')] string $action,
-		string $id
+		PUuid $id
 	): void {
+		$id = $id();
 		$row = $this->getNewsItem($id);
 
 		if (!isset($row)) {
@@ -357,8 +361,9 @@ class NewsController extends ModuleInstance {
 	public function newsUnpinCommand(
 		CmdContext $context,
 		#[NCA\Str('unpin')] string $action,
-		string $id
+		PUuid $id
 	): void {
+		$id = $id();
 		$row = $this->getNewsItem($id);
 
 		if (!isset($row)) {

--- a/src/Modules/NEWS_MODULE/NewsController.php
+++ b/src/Modules/NEWS_MODULE/NewsController.php
@@ -236,7 +236,7 @@ class NewsController extends ModuleInstance {
 	public function newsconfirmCommand(
 		CmdContext $context,
 		#[NCA\Str('confirm')] string $action,
-		int $id
+		string $id
 	): void {
 		$row = $this->getNewsItem($id);
 		if ($row === null) {
@@ -259,7 +259,7 @@ class NewsController extends ModuleInstance {
 			return;
 		}
 		$this->db->insert(new NewsConfirmed(
-			id: $id,
+			id: $row->id,
 			player: $sender,
 			time: time(),
 		));
@@ -280,7 +280,6 @@ class NewsController extends ModuleInstance {
 			news: $news,
 			sticky: false,
 			deleted: false,
-			uuid: Util::createUUID(),
 		);
 		$this->db->insert($entry);
 		$msg = 'News has been added successfully.';
@@ -288,7 +287,7 @@ class NewsController extends ModuleInstance {
 			time: $entry->time,
 			name: $entry->name,
 			news: $entry->news,
-			uuid: $entry->uuid,
+			uuid: $entry->id->toString(),
 			sticky: $entry->sticky,
 			forceSync: $context->forceSync,
 		);
@@ -302,7 +301,7 @@ class NewsController extends ModuleInstance {
 	public function newsRemCommand(
 		CmdContext $context,
 		PRemove $action,
-		int $id
+		string $id
 	): void {
 		$row = $this->getNewsItem($id);
 		if ($row === null) {
@@ -313,7 +312,7 @@ class NewsController extends ModuleInstance {
 				->update(['deleted' => 1]);
 			$msg = "News entry <highlight>{$id}<end> was deleted successfully.";
 			$event = new SyncNewsDeleteEvent(
-				uuid: $row->uuid,
+				uuid: $row->id->toString(),
 				forceSync: $context->forceSync,
 			);
 			$this->eventManager->fireEvent($event);
@@ -327,7 +326,7 @@ class NewsController extends ModuleInstance {
 	public function newsPinCommand(
 		CmdContext $context,
 		#[NCA\Str('pin')] string $action,
-		int $id
+		string $id
 	): void {
 		$row = $this->getNewsItem($id);
 
@@ -344,7 +343,7 @@ class NewsController extends ModuleInstance {
 				time: $row->time,
 				name: $row->name,
 				news: $row->news,
-				uuid: $row->uuid,
+				uuid: $row->id->toString(),
 				sticky: true,
 				forceSync: $context->forceSync,
 			);
@@ -358,7 +357,7 @@ class NewsController extends ModuleInstance {
 	public function newsUnpinCommand(
 		CmdContext $context,
 		#[NCA\Str('unpin')] string $action,
-		int $id
+		string $id
 	): void {
 		$row = $this->getNewsItem($id);
 
@@ -375,7 +374,7 @@ class NewsController extends ModuleInstance {
 				time: $row->time,
 				name: $row->name,
 				news: $row->news,
-				uuid: $row->uuid,
+				uuid: $row->id->toString(),
 				sticky: false,
 				forceSync: $context->forceSync,
 			);
@@ -384,10 +383,10 @@ class NewsController extends ModuleInstance {
 		$context->reply($msg);
 	}
 
-	public function getNewsItem(int $id): ?News {
+	public function getNewsItem(\Stringable|string $id): ?News {
 		return $this->db->table(News::getTable())
 			->where('deleted', 0)
-			->where('id', $id)
+			->where('id', (string)$id)
 			->asObj(News::class)
 			->first();
 	}
@@ -414,7 +413,7 @@ class NewsController extends ModuleInstance {
 		NCA\ApiResult(code: 200, class: 'News', desc: 'The requested news item'),
 		NCA\ApiResult(code: 404, desc: 'Given news id not found')
 	]
-	public function apiNewsIdEndpoint(Request $request, int $id): Response {
+	public function apiNewsIdEndpoint(Request $request, string $id): Response {
 		$result = $this->getNewsItem($id);
 		if (!isset($result)) {
 			return new Response(status: HttpStatus::NOT_FOUND);
@@ -472,7 +471,7 @@ class NewsController extends ModuleInstance {
 		NCA\RequestBody(class: 'NewNews', desc: 'The new data for the item', required: true),
 		NCA\ApiResult(code: 200, class: 'News', desc: 'The news item it is now')
 	]
-	public function apiNewsModifyEndpoint(Request $request, int $id): Response {
+	public function apiNewsModifyEndpoint(Request $request, string $id): Response {
 		$oldItem = $this->getNewsItem($id);
 		if (!isset($oldItem)) {
 			return new Response(status: HttpStatus::NOT_FOUND);

--- a/src/Modules/NEWS_MODULE/SyncNewsEvent.php
+++ b/src/Modules/NEWS_MODULE/SyncNewsEvent.php
@@ -33,7 +33,7 @@ class SyncNewsEvent extends SyncEvent {
 			time: $news->time,
 			name: $news->name,
 			news: $news->news,
-			uuid: $news->uuid,
+			uuid: $news->id->toString(),
 			sticky: $news->sticky,
 		);
 	}

--- a/src/Modules/NOTES_MODULE/Link.php
+++ b/src/Modules/NOTES_MODULE/Link.php
@@ -3,9 +3,12 @@
 namespace Nadybot\Modules\NOTES_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[NCA\DB\Table(name: 'links', shared: NCA\DB\Shared::Yes)]
 class Link extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
 	public int $dt;
 
 	public function __construct(
@@ -13,8 +16,13 @@ class Link extends DBTable {
 		public string $website,
 		public string $comments,
 		?int $dt=null,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
 		$this->dt = $dt ?? time();
+		$time = null;
+		if (isset($dt) && !isset($id)) {
+			$time = (new DateTimeImmutable())->setTimestamp($dt);
+		}
+		$this->id = $id ?? Uuid::uuid7($time);
 	}
 }

--- a/src/Modules/NOTES_MODULE/LinksController.php
+++ b/src/Modules/NOTES_MODULE/LinksController.php
@@ -98,9 +98,9 @@ class LinksController extends ModuleInstance implements ImporterInterface, Expor
 		$context->reply($msg);
 	}
 
-	/** Remoev a link from the list */
+	/** Remove a link from the list */
 	#[NCA\HandlesCommand('links')]
-	public function linksRemoveCommand(CmdContext $context, PRemove $action, int $id): void {
+	public function linksRemoveCommand(CmdContext $context, PRemove $action, string $id): void {
 		/** @var ?Link */
 		$obj = $this->db->table(Link::getTable())
 			->where('id', $id)

--- a/src/Modules/NOTES_MODULE/LinksController.php
+++ b/src/Modules/NOTES_MODULE/LinksController.php
@@ -4,6 +4,7 @@ namespace Nadybot\Modules\NOTES_MODULE;
 
 use InvalidArgumentException;
 use Nadybot\Core\Config\BotConfig;
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	AccessManager,
 	Attributes as NCA,
@@ -100,7 +101,9 @@ class LinksController extends ModuleInstance implements ImporterInterface, Expor
 
 	/** Remove a link from the list */
 	#[NCA\HandlesCommand('links')]
-	public function linksRemoveCommand(CmdContext $context, PRemove $action, string $id): void {
+	public function linksRemoveCommand(CmdContext $context, PRemove $action, PUuid $id): void {
+		$id = $id();
+
 		/** @var ?Link */
 		$obj = $this->db->table(Link::getTable())
 			->where('id', $id)

--- a/src/Modules/NOTES_MODULE/Migrations/Links/CreateLinksTable.php
+++ b/src/Modules/NOTES_MODULE/Migrations/Links/CreateLinksTable.php
@@ -5,12 +5,13 @@ namespace Nadybot\Modules\NOTES_MODULE\Migrations\Links;
 use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\NOTES_MODULE\Link;
 use Psr\Log\LoggerInterface;
 
 #[NCA\Migration(order: 2021_04_27_05_36_08, shared: true)]
 class CreateLinksTable implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$table = 'links';
+		$table = Link::getTable();
 		if ($db->schema()->hasTable($table)) {
 			$db->schema()->table($table, static function (Blueprint $table): void {
 				$table->id('id')->change();

--- a/src/Modules/NOTES_MODULE/Migrations/Links/MigrateLinksTableToUuids.php
+++ b/src/Modules/NOTES_MODULE/Migrations/Links/MigrateLinksTableToUuids.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\NOTES_MODULE\Migrations\Links;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\NOTES_MODULE\Link;
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_01_12_14_00, shared: true)]
+class MigrateLinksTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			Link::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('name', 25);
+				$table->string('website', 255);
+				$table->string('comments', 255);
+				$table->integer('dt');
+			},
+			'id',
+			'dt'
+		);
+	}
+}

--- a/src/Modules/NOTES_MODULE/Migrations/Notes/MigrateNotesTableToUuids.php
+++ b/src/Modules/NOTES_MODULE/Migrations/Notes/MigrateNotesTableToUuids.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\NOTES_MODULE\Migrations\Notes;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\NOTES_MODULE\Note;
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_02_14_57_00, shared: true)]
+class MigrateNotesTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			Note::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('owner', 25);
+				$table->string('added_by', 25);
+				$table->text('note');
+				$table->integer('dt');
+				$table->integer('reminder')->default(0);
+			},
+			'id',
+			'dt'
+		);
+	}
+}

--- a/src/Modules/NOTES_MODULE/Migrations/OrgNotes/MigrateOrgNotesTableToUuids.php
+++ b/src/Modules/NOTES_MODULE/Migrations/OrgNotes/MigrateOrgNotesTableToUuids.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\NOTES_MODULE\Migrations\OrgNotes;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\NOTES_MODULE\{OrgNote};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_02_15_06_00, shared: true)]
+class MigrateOrgNotesTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$table =  OrgNote::getTable();
+		$entries = $db->table($table)->orderBy('id')->get();
+		$db->schema()->drop($table);
+		$db->schema()->create(
+			$table,
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('added_by', 12);
+				$table->integer('added_on');
+				$table->text('note');
+			}
+		);
+
+		/** @return array<string,mixed> */
+		$entries = $entries->map(static function (\stdClass $entry): array {
+			$new = (array)$entry;
+			$new['id'] = $new['uuid'];
+			unset($new['uuid']);
+			return $new;
+		})->toList();
+		$db->table($table)->chunkInsert($entries);
+	}
+}

--- a/src/Modules/NOTES_MODULE/Note.php
+++ b/src/Modules/NOTES_MODULE/Note.php
@@ -3,6 +3,8 @@
 namespace Nadybot\Modules\NOTES_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[NCA\DB\Table(name: 'notes', shared: NCA\DB\Shared::Yes)]
 class Note extends DBTable {
@@ -10,6 +12,7 @@ class Note extends DBTable {
 	public const REMIND_SELF = 1;
 	public const REMIND_ALL = 2;
 
+	#[NCA\DB\PK] public UuidInterface $id;
 	public int $dt;
 
 	public function __construct(
@@ -18,8 +21,13 @@ class Note extends DBTable {
 		public string $note,
 		?int $dt=null,
 		public int $reminder=self::REMIND_NONE,
-		#[NCA\DB\AutoInc] public ?int $id=null
+		?UuidInterface $id=null,
 	) {
 		$this->dt = $dt ?? time();
+		$time = null;
+		if (isset($dt) && !isset($id)) {
+			$time = ((new DateTimeImmutable())->setTimestamp($dt));
+		}
+		$this->id = $id ?? Uuid::uuid7($time);
 	}
 }

--- a/src/Modules/NOTES_MODULE/NotesController.php
+++ b/src/Modules/NOTES_MODULE/NotesController.php
@@ -3,6 +3,7 @@
 namespace Nadybot\Modules\NOTES_MODULE;
 
 use Nadybot\Core\Modules\ALTS\AltNewMainEvent;
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	Attributes as NCA,
 	BuddylistManager,
@@ -194,7 +195,8 @@ class NotesController extends ModuleInstance {
 	/** Remove a note from your list */
 	#[NCA\HandlesCommand('notes')]
 	#[NCA\Help\Group('notes')]
-	public function notesRemoveCommand(CmdContext $context, PRemove $action, string $id): void {
+	public function notesRemoveCommand(CmdContext $context, PRemove $action, PUuid $id): void {
+		$id = $id();
 		$altInfo = $this->altsController->getAltInfo($context->char->name);
 		$main = $altInfo->getValidatedMain($context->char->name);
 
@@ -224,8 +226,9 @@ class NotesController extends ModuleInstance {
 		CmdContext $context,
 		#[NCA\Str('set')] string $action,
 		#[NCA\StrChoice('all', 'self', 'off')] string $type,
-		string $id
+		PUuid $id
 	): void {
+		$id = $id();
 		$reminder = Note::REMIND_ALL;
 		if ($type === 'self') {
 			$reminder = Note::REMIND_SELF;

--- a/src/Modules/NOTES_MODULE/NotesController.php
+++ b/src/Modules/NOTES_MODULE/NotesController.php
@@ -194,7 +194,7 @@ class NotesController extends ModuleInstance {
 	/** Remove a note from your list */
 	#[NCA\HandlesCommand('notes')]
 	#[NCA\Help\Group('notes')]
-	public function notesRemoveCommand(CmdContext $context, PRemove $action, int $id): void {
+	public function notesRemoveCommand(CmdContext $context, PRemove $action, string $id): void {
 		$altInfo = $this->altsController->getAltInfo($context->char->name);
 		$main = $altInfo->getValidatedMain($context->char->name);
 
@@ -224,7 +224,7 @@ class NotesController extends ModuleInstance {
 		CmdContext $context,
 		#[NCA\Str('set')] string $action,
 		#[NCA\StrChoice('all', 'self', 'off')] string $type,
-		int $id
+		string $id
 	): void {
 		$reminder = Note::REMIND_ALL;
 		if ($type === 'self') {
@@ -239,7 +239,7 @@ class NotesController extends ModuleInstance {
 			->where('owner', $main)
 			->update(['reminder' => $reminder]);
 		if (!$updated) {
-			$context->reply("No note or reminder #{$id} found for you.");
+			$context->reply("No note or reminder {$id} found for you.");
 			return;
 		}
 		$msg = 'Reminder changed successfully.';

--- a/src/Modules/NOTES_MODULE/OrgNote.php
+++ b/src/Modules/NOTES_MODULE/OrgNote.php
@@ -3,18 +3,25 @@
 namespace Nadybot\Modules\NOTES_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[NCA\DB\Table(name: 'org_notes', shared: NCA\DB\Shared::Yes)]
 class OrgNote extends DBTable {
 	public int $added_on;
+	#[NCA\DB\PK] public UuidInterface $id;
 
 	public function __construct(
-		public string $uuid,
 		public string $added_by,
 		public string $note,
 		?int $added_on=null,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
 		$this->added_on = $added_on ?? time();
+		$time = null;
+		if (isset($added_on) && !isset($id)) {
+			$time = ((new DateTimeImmutable())->setTimestamp($added_on));
+		}
+		$this->id = $id ?? Uuid::uuid7($time);
 	}
 }

--- a/src/Modules/NOTES_MODULE/OrgNotesController.php
+++ b/src/Modules/NOTES_MODULE/OrgNotesController.php
@@ -3,6 +3,7 @@
 namespace Nadybot\Modules\NOTES_MODULE;
 
 use Illuminate\Support\Collection;
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	AccessManager,
 	Attributes as NCA,
@@ -166,8 +167,9 @@ class OrgNotesController extends ModuleInstance {
 	public function cmdRemOrgNote(
 		CmdContext $context,
 		PRemove $action,
-		string $id
+		PUuid $id
 	): void {
+		$id = $id();
 		try {
 			$removed = $this->removeOrgNoteId($id, $context->char->name, $context->forceSync);
 		} catch (InsufficientAccessException $e) {

--- a/src/Modules/NOTES_MODULE/OrgNotesController.php
+++ b/src/Modules/NOTES_MODULE/OrgNotesController.php
@@ -16,6 +16,7 @@ use Nadybot\Core\{
 	Text,
 	Util,
 };
+use Ramsey\Uuid\Uuid;
 
 /**
  * @author Nadyita (RK5)
@@ -69,9 +70,9 @@ class OrgNotesController extends ModuleInstance {
 	}
 
 	/** Get a single org note */
-	public function getOrgNote(int $id): ?OrgNote {
+	public function getOrgNote(\Stringable|string $id): ?OrgNote {
 		return $this->db->table(OrgNote::getTable())
-			->where('id', $id)
+			->where('id', (string)$id)
 			->asObj(OrgNote::class)
 			->first();
 	}
@@ -79,10 +80,9 @@ class OrgNotesController extends ModuleInstance {
 	public function createOrgNote(string $creator, string $text, bool $forceSync=false): OrgNote {
 		$note = new OrgNote(
 			added_by: $creator,
-			uuid: Util::createUUID(),
 			note: $text,
 		);
-		$note->id = $this->db->insert($note);
+		$this->db->insert($note);
 
 		$event = SyncOrgNoteEvent::fromOrgNote($note);
 		$event->forceSync = $forceSync;
@@ -97,7 +97,7 @@ class OrgNotesController extends ModuleInstance {
 			return false;
 		}
 		$event = new SyncOrgNoteDeleteEvent(
-			uuid: $note->uuid,
+			uuid: $note->id->toString(),
 			forceSync: $forceSync,
 		);
 		$this->eventManager->fireEvent($event);
@@ -109,7 +109,7 @@ class OrgNotesController extends ModuleInstance {
 	 *
 	 * @throws InsufficientAccessException if no right to delete note
 	 */
-	public function removeOrgNoteId(int $noteId, string $actor, bool $forceSync=false): bool {
+	public function removeOrgNoteId(\Stringable|string $noteId, string $actor, bool $forceSync=false): bool {
 		$note = $this->getOrgNote($noteId);
 		if (!isset($note)) {
 			return false;
@@ -166,7 +166,7 @@ class OrgNotesController extends ModuleInstance {
 	public function cmdRemOrgNote(
 		CmdContext $context,
 		PRemove $action,
-		int $id
+		string $id
 	): void {
 		try {
 			$removed = $this->removeOrgNoteId($id, $context->char->name, $context->forceSync);
@@ -190,11 +190,12 @@ class OrgNotesController extends ModuleInstance {
 			return;
 		}
 		$note = $event->toOrgNote();
-		$note->id = $this->db->table(OrgNote::getTable())
+		$id = $this->db->table(OrgNote::getTable())
 			->where('uuid', $event->uuid)
-			->pluckInts('id')
+			->pluckStrings('id')
 			->first();
-		if (isset($note->id)) {
+		if (isset($id)) {
+			$note->id = Uuid::fromString($id);
 			$this->db->update($note);
 		} else {
 			$this->db->insert($note);

--- a/src/Modules/NOTES_MODULE/OrgNotesExporter.php
+++ b/src/Modules/NOTES_MODULE/OrgNotesExporter.php
@@ -9,10 +9,10 @@ use Nadybot\Core\{
 	ExportCharacter,
 	ExporterInterface,
 	ImporterInterface,
-	ModuleInstance,
-	Util
+	ModuleInstance
 };
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
 use Throwable;
 
 /**
@@ -33,7 +33,7 @@ class OrgNotesExporter extends ModuleInstance implements ExporterInterface, Impo
 					author: new ExportCharacter(name: $note->added_by),
 					creationTime: $note->added_on,
 					text: $note->note,
-					uuid: $note->uuid,
+					uuid: $note->id->toString(),
 				);
 			})->toList();
 	}
@@ -58,7 +58,7 @@ class OrgNotesExporter extends ModuleInstance implements ExporterInterface, Impo
 					added_by: $owner,
 					note: $note->text,
 					added_on: $note->creationTime ?? null,
-					uuid: $note->uuid ?? Util::createUUID(),
+					id: isset($note->uuid) ? Uuid::fromString($note->uuid) : null,
 				));
 			}
 		} catch (Throwable $e) {

--- a/src/Modules/NOTES_MODULE/SyncOrgNoteEvent.php
+++ b/src/Modules/NOTES_MODULE/SyncOrgNoteEvent.php
@@ -3,6 +3,7 @@
 namespace Nadybot\Modules\NOTES_MODULE;
 
 use Nadybot\Core\Events\SyncEvent;
+use Ramsey\Uuid\Uuid;
 
 class SyncOrgNoteEvent extends SyncEvent {
 	public const EVENT_MASK = 'sync(orgnote)';
@@ -31,7 +32,7 @@ class SyncOrgNoteEvent extends SyncEvent {
 			time: $note->added_on,
 			name: $note->added_by,
 			note: $note->note,
-			uuid: $note->uuid,
+			uuid: $note->id->toString(),
 		);
 	}
 
@@ -39,7 +40,7 @@ class SyncOrgNoteEvent extends SyncEvent {
 		$note = new OrgNote(
 			added_by: $this->name,
 			added_on: $this->time,
-			uuid: $this->uuid,
+			id: Uuid::fromString($this->uuid),
 			note: $this->note,
 		);
 		return $note;

--- a/src/Modules/ONLINE_MODULE/Migrations/MigrateOnlineHideTableToUuids.php
+++ b/src/Modules/ONLINE_MODULE/Migrations/MigrateOnlineHideTableToUuids.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\ONLINE_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\ONLINE_MODULE\{OnlineHide};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_02_15_25_00)]
+class MigrateOnlineHideTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			OnlineHide::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('mask', 20)->unique();
+				$table->string('created_by', 12);
+				$table->unsignedInteger('created_on');
+			},
+			'id',
+			'created_on'
+		);
+	}
+}

--- a/src/Modules/ONLINE_MODULE/OnlineController.php
+++ b/src/Modules/ONLINE_MODULE/OnlineController.php
@@ -337,12 +337,12 @@ class OnlineController extends ModuleInstance {
 	public function onlineDelHiddenByIDCommand(
 		CmdContext $context,
 		#[NCA\Str('show', 'unhide')] string $action,
-		int $id
+		string $id
 	): void {
 		if ($this->db->table(OnlineHide::getTable())->delete($id) === 0) {
-			$context->reply("The mask <highlight>#{$id}<end> is not hidden.");
+			$context->reply("The mask <highlight>{$id}<end> is not hidden.");
 		} else {
-			$context->reply("<highlight>#{$id}<end> removed from the online hidden mask list.");
+			$context->reply("<highlight>{$id}<end> removed from the online hidden mask list.");
 		}
 	}
 

--- a/src/Modules/ONLINE_MODULE/OnlineController.php
+++ b/src/Modules/ONLINE_MODULE/OnlineController.php
@@ -6,6 +6,7 @@ use function Safe\preg_match;
 
 use Amp\Http\Server\{Request, Response};
 use Illuminate\Support\Collection;
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	AccessManager,
 	Attributes as NCA,
@@ -337,8 +338,9 @@ class OnlineController extends ModuleInstance {
 	public function onlineDelHiddenByIDCommand(
 		CmdContext $context,
 		#[NCA\Str('show', 'unhide')] string $action,
-		string $id
+		PUuid $id
 	): void {
+		$id = $id();
 		if ($this->db->table(OnlineHide::getTable())->delete($id) === 0) {
 			$context->reply("The mask <highlight>{$id}<end> is not hidden.");
 		} else {

--- a/src/Modules/ONLINE_MODULE/OnlineHide.php
+++ b/src/Modules/ONLINE_MODULE/OnlineHide.php
@@ -4,6 +4,7 @@ namespace Nadybot\Modules\ONLINE_MODULE;
 
 use DateTimeInterface;
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 use Safe\DateTimeImmutable;
 
 /**
@@ -13,6 +14,9 @@ use Safe\DateTimeImmutable;
  */
 #[NCA\DB\Table(name: 'online_hide')]
 class OnlineHide extends DBTable {
+	/** The artificial ID of this hide mask */
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/** Time and date when this mask was created */
 	public DateTimeInterface $created_on;
 
@@ -20,14 +24,15 @@ class OnlineHide extends DBTable {
 	 * @param string             $mask       A glob mask that will match one or more names
 	 * @param string             $created_by Name of the character who hid this mask
 	 * @param ?DateTimeInterface $created_on Time and date when this mask was created
-	 * @param ?int               $id         The artificial ID of this hide mask
+	 * @param ?UuidInterface     $id         The artificial ID of this hide mask
 	 */
 	public function __construct(
 		public string $mask,
 		public string $created_by,
 		?DateTimeInterface $created_on=null,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
 		$this->created_on = $created_on ?? new DateTimeImmutable();
+		$this->id = $id ?? Uuid::uuid7($created_on);
 	}
 }

--- a/src/Modules/PRIVATE_CHANNEL_MODULE/Migrations/LockReminderToRoute.php
+++ b/src/Modules/PRIVATE_CHANNEL_MODULE/Migrations/LockReminderToRoute.php
@@ -18,13 +18,13 @@ class LockReminderToRoute implements SchemaMigration {
 			destination: Source::PRIV . "({$this->config->main->character})",
 			two_way: false,
 		);
-		$route->id = $db->insert($route);
+		$db->insert($route);
 
 		$route = new Route(
 			source: Source::SYSTEM . '(lock-reminder)',
 			destination: Source::ORG,
 			two_way: false,
 		);
-		$route->id = $db->insert($route);
+		$db->insert($route);
 	}
 }

--- a/src/Modules/PRIVATE_CHANNEL_MODULE/Migrations/LockReminderToRoute.php
+++ b/src/Modules/PRIVATE_CHANNEL_MODULE/Migrations/LockReminderToRoute.php
@@ -13,18 +13,18 @@ class LockReminderToRoute implements SchemaMigration {
 	private BotConfig $config;
 
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$route = new Route(
-			source: Source::SYSTEM . '(lock-reminder)',
-			destination: Source::PRIV . "({$this->config->main->character})",
-			two_way: false,
-		);
-		$db->insert($route);
+		$route = [
+			'source' => Source::SYSTEM . '(lock-reminder)',
+			'destination' => Source::PRIV . "({$this->config->main->character})",
+			'two_way' => false,
+		];
+		$db->table(Route::getTable())->insert($route);
 
-		$route = new Route(
-			source: Source::SYSTEM . '(lock-reminder)',
-			destination: Source::ORG,
-			two_way: false,
-		);
-		$db->insert($route);
+		$route = [
+			'source' => Source::SYSTEM . '(lock-reminder)',
+			'destination' => Source::ORG,
+			'two_way' => false,
+		];
+		$db->table(Route::getTable())->insert($route);
 	}
 }

--- a/src/Modules/PRIVATE_CHANNEL_MODULE/Migrations/MoveSettingsToRoutes.php
+++ b/src/Modules/PRIVATE_CHANNEL_MODULE/Migrations/MoveSettingsToRoutes.php
@@ -14,7 +14,6 @@ use Nadybot\Core\{
 	SchemaMigration,
 };
 use Psr\Log\LoggerInterface;
-use Ramsey\Uuid\UuidInterface;
 
 #[NCA\Migration(order: 2021_08_12_05_22_46)]
 class MoveSettingsToRoutes implements SchemaMigration {
@@ -33,31 +32,31 @@ class MoveSettingsToRoutes implements SchemaMigration {
 		$unfiltered = (!isset($ignoreSenders) || !strlen($ignoreSenders->value??''))
 			&& (!isset($relayFilter) || !strlen($relayFilter->value??''));
 
-		$route = new Route(
-			source: Source::PRIV . "({$this->config->main->character})",
-			destination: Source::ORG,
-			two_way: $unfiltered,
-		);
-		$db->insert($route);
-		$this->addCommandFilter($db, $relayCommands, $route->id);
+		$route = [
+			'source' => Source::PRIV . "({$this->config->main->character})",
+			'destination' => Source::ORG,
+			'two_way' => $unfiltered,
+		];
+		$route['id'] = $db->table(Route::getTable())->insertGetId($route);
+		$this->addCommandFilter($db, $relayCommands, $route['id']);
 		if ($unfiltered) {
 			return;
 		}
-		$route = new Route(
-			source: Source::ORG,
-			destination: Source::PRIV . "({$this->config->main->character})",
-			two_way: false,
-		);
-		$db->insert($route);
-		$this->addCommandFilter($db, $relayCommands, $route->id);
+		$route = [
+			'source' => Source::ORG,
+			'destination' => Source::PRIV . "({$this->config->main->character})",
+			'two_way' => false,
+		];
+		$route['id'] = $db->table(Route::getTable())->insertGetId($route);
+		$this->addCommandFilter($db, $relayCommands, $route['id']);
 
 		if (isset($ignoreSenders) && strlen($ignoreSenders->value??'') > 0) {
 			$toIgnore = explode(',', $ignoreSenders->value??'');
-			$this->ignoreSenders($db, $route->id, ...$toIgnore);
+			$this->ignoreSenders($db, $route['id'], ...$toIgnore);
 		}
 
 		if (isset($relayFilter) && strlen($relayFilter->value??'') > 0) {
-			$this->addRegExpFilter($db, $route->id, $relayFilter->value??'');
+			$this->addRegExpFilter($db, $route['id'], $relayFilter->value??'');
 		}
 	}
 
@@ -68,52 +67,52 @@ class MoveSettingsToRoutes implements SchemaMigration {
 			->first();
 	}
 
-	protected function addCommandFilter(DB $db, ?Setting $relayCommands, UuidInterface $routeId): void {
+	protected function addCommandFilter(DB $db, ?Setting $relayCommands, int $routeId): void {
 		if (!isset($relayCommands) || $relayCommands->value === '1') {
 			return;
 		}
-		$mod = new RouteModifier(
-			modifier: 'if-not-command',
-			route_id: $routeId,
-		);
-		$mod->id = $db->insert($mod);
+		$mod = [
+			'modifier' => 'if-not-command',
+			'route_id' => $routeId,
+		];
+		$db->table(RouteModifier::getTable())->insert($mod);
 	}
 
-	protected function ignoreSenders(DB $db, UuidInterface $routeId, string ...$senders): void {
+	protected function ignoreSenders(DB $db, int $routeId, string ...$senders): void {
 		foreach ($senders as $sender) {
-			$mod = new RouteModifier(
-				modifier: 'if-not-by',
-				route_id: $routeId,
-			);
-			$mod->id = $db->insert($mod);
+			$mod = [
+				'modifier' => 'if-not-by',
+				'route_id' => $routeId,
+			];
+			$mod['id'] = $db->table(RouteModifier::getTable())->insertGetId($mod);
 
-			$arg = new RouteModifierArgument(
-				name: 'sender',
-				value: $sender,
-				route_modifier_id: $mod->id,
-			);
+			$arg = [
+				'name' => 'sender',
+				'value' => $sender,
+				'route_modifier_id' => $mod['id'],
+			];
 
-			$arg->id = $db->insert($arg);
+			$arg['id'] = $db->table(RouteModifierArgument::getTable())->insertGetId($arg);
 		}
 	}
 
-	protected function addRegExpFilter(DB $db, UuidInterface $routeId, string $filter): void {
-		$mod = new RouteModifier(
-			modifier: 'if-matches',
-			route_id: $routeId,
-		);
-		$mod->id = $db->insert($mod);
+	protected function addRegExpFilter(DB $db, int $routeId, string $filter): void {
+		$mod = [
+			'modifier' => 'if-matches',
+			'route_id' => $routeId,
+		];
+		$mod['id'] = $db->table(RouteModifier::getTable())->insertGetId($mod);
 
-		$db->insert(new RouteModifierArgument(
-			name: 'text',
-			value: $filter,
-			route_modifier_id: $mod->id,
-		));
+		$db->table(RouteModifierArgument::getTable())->insert([
+			'name' => 'text',
+			'value' => $filter,
+			'route_modifier_id' => $mod['id'],
+		]);
 
-		$db->insert(new RouteModifierArgument(
-			name: 'regexp',
-			value: 'true',
-			route_modifier_id: $mod->id,
-		));
+		$db->table(RouteModifierArgument::getTable())->insert([
+			'name' => 'regexp',
+			'value' => 'true',
+			'route_modifier_id' => $mod['id'],
+		]);
 	}
 }

--- a/src/Modules/PRIVATE_CHANNEL_MODULE/Migrations/MoveSettingsToRoutes.php
+++ b/src/Modules/PRIVATE_CHANNEL_MODULE/Migrations/MoveSettingsToRoutes.php
@@ -14,6 +14,7 @@ use Nadybot\Core\{
 	SchemaMigration,
 };
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\UuidInterface;
 
 #[NCA\Migration(order: 2021_08_12_05_22_46)]
 class MoveSettingsToRoutes implements SchemaMigration {
@@ -37,7 +38,7 @@ class MoveSettingsToRoutes implements SchemaMigration {
 			destination: Source::ORG,
 			two_way: $unfiltered,
 		);
-		$route->id = $db->insert($route);
+		$db->insert($route);
 		$this->addCommandFilter($db, $relayCommands, $route->id);
 		if ($unfiltered) {
 			return;
@@ -47,7 +48,7 @@ class MoveSettingsToRoutes implements SchemaMigration {
 			destination: Source::PRIV . "({$this->config->main->character})",
 			two_way: false,
 		);
-		$route->id = $db->insert($route);
+		$db->insert($route);
 		$this->addCommandFilter($db, $relayCommands, $route->id);
 
 		if (isset($ignoreSenders) && strlen($ignoreSenders->value??'') > 0) {
@@ -67,7 +68,7 @@ class MoveSettingsToRoutes implements SchemaMigration {
 			->first();
 	}
 
-	protected function addCommandFilter(DB $db, ?Setting $relayCommands, int $routeId): void {
+	protected function addCommandFilter(DB $db, ?Setting $relayCommands, UuidInterface $routeId): void {
 		if (!isset($relayCommands) || $relayCommands->value === '1') {
 			return;
 		}
@@ -78,7 +79,7 @@ class MoveSettingsToRoutes implements SchemaMigration {
 		$mod->id = $db->insert($mod);
 	}
 
-	protected function ignoreSenders(DB $db, int $routeId, string ...$senders): void {
+	protected function ignoreSenders(DB $db, UuidInterface $routeId, string ...$senders): void {
 		foreach ($senders as $sender) {
 			$mod = new RouteModifier(
 				modifier: 'if-not-by',
@@ -96,7 +97,7 @@ class MoveSettingsToRoutes implements SchemaMigration {
 		}
 	}
 
-	protected function addRegExpFilter(DB $db, int $routeId, string $filter): void {
+	protected function addRegExpFilter(DB $db, UuidInterface $routeId, string $filter): void {
 		$mod = new RouteModifier(
 			modifier: 'if-matches',
 			route_id: $routeId,

--- a/src/Modules/PVP_MODULE/Migrations/AddRoutingLayoutAndColors.php
+++ b/src/Modules/PVP_MODULE/Migrations/AddRoutingLayoutAndColors.php
@@ -13,18 +13,18 @@ class AddRoutingLayoutAndColors implements SchemaMigration {
 		if ($db->table(RouteHopFormat::getTable())->whereIlike('hop', 'pvp%')->exists()) {
 			return;
 		}
-		$db->insert(new RouteHopFormat(
-			hop: 'pvp',
-			render: true,
-			format: 'PVP',
-		));
+		$db->table(RouteHopFormat::getTable())->insert([
+			'hop' => 'pvp',
+			'render' => true,
+			'format' => 'PVP',
+		]);
 
 		if ($db->table(RouteHopColor::getTable())->whereIlike('hop', 'pvp%')->exists()) {
 			return;
 		}
-		$db->insert(new RouteHopColor(
-			hop: 'pvp',
-			tag_color: 'F06AED',
-		));
+		$db->table(RouteHopColor::getTable())->insert([
+			'hop' => 'pvp',
+			'tag_color' => 'F06AED',
+		]);
 	}
 }

--- a/src/Modules/PVP_MODULE/Migrations/MigrateTrackerTableToUuids.php
+++ b/src/Modules/PVP_MODULE/Migrations/MigrateTrackerTableToUuids.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\PVP_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\DBSchema\Route;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\PVP_MODULE\{TrackerEntry};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_04_07_32_00)]
+class MigrateTrackerTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$idMapping = $db->migrateIdToUuid(
+			TrackerEntry::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('created_by', 12);
+				$table->unsignedInteger('created_on');
+				$table->string('expression');
+				$table->string('events');
+			},
+			'id',
+			'created_on'
+		);
+
+		foreach ($idMapping as $id => $uuid) {
+			$db->table(Route::getTable())
+				->where('source', "site-tracker({$id})")
+				->update(['source' => "site-tracker({$uuid})"]);
+			$db->table(Route::getTable())
+				->where('destination', "site-tracker({$id})")
+				->update(['destination' => "site-tracker({$uuid})"]);
+		}
+	}
+}

--- a/src/Modules/PVP_MODULE/Migrations/SetSiteTrackerRoutingFormat.php
+++ b/src/Modules/PVP_MODULE/Migrations/SetSiteTrackerRoutingFormat.php
@@ -3,14 +3,11 @@
 namespace Nadybot\Modules\PVP_MODULE\Migrations;
 
 use Nadybot\Core\DBSchema\{RouteHopColor, RouteHopFormat};
-use Nadybot\Core\{Attributes as NCA, DB, MessageHub, SchemaMigration};
+use Nadybot\Core\{Attributes as NCA, DB, SchemaMigration};
 use Psr\Log\LoggerInterface;
 
 #[NCA\Migration(order: 2023_03_08_16_39_57)]
 class SetSiteTrackerRoutingFormat implements SchemaMigration {
-	#[NCA\Inject]
-	private MessageHub $messageHub;
-
 	public function migrate(LoggerInterface $logger, DB $db): void {
 		$towerColor = 'F06AED';
 		$hopColor = [
@@ -26,7 +23,5 @@ class SetSiteTrackerRoutingFormat implements SchemaMigration {
 			'render' => true,
 		];
 		$db->table(RouteHopFormat::getTable())->insert($hopFormat);
-
-		$this->messageHub->loadTagFormat();
 	}
 }

--- a/src/Modules/PVP_MODULE/NotumWarsController.php
+++ b/src/Modules/PVP_MODULE/NotumWarsController.php
@@ -909,11 +909,11 @@ class NotumWarsController extends ModuleInstance {
 		$this->timerController->remove($timer->name);
 
 		$this->timerController->add(
-			$timer->name,
-			$context->char->name,
-			$timer->mode,
-			$timer->alerts,
-			'timercontroller.timerCallback'
+			name: $timer->name,
+			owner: $context->char->name,
+			mode: $timer->mode,
+			alerts: $timer->alerts,
+			callback: 'timercontroller.timerCallback',
 		);
 	}
 
@@ -1551,11 +1551,11 @@ class NotumWarsController extends ModuleInstance {
 			$this->timerController->remove($timer->name);
 
 			$this->timerController->add(
-				$timer->name,
-				$this->config->main->character,
-				$timer->mode,
-				$timer->alerts,
-				'timercontroller.timerCallback'
+				name: $timer->name,
+				owner: $this->config->main->character,
+				mode: $timer->mode,
+				alerts: $timer->alerts,
+				callback: 'timercontroller.timerCallback',
 			);
 		}
 		// Send "WW 6 @ QL 112 destroyed [details]"-message

--- a/src/Modules/PVP_MODULE/SiteTrackerController.php
+++ b/src/Modules/PVP_MODULE/SiteTrackerController.php
@@ -68,7 +68,7 @@ class SiteTrackerController extends ModuleInstance {
 	#[NCA\Inject]
 	private MessageHubController $msgHubCtrl;
 
-	/** @var array<int,TrackerEntry> */
+	/** @var array<string,TrackerEntry> */
 	private array $trackers = [];
 
 	/**
@@ -139,7 +139,7 @@ class SiteTrackerController extends ModuleInstance {
 						return $result;
 					}
 					$entry->handlers = $parsed->handlers;
-					$result[$entry->id] = $entry;
+					$result[$entry->id->toString()] = $entry;
 					$this->msgHub->registerMessageEmitter($entry);
 					return $result;
 				},
@@ -173,9 +173,9 @@ class SiteTrackerController extends ModuleInstance {
 	): void {
 		$entry = $this->parseExpression($expression);
 		$entry->created_by = $context->char->name;
-		$entry->id = $this->db->insert($entry);
+		$this->db->insert($entry);
 		$this->msgHub->registerMessageEmitter($entry);
-		$this->trackers[$entry->id] = $entry;
+		$this->trackers[$entry->id->toString()] = $entry;
 		$numMatches = $this->countMatches($entry);
 		$channel = $entry->getChannelName();
 		$details = '';
@@ -214,11 +214,11 @@ class SiteTrackerController extends ModuleInstance {
 		CmdContext $context,
 		#[NCA\Str('track', 'tracker')] string $action,
 		PRemove $subAction,
-		int $id,
+		string $id,
 	): void {
 		$tracker = $this->trackers[$id] ?? null;
 		if (!isset($tracker)) {
-			$context->reply("No tracker <highlight>#{$id}<end> found.");
+			$context->reply("No tracker <highlight>{$id}<end> found.");
 			return;
 		}
 		$this->db->table(TrackerEntry::getTable())->delete($id);
@@ -230,7 +230,7 @@ class SiteTrackerController extends ModuleInstance {
 			}
 		}
 		unset($this->trackers[$id]);
-		$context->reply("Tracker <highlight>#{$id}<end> successfully removed.");
+		$context->reply("Tracker <highlight>{$id}<end> successfully removed.");
 	}
 
 	/** Show all currently setup site trackers */
@@ -261,11 +261,11 @@ class SiteTrackerController extends ModuleInstance {
 		CmdContext $context,
 		#[NCA\Str('track', 'tracker')] string $action,
 		#[NCA\Str('show', 'view')] string $subAction,
-		int $id,
+		string $id,
 	): void {
 		$tracker = $this->trackers[$id] ?? null;
 		if (!isset($tracker)) {
-			$context->reply("No tracker <highlight>#{$id}<end> found.");
+			$context->reply("No tracker <highlight>{$id}<end> found.");
 			return;
 		}
 
@@ -431,7 +431,6 @@ class SiteTrackerController extends ModuleInstance {
 			events: $config->events,
 			handlers: $handlers,
 			created_by: $this->config->main->character,
-			id: 0,
 		);
 		return $entry;
 	}

--- a/src/Modules/PVP_MODULE/SiteTrackerController.php
+++ b/src/Modules/PVP_MODULE/SiteTrackerController.php
@@ -5,6 +5,7 @@ namespace Nadybot\Modules\PVP_MODULE;
 // pf, site
 
 use Nadybot\Core\Modules\MESSAGES\MessageHubController;
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
@@ -214,8 +215,9 @@ class SiteTrackerController extends ModuleInstance {
 		CmdContext $context,
 		#[NCA\Str('track', 'tracker')] string $action,
 		PRemove $subAction,
-		string $id,
+		PUuid $id,
 	): void {
+		$id = $id();
 		$tracker = $this->trackers[$id] ?? null;
 		if (!isset($tracker)) {
 			$context->reply("No tracker <highlight>{$id}<end> found.");
@@ -261,8 +263,9 @@ class SiteTrackerController extends ModuleInstance {
 		CmdContext $context,
 		#[NCA\Str('track', 'tracker')] string $action,
 		#[NCA\Str('show', 'view')] string $subAction,
-		string $id,
+		PUuid $id,
 	): void {
+		$id = $id();
 		$tracker = $this->trackers[$id] ?? null;
 		if (!isset($tracker)) {
 			$context->reply("No tracker <highlight>{$id}<end> found.");

--- a/src/Modules/PVP_MODULE/SiteTrackerController.php
+++ b/src/Modules/PVP_MODULE/SiteTrackerController.php
@@ -228,7 +228,7 @@ class SiteTrackerController extends ModuleInstance {
 		$routes = $this->msgHub->getRoutes();
 		foreach ($routes as $route) {
 			if ($route->getSource() === $tracker->getChannelName()) {
-				$this->msgHubCtrl->routeDel($context, $subAction, $route->getID()->toString());
+				$this->msgHubCtrl->routeDel($context, $subAction, new PUuid($route->getID()->toString()));
 			}
 		}
 		unset($this->trackers[$id]);

--- a/src/Modules/PVP_MODULE/SiteTrackerController.php
+++ b/src/Modules/PVP_MODULE/SiteTrackerController.php
@@ -226,7 +226,7 @@ class SiteTrackerController extends ModuleInstance {
 		$routes = $this->msgHub->getRoutes();
 		foreach ($routes as $route) {
 			if ($route->getSource() === $tracker->getChannelName()) {
-				$this->msgHubCtrl->routeDel($context, $subAction, $route->getID());
+				$this->msgHubCtrl->routeDel($context, $subAction, $route->getID()->toString());
 			}
 		}
 		unset($this->trackers[$id]);

--- a/src/Modules/PVP_MODULE/TrackerEntry.php
+++ b/src/Modules/PVP_MODULE/TrackerEntry.php
@@ -5,29 +5,39 @@ namespace Nadybot\Modules\PVP_MODULE;
 use Nadybot\Core\{Attributes as NCA, DBTable, Types\MessageEmitter};
 use Nadybot\Modules\PVP_MODULE\FeedMessage\SiteUpdate;
 use Nadybot\Modules\PVP_MODULE\Handlers\Base;
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[NCA\DB\Table(name: 'nw_tracker')]
 class TrackerEntry extends DBTable implements MessageEmitter {
 	/** Timestamp when the entry was created */
 	public int $created_on;
 
+	/** The id of the tracker entry */
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param int          $id         The id of the tracker entry
-	 * @param string       $created_by Name of the character who created this entry
-	 * @param string       $expression The expression to filter on
-	 * @param list<string> $events     The events to trigger for this tracker
-	 * @param list<Base>   $handlers
-	 * @param ?int         $created_on Timestamp when the entry was created
+	 * @param string         $created_by Name of the character who created this entry
+	 * @param string         $expression The expression to filter on
+	 * @param list<string>   $events     The events to trigger for this tracker
+	 * @param list<Base>     $handlers
+	 * @param ?UuidInterface $id         The id of the tracker entry
+	 * @param ?int           $created_on Timestamp when the entry was created
 	 */
 	public function __construct(
-		#[NCA\DB\AutoInc] public int $id,
 		public string $created_by,
 		public string $expression,
 		#[NCA\DB\MapRead([self::class, 'decodeEvents'])] #[NCA\DB\MapWrite([self::class, 'encodeEvents'])] public array $events=[],
 		#[NCA\DB\Ignore] public array $handlers=[],
+		?UuidInterface $id=null,
 		?int $created_on=null,
 	) {
 		$this->created_on = $created_on ?? time();
+		$dt = null;
+		if (isset($created_on) && !isset($id)) {
+			$dt = (new DateTimeImmutable())->setTimestamp($created_on);
+		}
+		$this->id = $id ?? Uuid::uuid7($dt);
 	}
 
 	public function matches(SiteUpdate $site, ?string $eventName=null): bool {

--- a/src/Modules/QUOTE_MODULE/Migrations/MigrateQuoteTableToUuids.php
+++ b/src/Modules/QUOTE_MODULE/Migrations/MigrateQuoteTableToUuids.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\QUOTE_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\QUOTE_MODULE\Quote;
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_04_07_57_00, shared: true)]
+class MigrateQuoteTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			Quote::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('poster', 25);
+				$table->integer('dt');
+				$table->string('msg', 1_000);
+			},
+			'id',
+			'dt',
+		);
+	}
+}

--- a/src/Modules/QUOTE_MODULE/Quote.php
+++ b/src/Modules/QUOTE_MODULE/Quote.php
@@ -3,14 +3,23 @@
 namespace Nadybot\Modules\QUOTE_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[NCA\DB\Table(name: 'quote', shared: NCA\DB\Shared::Yes)]
 class Quote extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	public function __construct(
 		public string $poster,
 		public int $dt,
 		public string $msg,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$time = null;
+		if (!isset($id)) {
+			$time = (new DateTimeImmutable())->setTimestamp($dt);
+		}
+		$this->id = $id ?? Uuid::uuid7($time);
 	}
 }

--- a/src/Modules/QUOTE_MODULE/QuoteController.php
+++ b/src/Modules/QUOTE_MODULE/QuoteController.php
@@ -4,6 +4,7 @@ namespace Nadybot\Modules\QUOTE_MODULE;
 
 use function Safe\preg_split;
 
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	AccessManager,
 	Attributes as NCA,
@@ -83,8 +84,10 @@ class QuoteController extends ModuleInstance {
 	public function quoteRemoveCommand(
 		CmdContext $context,
 		PRemove $action,
-		string $id
+		PUuid $id
 	): void {
+		$id = $id();
+
 		/** @var ?Quote */
 		$row = $this->db->table(Quote::getTable())
 			->where('id', $id)
@@ -164,8 +167,9 @@ class QuoteController extends ModuleInstance {
 	public function quoteShowCommand(
 		CmdContext $context,
 		#[NCA\StrChoice('org', 'priv')] ?string $channel,
-		string $id
+		PUuid $id
 	): void {
+		$id = $id();
 		$result = $this->getQuoteInfo($id);
 
 		if ($result === null) {

--- a/src/Modules/QUOTE_MODULE/QuoteController.php
+++ b/src/Modules/QUOTE_MODULE/QuoteController.php
@@ -69,13 +69,12 @@ class QuoteController extends ModuleInstance {
 		}
 		$poster = $context->char->name;
 
-		$id = $this->db->table(Quote::getTable())
-			->insertGetId([
-				'poster' => $poster,
-				'dt' => time(),
-				'msg' => $quoteMsg,
-			]);
-		$msg = "Quote <highlight>{$id}<end> has been added.";
+		$this->db->insert($quote = new Quote(
+			poster: $poster,
+			dt: time(),
+			msg: $quoteMsg,
+		));
+		$msg = "Quote <highlight>{$quote->id}<end> has been added.";
 		$context->reply($msg);
 	}
 
@@ -84,7 +83,7 @@ class QuoteController extends ModuleInstance {
 	public function quoteRemoveCommand(
 		CmdContext $context,
 		PRemove $action,
-		int $id
+		string $id
 	): void {
 		/** @var ?Quote */
 		$row = $this->db->table(Quote::getTable())
@@ -165,7 +164,7 @@ class QuoteController extends ModuleInstance {
 	public function quoteShowCommand(
 		CmdContext $context,
 		#[NCA\StrChoice('org', 'priv')] ?string $channel,
-		int $id
+		string $id
 	): void {
 		$result = $this->getQuoteInfo($id);
 
@@ -200,13 +199,9 @@ class QuoteController extends ModuleInstance {
 		$context->reply($msg);
 	}
 
-	public function getMaxId(): int {
-		return (int)($this->db->table(Quote::getTable())->max('id') ?? 0);
-	}
-
 	/** @return ?list<string> */
-	public function getQuoteInfo(?int $id=null): ?array {
-		$count = $this->getMaxId();
+	public function getQuoteInfo(null|string|\Stringable $id=null): ?array {
+		$count = $this->db->table(Quote::getTable())->count();
 
 		if ($count === 0) {
 			return null;
@@ -224,7 +219,7 @@ class QuoteController extends ModuleInstance {
 		}
 
 		/** @var ?Quote $row */
-		if ($row === null || $row->id === null) {
+		if (!isset($row)) {
 			return null;
 		}
 

--- a/src/Modules/RAID_MODULE/DBAuction.php
+++ b/src/Modules/RAID_MODULE/DBAuction.php
@@ -3,9 +3,12 @@
 namespace Nadybot\Modules\RAID_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'auction')]
 class DBAuction extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/**
 	 * @param string  $item       Item that was auctioned
 	 * @param string  $auctioneer Person auctioning the item
@@ -22,7 +25,8 @@ class DBAuction extends DBTable {
 		public int $end,
 		public bool $reimbursed,
 		public ?int $raid_id=null,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Modules/RAID_MODULE/ExportRaid.php
+++ b/src/Modules/RAID_MODULE/ExportRaid.php
@@ -6,7 +6,7 @@ use EventSauce\ObjectHydrator\PropertyCasters\CastListToType;
 
 class ExportRaid {
 	/**
-	 * @param ?int               $raidId               The internal raid number, used so it can be referenced by the auctions
+	 * @param ?string            $raidId               The internal raid number, used so it can be referenced by the auctions
 	 * @param ?int               $time                 When did the raid start?
 	 * @param ?string            $raidDescription      What was raided?
 	 * @param ?bool              $raidLocked           Is/was the raid locked and only raid leaders were allowed to add raiders?
@@ -19,7 +19,7 @@ class ExportRaid {
 	 * @psalm-param ?list<ExportRaidState> $history
 	 */
 	public function __construct(
-		public ?int $raidId=null,
+		public ?string $raidId=null,
 		public ?int $time=null,
 		public ?string $raidDescription=null,
 		public ?bool $raidLocked=null,

--- a/src/Modules/RAID_MODULE/ExportRaidPointLog.php
+++ b/src/Modules/RAID_MODULE/ExportRaidPointLog.php
@@ -13,7 +13,7 @@ class ExportRaidPointLog {
 	 * @param ?string          $reason            Why were the raid points given?
 	 * @param ?bool            $givenByTick       True if the raidpoints were automatically given for raid participation
 	 * @param ?bool            $givenIndividually True if these points were given to only this character, false if to the whole raidforce
-	 * @param ?int             $raidId            If these points were given during a raid, this is the raid's ID
+	 * @param ?string          $raidId            If these points were given during a raid, this is the raid's ID
 	 */
 	public function __construct(
 		public ExportCharacter $character,
@@ -23,7 +23,7 @@ class ExportRaidPointLog {
 		public ?string $reason=null,
 		public ?bool $givenByTick=null,
 		public ?bool $givenIndividually=null,
-		public ?int $raidId=null,
+		public ?string $raidId=null,
 	) {
 	}
 }

--- a/src/Modules/RAID_MODULE/Migrations/Points/MigrateRaidRewardTableToUuids.php
+++ b/src/Modules/RAID_MODULE/Migrations/Points/MigrateRaidRewardTableToUuids.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\RAID_MODULE\Migrations\Points;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\RAID_MODULE\{RaidReward};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_05_07_41_00)]
+class MigrateRaidRewardTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			RaidReward::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('name', 20)->index();
+				$table->integer('points');
+				$table->string('reason', 100);
+			}
+		);
+	}
+}

--- a/src/Modules/RAID_MODULE/Migrations/Raid/MigrateRaidTableToUuids.php
+++ b/src/Modules/RAID_MODULE/Migrations/Raid/MigrateRaidTableToUuids.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\RAID_MODULE\Migrations\Raid;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\RAID_MODULE\{DBAuction, Raid, RaidLog, RaidMember, RaidPointsLog};
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
+
+#[NCA\Migration(order: 2024_08_04_18_24_00)]
+class MigrateRaidTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$idToUuid = $this->migrateRaidTable($logger, $db);
+		$this->migrateRaidLogs($logger, $db, $idToUuid);
+		$this->migrateAuctions($logger, $db, $idToUuid);
+		$this->migrateRaidMembers($logger, $db, $idToUuid);
+		$this->migrateRaidPointLogs($logger, $db, $idToUuid);
+	}
+
+	/** @return array<int,UuidInterface> */
+	private function migrateRaidTable(LoggerInterface $logger, DB $db): array {
+		return $db->migrateIdToUuid(
+			Raid::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('raid_id')->primary();
+				$table->string('description', 255)->nullable();
+				$table->integer('seconds_per_point');
+				$table->integer('announce_interval');
+				$table->boolean('locked')->default(false);
+				$table->integer('started')->index();
+				$table->string('started_by', 20);
+				$table->integer('stopped')->nullable()->index();
+				$table->string('stopped_by', 20)->nullable();
+				$table->unsignedInteger('max_members')->nullable(true);
+				$table->boolean('ticker_paused')->default(false);
+			},
+			'raid_id',
+			'started'
+		);
+	}
+
+	/** @param array<int,UuidInterface> $idToUuid */
+	private function migrateRaidLogs(LoggerInterface $logger, DB $db, array $idToUuid): void {
+		$raidLogs = $db->table(RaidLog::getTable())->orderBy('time')->get();
+		$createRaidLog = static function (Blueprint $table): void {
+			$table->uuid('raid_id')->index();
+			$table->string('description', 255)->nullable();
+			$table->integer('seconds_per_point');
+			$table->integer('announce_interval');
+			$table->boolean('locked');
+			$table->integer('time')->index();
+			$table->unsignedInteger('max_members')->nullable(true);
+			$table->boolean('ticker_paused')->default(false);
+		};
+
+		$db->schema()->drop(RaidLog::getTable());
+		$db->schema()->create(RaidLog::getTable(), $createRaidLog);
+
+		/** @return array<string,mixed> */
+		$raidLogs = $raidLogs->map(static function (\stdClass $entry) use ($idToUuid): array {
+			$entry->raid_id = $idToUuid[$entry->raid_id];
+			return (array)$entry;
+		})->toList();
+		$db->table(RaidLog::getTable())->chunkInsert($raidLogs);
+	}
+
+	/** @param array<int,UuidInterface> $idToUuid */
+	private function migrateAuctions(LoggerInterface $logger, DB $db, array $idToUuid): void {
+		$createAuction = static function (Blueprint $table): void {
+			$table->uuid('id')->primary();
+			$table->uuid('raid_id')->nullable()->index();
+			$table->text('item');
+			$table->string('auctioneer', 20);
+			$table->integer('cost')->nullable();
+			$table->string('winner', 20)->nullable();
+			$table->integer('end');
+			$table->boolean('reimbursed')->default(false);
+		};
+
+		$auctions = $db->table(DBAuction::getTable())->orderBy('id')->get();
+		$db->schema()->drop(DBAuction::getTable());
+		$db->schema()->create(DBAuction::getTable(), $createAuction);
+
+		/** @return array<string,mixed> */
+		$auctions = $auctions->map(static function (\stdClass $entry) use ($idToUuid): array {
+			$entry->raid_id = $idToUuid[$entry->raid_id];
+			$entry->id = Uuid::uuid7((new DateTimeImmutable())->setTimestamp($entry->end));
+			return (array)$entry;
+		})->toList();
+		$db->table(DBAuction::getTable())->chunkInsert($auctions);
+	}
+
+	/** @param array<int,UuidInterface> $idToUuid */
+	private function migrateRaidMembers(LoggerInterface $logger, DB $db, array $idToUuid): void {
+		$createRaidMembers = static function (Blueprint $table): void {
+			$table->uuid('raid_id')->index();
+			$table->string('player', 20)->index();
+			$table->integer('joined')->nullable();
+			$table->integer('left')->nullable();
+		};
+
+		$members = $db->table(RaidMember::getTable())->orderBy('raid_id')->get();
+		$db->schema()->drop(RaidMember::getTable());
+		$db->schema()->create(RaidMember::getTable(), $createRaidMembers);
+
+		/** @return array<string,mixed> */
+		$members = $members->map(static function (\stdClass $entry) use ($idToUuid): array {
+			$entry->raid_id = $idToUuid[$entry->raid_id];
+			return (array)$entry;
+		})->toList();
+		$db->table(RaidMember::getTable())->chunkInsert($members);
+	}
+
+	/** @param array<int,UuidInterface> $idToUuid */
+	private function migrateRaidPointLogs(LoggerInterface $logger, DB $db, array $idToUuid): void {
+		$createTable =  static function (Blueprint $table): void {
+			$table->string('username', 20)->index();
+			$table->integer('delta');
+			$table->integer('time')->index();
+			$table->string('changed_by', 20)->index();
+			$table->boolean('individual')->default(true)->index();
+			$table->text('reason');
+			$table->boolean('ticker')->default(false)->index();
+			$table->uuid('raid_id')->nullable()->index();
+		};
+
+		$logs = $db->table(RaidPointsLog::getTable())->get();
+		$db->schema()->drop(RaidPointsLog::getTable());
+		$db->schema()->create(RaidPointsLog::getTable(), $createTable);
+
+		/** @return array<string,mixed> */
+		$logs = $logs->map(static function (\stdClass $entry) use ($idToUuid): array {
+			if (isset($entry->raid_raid)) {
+				$entry->raid_id = $idToUuid[$entry->raid_id] ?? null;
+			}
+			return (array)$entry;
+		})->toList();
+		$db->table(RaidPointsLog::getTable())->chunkInsert($logs);
+	}
+}

--- a/src/Modules/RAID_MODULE/Raid.php
+++ b/src/Modules/RAID_MODULE/Raid.php
@@ -3,6 +3,8 @@
 namespace Nadybot\Modules\RAID_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[NCA\DB\Table(name: 'raid')]
 class Raid extends DBTable {
@@ -17,6 +19,9 @@ class Raid extends DBTable {
 	 * raid points for participation
 	 */
 	#[NCA\DB\Ignore] public int $last_award_from_ticker;
+
+	/** The internal ID of this raid */
+	#[NCA\DB\PK] public UuidInterface $raid_id;
 
 	/**
 	 * @param string                   $description            The description of the raid
@@ -35,7 +40,7 @@ class Raid extends DBTable {
 	 * @param ?int                     $max_members            Maximum number of allowed characters in the raid
 	 *                                                         If 0 or NULL, this is not limited
 	 * @param bool                     $ticker_paused          If set, then no points will be awarded until resumed
-	 * @param ?int                     $raid_id                The internal ID of this raid
+	 * @param ?UuidInterface           $raid_id                The internal ID of this raid
 	 * @param array<string,RaidMember> $raiders                List of all players who are or were in the raid
 	 * @param array<string,bool>       $pointsGiven            Internal array to track which mains already received points
 	 */
@@ -52,7 +57,7 @@ class Raid extends DBTable {
 		public ?string $stopped_by=null,
 		public ?int $max_members=null,
 		public bool $ticker_paused=false,
-		#[NCA\DB\AutoInc] public ?int $raid_id=null,
+		?UuidInterface $raid_id=null,
 		#[NCA\DB\Ignore] public array $raiders=[],
 		#[NCA\DB\Ignore] public array $pointsGiven=[],
 		#[NCA\DB\Ignore] public bool $we_are_most_recent_message=false,
@@ -60,6 +65,11 @@ class Raid extends DBTable {
 		$this->started = $started ?? time();
 		$this->last_announcement = $last_announcement ?? time();
 		$this->last_award_from_ticker = $last_award_from_ticker ?? time();
+		$dt = null;
+		if (isset($started) && !isset($raid_id)) {
+			$dt = (new DateTimeImmutable())->setTimestamp($started);
+		}
+		$this->raid_id = $raid_id ?? Uuid::uuid7($dt);
 	}
 
 	public function numActiveRaiders(): int {

--- a/src/Modules/RAID_MODULE/RaidController.php
+++ b/src/Modules/RAID_MODULE/RaidController.php
@@ -9,6 +9,7 @@ use Amp\Pipeline\Pipeline;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Collection;
 use Nadybot\Core\Events\{MyPrivateChannelMsgEvent, SendPrivEvent};
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
@@ -753,8 +754,10 @@ class RaidController extends ModuleInstance {
 	public function raidHistoryDetailCommand(
 		CmdContext $context,
 		#[NCA\Str('history')] string $action,
-		int $raidId
+		PUuid $raidId,
 	): void {
+		${$raidId} = $raidId();
+
 		/** @var ?Raid */
 		$raid = $this->db->table(Raid::getTable())
 			->where('raid_id', $raidId)
@@ -809,9 +812,11 @@ class RaidController extends ModuleInstance {
 	public function raidHistoryDetailRaiderCommand(
 		CmdContext $context,
 		#[NCA\Str('history')] string $action,
-		int $raidId,
+		PUuid $raidId,
 		PCharacter $char
 	): void {
+		$raidId = $raidId();
+
 		/** @var ?Raid */
 		$raid = $this->db->table(Raid::getTable())
 			->where('raid_id', $raidId)

--- a/src/Modules/RAID_MODULE/RaidController.php
+++ b/src/Modules/RAID_MODULE/RaidController.php
@@ -1055,20 +1055,14 @@ class RaidController extends ModuleInstance {
 
 	/** Start a new raid and also register it in the database */
 	public function startRaid(Raid $raid): void {
-		if (isset($raid->raid_id)) {
+		$oldRaid = $this->db->table(Raid::getTable())
+			->where('raid_id', $raid->raid_id)
+			->first();
+		if (isset($oldRaid)) {
 			$this->raid = $raid;
 			return;
 		}
-		$raid->raid_id = $this->db->table(Raid::getTable())
-			->insertGetId([
-				'description' => $raid->description,
-				'seconds_per_point' => $raid->seconds_per_point,
-				'started' => $raid->started,
-				'started_by' => $raid->started_by,
-				'announce_interval' => $raid->announce_interval,
-				'max_members' => $raid->max_members,
-				'ticker_paused' => $raid->ticker_paused,
-			], 'raid_id');
+		$this->db->insert($raid);
 		$this->raid = $raid;
 		$event = new RaidStartEvent(
 			raid: $raid,

--- a/src/Modules/RAID_MODULE/RaidExporter.php
+++ b/src/Modules/RAID_MODULE/RaidExporter.php
@@ -41,8 +41,8 @@ class RaidExporter extends ModuleInstance implements ExporterInterface, Importer
 		/** @var array<string,ExportRaid> */
 		$raids = [];
 		foreach ($data as $raid) {
-			$raids[$raid->raid_id] ??= new ExportRaid(
-				raidId: $raid->raid_id,
+			$raids[$raid->raid_id->toString()] ??= new ExportRaid(
+				raidId: $raid->raid_id->toString(),
 				time: $raid->time,
 				raidDescription: $raid->description,
 				raidLocked: $raid->locked,
@@ -51,9 +51,9 @@ class RaidExporter extends ModuleInstance implements ExporterInterface, Importer
 				history: [],
 			);
 			if ($raid->seconds_per_point > 0) {
-				$raids[$raid->raid_id]->raidSecondsPerPoint = $raid->seconds_per_point;
+				$raids[$raid->raid_id->toString()]->raidSecondsPerPoint = $raid->seconds_per_point;
 			}
-			$raids[$raid->raid_id]->history []= new ExportRaidState(
+			$raids[$raid->raid_id->toString()]->history []= new ExportRaidState(
 				time: $raid->time,
 				raidDescription: $raid->description,
 				raidLocked: $raid->locked,
@@ -72,7 +72,7 @@ class RaidExporter extends ModuleInstance implements ExporterInterface, Importer
 			if (isset($raidMember->left)) {
 				$raider->leaveTime = $raidMember->left;
 			}
-			$raids[$raidMember->raid_id]->raiders []= $raider;
+			$raids[$raidMember->raid_id->toString()]->raiders []= $raider;
 		}
 		return array_values($raids);
 	}
@@ -128,13 +128,13 @@ class RaidExporter extends ModuleInstance implements ExporterInterface, Importer
 			announce_interval: $raid->raidAnnounceInterval ?? $this->settingManager->getInt('raid_announcement_interval') ?? 0,
 			locked: $raid->raidLocked ?? false,
 		);
-		$raidId = $db->insert($entry);
+		$db->insert($entry);
 		$historyEntry = new RaidLog(
 			description: $entry->description,
 			seconds_per_point: $entry->seconds_per_point,
 			announce_interval: $entry->announce_interval,
 			locked: $entry->locked,
-			raid_id: $raidId,
+			raid_id: $entry->raid_id,
 			time: time(),
 		);
 		foreach ($raid->raiders??[] as $raider) {
@@ -143,7 +143,7 @@ class RaidExporter extends ModuleInstance implements ExporterInterface, Importer
 				continue;
 			}
 			$raiderEntry = new RaidMember(
-				raid_id: $raidId,
+				raid_id: $entry->raid_id,
 				player: $name,
 				joined: $raider->joinTime ?? time(),
 				left: $raider->leaveTime ?? time(),

--- a/src/Modules/RAID_MODULE/RaidLog.php
+++ b/src/Modules/RAID_MODULE/RaidLog.php
@@ -4,21 +4,22 @@ namespace Nadybot\Modules\RAID_MODULE;
 
 use Nadybot\Core\Attributes\DB\Table;
 use Nadybot\Core\DBTable;
+use Ramsey\Uuid\UuidInterface;
 
 #[Table(name: 'raid_log')]
 class RaidLog extends DBTable {
 	/**
-	 * @param int     $raid_id           The ID of the raid to which this belongs
-	 * @param ?string $description       The raid description of the raid
-	 * @param int     $seconds_per_point How many seconds for 1 raid point or 0 if disabled
-	 * @param int     $announce_interval At which interval was the raid announced? 0 meansoff
-	 * @param bool    $locked            Was the raid locked?
-	 * @param int     $time              At which time did the change occur?
-	 * @param ?int    $max_members       Maximum number of allowed characters in the raid If 0 or NULL, this is not limited
-	 * @param bool    $ticker_paused     If set, then no points will be awarded until resumed
+	 * @param UuidInterface $raid_id           The ID of the raid to which this belongs
+	 * @param ?string       $description       The raid description of the raid
+	 * @param int           $seconds_per_point How many seconds for 1 raid point or 0 if disabled
+	 * @param int           $announce_interval At which interval was the raid announced? 0 meansoff
+	 * @param bool          $locked            Was the raid locked?
+	 * @param int           $time              At which time did the change occur?
+	 * @param ?int          $max_members       Maximum number of allowed characters in the raid If 0 or NULL, this is not limited
+	 * @param bool          $ticker_paused     If set, then no points will be awarded until resumed
 	 */
 	public function __construct(
-		public int $raid_id,
+		public UuidInterface $raid_id,
 		public ?string $description,
 		public int $seconds_per_point,
 		public int $announce_interval,

--- a/src/Modules/RAID_MODULE/RaidMember.php
+++ b/src/Modules/RAID_MODULE/RaidMember.php
@@ -3,6 +3,7 @@
 namespace Nadybot\Modules\RAID_MODULE;
 
 use Nadybot\Core\{Attributes\DB, DBTable};
+use Ramsey\Uuid\UuidInterface;
 
 #[DB\Table(name: 'raid_member')]
 class RaidMember extends DBTable {
@@ -10,16 +11,16 @@ class RaidMember extends DBTable {
 	public int $joined;
 
 	/**
-	 * @param int    $raid_id          ID of the raid this player represents
-	 * @param string $player           Name of the character
-	 * @param ?int   $left             UNIX Timestamp when they left the raid/were kicked, null if still in
-	 * @param int    $points           How many points have they gotten in this raid
-	 * @param int    $pointsRewarded   How many points have they received from rewards in this raid
-	 * @param int    $pointsIndividual How many points have they gained/lost individually in this raid
-	 * @param ?int   $joined           UNIX Timestamp when they joined the raid
+	 * @param UuidInterface $raid_id          ID of the raid this player represents
+	 * @param string        $player           Name of the character
+	 * @param ?int          $left             UNIX Timestamp when they left the raid/were kicked, null if still in
+	 * @param int           $points           How many points have they gotten in this raid
+	 * @param int           $pointsRewarded   How many points have they received from rewards in this raid
+	 * @param int           $pointsIndividual How many points have they gained/lost individually in this raid
+	 * @param ?int          $joined           UNIX Timestamp when they joined the raid
 	 */
 	public function __construct(
-		public int $raid_id,
+		public UuidInterface $raid_id,
 		public string $player,
 		public ?int $left=null,
 		#[DB\Ignore] public int $points=0,

--- a/src/Modules/RAID_MODULE/RaidPointsController.php
+++ b/src/Modules/RAID_MODULE/RaidPointsController.php
@@ -4,6 +4,7 @@ namespace Nadybot\Modules\RAID_MODULE;
 
 use Exception;
 use Nadybot\Core\Modules\ALTS\AltNewMainEvent;
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
@@ -747,17 +748,17 @@ class RaidPointsController extends ModuleInstance {
 			$context->reply("The raid reward <highlight>{$name}<end> does not exist.");
 			return;
 		}
-		$this->rewardRemIdCommand($context, $action, $reward->id);
+		$this->rewardRemIdCommand($context, $action, new PUuid($reward->id->toString()));
 	}
 
 	/** Remove a pre-defined raid reward */
 	#[NCA\HandlesCommand(self::CMD_REWARD_EDIT)]
-	public function rewardRemIdCommand(CmdContext $context, PRemove $action, int $id): void {
+	public function rewardRemIdCommand(CmdContext $context, PRemove $action, PUuid $id): void {
 		$deleted = $this->db->table(RaidReward::getTable())->delete($id);
 		if ($deleted) {
-			$context->reply("Raid reward <highlight>#{$id}<end> successfully deleted.");
+			$context->reply("Raid reward <highlight>{$id}<end> successfully deleted.");
 		} else {
-			$context->reply("Raid reward <highlight>#{$id}<end> was not found.");
+			$context->reply("Raid reward <highlight>{$id}<end> was not found.");
 		}
 	}
 

--- a/src/Modules/RAID_MODULE/RaidPointsController.php
+++ b/src/Modules/RAID_MODULE/RaidPointsController.php
@@ -24,6 +24,7 @@ use Nadybot\Core\{
 	Text,
 };
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
 use Safe\DateTimeImmutable;
 use Throwable;
 
@@ -743,7 +744,12 @@ class RaidPointsController extends ModuleInstance {
 		PRemove $action,
 		PNonNumberWord $name
 	): void {
-		$reward = $this->getRaidReward($name());
+		$name = $name();
+		if (Uuid::isValid($name) || ctype_digit($name)) {
+			$this->rewardRemIdCommand($context, $action, new PUuid($name));
+			return;
+		}
+		$reward = $this->getRaidReward($name);
 		if (!isset($reward) || !isset($reward->id)) {
 			$context->reply("The raid reward <highlight>{$name}<end> does not exist.");
 			return;
@@ -754,6 +760,7 @@ class RaidPointsController extends ModuleInstance {
 	/** Remove a pre-defined raid reward */
 	#[NCA\HandlesCommand(self::CMD_REWARD_EDIT)]
 	public function rewardRemIdCommand(CmdContext $context, PRemove $action, PUuid $id): void {
+		$id = $id();
 		$deleted = $this->db->table(RaidReward::getTable())->delete($id);
 		if ($deleted) {
 			$context->reply("Raid reward <highlight>{$id}<end> successfully deleted.");

--- a/src/Modules/RAID_MODULE/RaidPointsLog.php
+++ b/src/Modules/RAID_MODULE/RaidPointsLog.php
@@ -4,18 +4,19 @@ namespace Nadybot\Modules\RAID_MODULE;
 
 use Nadybot\Core\Attributes\DB\Table;
 use Nadybot\Core\DBTable;
+use Ramsey\Uuid\UuidInterface;
 
 #[Table(name: 'raid_points_log')]
 class RaidPointsLog extends DBTable {
 	/**
-	 * @param string $username   Name of the main character for this log entry
-	 * @param int    $delta      How many points were given or taken
-	 * @param int    $time       When did this happen
-	 * @param string $changed_by Who gave or took points?
-	 * @param bool   $individual Was this change for this player only?
-	 * @param string $reason     Why were points given  or taken?
-	 * @param bool   $ticker     Are these points for simple raid participation?
-	 * @param ?int   $raid_id    If points were given during a raid, which raid was it?
+	 * @param string         $username   Name of the main character for this log entry
+	 * @param int            $delta      How many points were given or taken
+	 * @param int            $time       When did this happen
+	 * @param string         $changed_by Who gave or took points?
+	 * @param bool           $individual Was this change for this player only?
+	 * @param string         $reason     Why were points given  or taken?
+	 * @param bool           $ticker     Are these points for simple raid participation?
+	 * @param ?UuidInterface $raid_id    If points were given during a raid, which raid was it?
 	 */
 	public function __construct(
 		public string $username,
@@ -25,7 +26,7 @@ class RaidPointsLog extends DBTable {
 		public bool $individual,
 		public string $reason,
 		public bool $ticker,
-		public ?int $raid_id,
+		public ?UuidInterface $raid_id,
 	) {
 	}
 }

--- a/src/Modules/RAID_MODULE/RaidPointsLogExporter.php
+++ b/src/Modules/RAID_MODULE/RaidPointsLogExporter.php
@@ -14,6 +14,7 @@ use Nadybot\Core\{
 	ModuleInstance
 };
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
 use Throwable;
 
 /**
@@ -45,7 +46,7 @@ class RaidPointsLogExporter extends ModuleInstance implements ExporterInterface,
 					givenIndividually: $datum->individual,
 				);
 				if (isset($datum->raid_id)) {
-					$raidLog->raidId = $datum->raid_id;
+					$raidLog->raidId = $datum->raid_id->toString();
 				}
 				return $raidLog;
 			})->toList();
@@ -73,7 +74,7 @@ class RaidPointsLogExporter extends ModuleInstance implements ExporterInterface,
 					time: $point->time ?? time(),
 					changed_by: $point->givenBy?->tryGetName() ?? $this->config->main->character,
 					individual: $point->givenIndividually ?? true,
-					raid_id: $point->raidId ?? null,
+					raid_id: isset($point->raidId) ? Uuid::fromString($point->raidId) : null,
 					reason: $point->reason ?? 'Raid participation',
 					ticker: $point->givenByTick ?? false,
 				));

--- a/src/Modules/RAID_MODULE/RaidReward.php
+++ b/src/Modules/RAID_MODULE/RaidReward.php
@@ -3,20 +3,25 @@
 namespace Nadybot\Modules\RAID_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'raid_reward')]
 class RaidReward extends DBTable {
+	/** The ID of the raid reward */
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param string $name   The primary name how to address this reward
-	 * @param int    $points How many points does this reward give
-	 * @param string $reason Which reason to log when giving this reward
-	 * @param ?int   $id     The ID of the raid reward
+	 * @param string         $name   The primary name how to address this reward
+	 * @param int            $points How many points does this reward give
+	 * @param string         $reason Which reason to log when giving this reward
+	 * @param ?UuidInterface $id     The ID of the raid reward
 	 */
 	public function __construct(
 		public string $name,
 		public int $points,
 		public string $reason,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Modules/RECIPE_MODULE/Ingredient.php
+++ b/src/Modules/RECIPE_MODULE/Ingredient.php
@@ -8,6 +8,7 @@ use Nadybot\Modules\ITEMS_MODULE\AODBItem;
 #[NCA\DB\Table(name: 'ingredient', shared: NCA\DB\Shared::Yes)]
 class Ingredient extends DBTable {
 	/**
+	 * @param int       $id            Internal ID of the ingredient
 	 * @param string    $name          Name of the ingredient. Usually the same as in the AODB
 	 * @param ?int      $aoid          Anarchy Online Item ID of this ingredient
 	 * @param ?string   $where         Description where you can get this ingredient
@@ -15,9 +16,9 @@ class Ingredient extends DBTable {
 	 * @param ?AODBItem $item          The pointer to the AO item
 	 * @param ?int      $ql            Which QL is needed
 	 * @param bool      $qlCanBeHigher Set to true if a higher QL is also okay
-	 * @param ?int      $id            Internal ID of the ingredient
 	 */
 	public function __construct(
+		#[NCA\DB\PK] public int $id,
 		public string $name,
 		public ?int $aoid=null,
 		public ?string $where=null,
@@ -25,7 +26,6 @@ class Ingredient extends DBTable {
 		#[NCA\DB\Ignore] public ?AODBItem $item=null,
 		#[NCA\DB\Ignore] public ?int $ql=null,
 		#[NCA\DB\Ignore] public bool $qlCanBeHigher=false,
-		#[NCA\DB\AutoInc] public ?int $id=null,
 	) {
 	}
 }

--- a/src/Modules/RELAY_MODULE/Migrations/MigrateRelaysToUuids.php
+++ b/src/Modules/RELAY_MODULE/Migrations/MigrateRelaysToUuids.php
@@ -1,0 +1,157 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\RELAY_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\{
+	Attributes as NCA,
+	DB,
+	SchemaMigration,
+};
+use Nadybot\Modules\RELAY_MODULE\{
+	RelayConfig,
+	RelayEvent,
+	RelayLayer,
+	RelayLayerArgument,
+	RelayProperty,
+};
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\{Uuid, UuidInterface};
+
+#[NCA\Migration(order: 2024_08_05_10_09_00)]
+class MigrateRelaysToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$relayIdToUuid = $this->migrateRelayTable($logger, $db);
+		$layerIdToUuid = $this->migrateRelayLayerTable($logger, $db, $relayIdToUuid);
+		$this->migrateRelayLayerArgumentTable($logger, $db, $layerIdToUuid);
+		$this->migrateRelayEventTable($logger, $db, $relayIdToUuid);
+		$this->migrateRelayPropertiesTable($logger, $db, $relayIdToUuid);
+	}
+
+	/** @return array<int,UuidInterface> */
+	private function migrateRelayTable(LoggerInterface $logger, DB $db): array {
+		$createTable = static function (Blueprint $table): void {
+			$table->uuid('id')->primary();
+			$table->string('name', 100)->unique();
+		};
+		return $db->migrateIdToUuid(RelayConfig::getTable(), $createTable);
+	}
+
+	/**
+	 * @param array<int,UuidInterface> $relayIdToUuid
+	 *
+	 * @return array<int,UuidInterface>
+	 */
+	private function migrateRelayLayerTable(
+		LoggerInterface $logger,
+		DB $db,
+		array $relayIdToUuid
+	): array {
+		$table = RelayLayer::getTable();
+		$createTable = static function (Blueprint $table): void {
+			$table->uuid('id')->primary();
+			$table->uuid('relay_id')->index();
+			$table->string('layer', 100);
+		};
+		$entries = $db->table($table)->orderBy('id')->get();
+		$db->schema()->drop($table);
+		$db->schema()->create($table, $createTable);
+
+		$result = [];
+
+		/** @return array<string,mixed> */
+		$entries = $entries->map(static function (\stdClass $entry) use (&$result, $relayIdToUuid): array {
+			$uuid = Uuid::uuid7();
+			$result[(int)$entry->id] = $uuid;
+			$entry->id = $uuid->toString();
+			$entry->relay_id = $relayIdToUuid[$entry->relay_id]->toString();
+			return (array)$entry;
+		})->toList();
+		$db->table($table)->chunkInsert($entries);
+		return $result;
+	}
+
+	/** @param array<int,UuidInterface> $relayLayerIdToUuid */
+	private function migrateRelayLayerArgumentTable(
+		LoggerInterface $logger,
+		DB $db,
+		array $relayLayerIdToUuid
+	): void {
+		$table = RelayLayerArgument::getTable();
+		$createTable = static function (Blueprint $table): void {
+			$table->uuid('id');
+			$table->uuid('layer_id')->index();
+			$table->string('name', 100);
+			$table->string('value', 200);
+		};
+		$entries = $db->table($table)->orderBy('id')->get();
+		$db->schema()->drop($table);
+		$db->schema()->create($table, $createTable);
+
+		$result = [];
+
+		/** @return array<string,mixed> */
+		$entries = $entries->map(static function (\stdClass $entry) use (&$result, $relayLayerIdToUuid): array {
+			$uuid = Uuid::uuid7();
+			$result[(int)$entry->id] = $uuid;
+			$entry->id = $uuid->toString();
+			$entry->layer_id = $relayLayerIdToUuid[$entry->layer_id]->toString();
+			return (array)$entry;
+		})->toList();
+		$db->table($table)->chunkInsert($entries);
+	}
+
+	/** @param array<int,UuidInterface> $relayIdToUuid */
+	private function migrateRelayEventTable(
+		LoggerInterface $logger,
+		DB $db,
+		array $relayIdToUuid
+	): void {
+		$table = RelayEvent::getTable();
+		$createTable = static function (Blueprint $table): void {
+			$table->uuid('id')->primary();
+			$table->uuid('relay_id')->index();
+			$table->string('event', 50);
+			$table->boolean('incoming')->default(false);
+			$table->boolean('outgoing')->default(false);
+			$table->unique(['relay_id', 'event']);
+		};
+		$entries = $db->table($table)->orderBy('id')->get();
+		$db->schema()->drop($table);
+		$db->schema()->create($table, $createTable);
+
+		/** @return array<string,mixed> */
+		$entries = $entries->map(static function (\stdClass $entry) use ($relayIdToUuid): array {
+			$uuid = Uuid::uuid7();
+			$entry->id = $uuid->toString();
+			$entry->relay_id = $relayIdToUuid[$entry->relay_id]->toString();
+			return (array)$entry;
+		})->toList();
+		$db->table($table)->chunkInsert($entries);
+	}
+
+	/** @param array<int,UuidInterface> $relayIdToUuid */
+	private function migrateRelayPropertiesTable(
+		LoggerInterface $logger,
+		DB $db,
+		array $relayIdToUuid
+	): void {
+		$table = RelayProperty::getTable();
+		$createTable = static function (Blueprint $table): void {
+			$table->uuid('relay_id')->nullable(false)->index();
+			$table->string('property', 50)->nullable(false)->index();
+			$table->string('value')->nullable(true);
+			$table->unique(['relay_id', 'property']);
+		};
+		$entries = $db->table($table)->get();
+		$db->schema()->drop($table);
+		$db->schema()->create($table, $createTable);
+
+		/** @return array<string,mixed> */
+		$entries = $entries->map(static function (\stdClass $entry) use ($relayIdToUuid): array {
+			$entry->relay_id = $relayIdToUuid[$entry->relay_id]->toString();
+			return (array)$entry;
+		})->toList();
+		$db->table($table)->chunkInsert($entries);
+	}
+}

--- a/src/Modules/RELAY_MODULE/Migrations/MigrateToRelayTable.php
+++ b/src/Modules/RELAY_MODULE/Migrations/MigrateToRelayTable.php
@@ -23,7 +23,6 @@ use Nadybot\Modules\RELAY_MODULE\{
 	RelayLayerArgument,
 };
 use Psr\Log\LoggerInterface;
-use Ramsey\Uuid\{UuidInterface};
 
 #[NCA\Migration(order: 2021_08_17_09_03_34)]
 class MigrateToRelayTable implements SchemaMigration {
@@ -68,21 +67,21 @@ class MigrateToRelayTable implements SchemaMigration {
 		return $relayLogon;
 	}
 
-	protected function addMod(DB $db, UuidInterface $routeId, string $modifier): int {
-		return $db->insert(new RouteModifier(
-			route_id: $routeId,
-			modifier: $modifier,
-		));
+	protected function addMod(DB $db, int $routeId, string $modifier): int {
+		return $db->table(RouteModifier::getTable())->insertGetId([
+			'route_id' => $routeId,
+			'modifier' => $modifier,
+		]);
 	}
 
 	/** @param array<string,mixed> $kv */
 	protected function addArgs(DB $db, int $modId, array $kv): void {
 		foreach ($kv as $name => $value) {
-			$db->insert(new RouteModifierArgument(
-				route_modifier_id: $modId,
-				name: $name,
-				value: (string)$value,
-			));
+			$db->table(RouteModifierArgument::getTable())->insert([
+				'route_modifier_id' => $modId,
+				'name' => $name,
+				'value' => (string)$value,
+			]);
 		}
 	}
 
@@ -142,34 +141,26 @@ class MigrateToRelayTable implements SchemaMigration {
 	protected function addRouting(DB $db, RelayConfig $relay): void {
 		$guestRelay = $this->getSetting($db, 'guest_relay');
 
-		/** @var list<UuidInterface> */
 		$routesOut = [];
-		$route = new Route(
-			source: Source::RELAY . "({$relay->name})",
-			destination: Source::ORG,
-		);
-		$db->insert($route);
-		$routeInOrg = $route->id;
-		$route = new Route(
-			source: Source::ORG,
-			destination: Source::RELAY . "({$relay->name})",
-		);
-		$db->insert($route);
-		$routesOut []= $route->id;
+
+		$routeInOrg = $db->table(Route::getTable())->insertGetId([
+			'source' => Source::RELAY . "({$relay->name})",
+			'destination' => Source::ORG,
+		]);
+		$routesOut []= $db->table(Route::getTable())->insertGetId([
+			'source' => Source::ORG,
+			'destination' => Source::RELAY . "({$relay->name})",
+		]);
 
 		if (isset($guestRelay) && (int)$guestRelay->value) {
-			$route = new Route(
-				source: Source::RELAY . "({$relay->name})",
-				destination: Source::PRIV . "({$this->config->main->character})",
-			);
-			$db->insert($route);
-			$routeInPriv = $route->id;
-			$route = new Route(
-				source: Source::PRIV . "({$this->config->main->character})",
-				destination: Source::RELAY . "({$relay->name})",
-			);
-			$db->insert($route);
-			$routesOut []= $route->id;
+			$routeInPriv = $db->table(Route::getTable())->insertGetId([
+				'source' => Source::RELAY . "({$relay->name})",
+				'destination' => Source::PRIV . "({$this->config->main->character})",
+			]);
+			$routesOut[] = $db->table(Route::getTable())->insertGetId([
+				'source' => Source::PRIV . "({$this->config->main->character})",
+				'destonation' => Source::RELAY . "({$relay->name})",
+			]);
 		}
 		$relayWhen = $this->getSetting($db, 'relay_symbol_method');
 		$relaySymbol = $this->getSetting($db, 'relaysymbol');

--- a/src/Modules/RELAY_MODULE/Migrations/MigrateToRelayTable.php
+++ b/src/Modules/RELAY_MODULE/Migrations/MigrateToRelayTable.php
@@ -23,6 +23,7 @@ use Nadybot\Modules\RELAY_MODULE\{
 	RelayLayerArgument,
 };
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\{UuidInterface};
 
 #[NCA\Migration(order: 2021_08_17_09_03_34)]
 class MigrateToRelayTable implements SchemaMigration {
@@ -67,7 +68,7 @@ class MigrateToRelayTable implements SchemaMigration {
 		return $relayLogon;
 	}
 
-	protected function addMod(DB $db, int $routeId, string $modifier): int {
+	protected function addMod(DB $db, UuidInterface $routeId, string $modifier): int {
 		return $db->insert(new RouteModifier(
 			route_id: $routeId,
 			modifier: $modifier,
@@ -140,29 +141,35 @@ class MigrateToRelayTable implements SchemaMigration {
 
 	protected function addRouting(DB $db, RelayConfig $relay): void {
 		$guestRelay = $this->getSetting($db, 'guest_relay');
+
+		/** @var list<UuidInterface> */
 		$routesOut = [];
 		$route = new Route(
 			source: Source::RELAY . "({$relay->name})",
 			destination: Source::ORG,
 		);
-		$routeInOrg = $db->insert($route);
+		$db->insert($route);
+		$routeInOrg = $route->id;
 		$route = new Route(
 			source: Source::ORG,
 			destination: Source::RELAY . "({$relay->name})",
 		);
-		$routesOut []= $db->insert($route);
+		$db->insert($route);
+		$routesOut []= $route->id;
 
 		if (isset($guestRelay) && (int)$guestRelay->value) {
 			$route = new Route(
 				source: Source::RELAY . "({$relay->name})",
 				destination: Source::PRIV . "({$this->config->main->character})",
 			);
-			$routeInPriv = $db->insert($route);
+			$db->insert($route);
+			$routeInPriv = $route->id;
 			$route = new Route(
 				source: Source::PRIV . "({$this->config->main->character})",
 				destination: Source::RELAY . "({$relay->name})",
 			);
-			$routesOut []= $db->insert($route);
+			$db->insert($route);
+			$routesOut []= $route->id;
 		}
 		$relayWhen = $this->getSetting($db, 'relay_symbol_method');
 		$relaySymbol = $this->getSetting($db, 'relaysymbol');

--- a/src/Modules/RELAY_MODULE/Migrations/MigrateToRelayTable.php
+++ b/src/Modules/RELAY_MODULE/Migrations/MigrateToRelayTable.php
@@ -39,9 +39,8 @@ class MigrateToRelayTable implements SchemaMigration {
 
 	public function migrate(LoggerInterface $logger, DB $db): void {
 		$relay = $this->migrateRelay($db);
-		if (isset($relay)) {
+		if ($relay) {
 			$this->configController->toggleEvent('connect', 'relaycontroller.loadRelays', true);
-			$this->addRouting($db, $relay);
 		}
 	}
 
@@ -85,12 +84,12 @@ class MigrateToRelayTable implements SchemaMigration {
 		}
 	}
 
-	protected function migrateRelay(DB $db): ?RelayConfig {
+	protected function migrateRelay(DB $db): bool {
 		$relayType = $this->getSetting($db, 'relaytype');
 		$relayBot = $this->getSetting($db, 'relaybot');
 		if (!isset($relayType) || !isset($relayBot) || $relayBot->value === 'Off') {
 			if ($this->prefix !== '') {
-				return null;
+				return false;
 			}
 			$this->prefix = 'a';
 			return $this->migrateRelay($db);
@@ -101,10 +100,9 @@ class MigrateToRelayTable implements SchemaMigration {
 				$this->settingManager->save('relay_guild_abbreviation', $abbr->value);
 			}
 		}
-		$relay = new RelayConfig(
-			name: $relayBot->value ?? 'Relay',
-		);
-		$relay->id = $db->insert($relay);
+		$relayId = $db->table(RelayConfig::getTable())->insertGetId([
+			'name' => $relayBot->value ?? 'Relay',
+		]);
 		$transportArgs = [];
 		switch ((int)$relayType->value) {
 			case 1:
@@ -116,26 +114,25 @@ class MigrateToRelayTable implements SchemaMigration {
 				$transportArgs['channel'] = $relayBot->value;
 				break;
 			default:
-				$db->table(RelayConfig::getTable())->delete($relay->id);
-				return null;
+				$db->table(RelayConfig::getTable())->delete($relayId);
+				return false;
 		}
-		$transport = new RelayLayer(
-			layer: $transportLayer,
-			relay_id: $relay->id,
-		);
-		$transport->id = $db->insert($transport);
+		$transportId = $db->table(RelayLayer::getTable())->insertGetId([
+			'layer' => $transportLayer,
+			'relay_id' => $relayId,
+		]);
 		foreach ($transportArgs as $key => $value) {
-			$db->insert(new RelayLayerArgument(
-				name: $key,
-				value: (string)$value,
-				layer_id: $transport->id,
-			));
+			$db->table(RelayLayerArgument::getTable())->insert([
+				'name' => $key,
+				'value' => (string)$value,
+				'layer_id' => $transportId,
+			]);
 		}
-		$db->insert(new RelayLayer(
-			relay_id: $relay->id,
-			layer: ($this->prefix === 'a') ? 'agcr' : 'grcv2',
-		));
-		return $relay;
+		$db->table(RelayLayer::getTable())->insert([
+			'relay_id' => $relayId,
+			'layer' => ($this->prefix === 'a') ? 'agcr' : 'grcv2',
+		]);
+		return true;
 	}
 
 	protected function addRouting(DB $db, RelayConfig $relay): void {

--- a/src/Modules/RELAY_MODULE/RelayConfig.php
+++ b/src/Modules/RELAY_MODULE/RelayConfig.php
@@ -4,21 +4,24 @@ namespace Nadybot\Modules\RELAY_MODULE;
 
 use EventSauce\ObjectHydrator\PropertyCasters\CastListToType;
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'relay')]
 class RelayConfig extends DBTable {
+	#[NCA\JSON\Ignore] #[NCA\DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param string       $name   The name of this relay
-	 * @param ?int         $id     The unique ID of this relay config
-	 * @param RelayLayer[] $layers The individual layers that make up this relay
-	 * @param RelayEvent[] $events A list of events this relay allows in- and/or outbound
+	 * @param string         $name   The name of this relay
+	 * @param ?UuidInterface $id     The unique ID of this relay config
+	 * @param RelayLayer[]   $layers The individual layers that make up this relay
+	 * @param RelayEvent[]   $events A list of events this relay allows in- and/or outbound
 	 *
 	 * @psalm-param list<RelayLayer> $layers
 	 * @psalm-param list<RelayEvent> $events
 	 */
 	public function __construct(
 		public string $name,
-		#[NCA\JSON\Ignore] #[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 		#[
 			NCA\DB\Ignore,
 			CastListToType(RelayLayer::class)
@@ -28,6 +31,7 @@ class RelayConfig extends DBTable {
 			CastListToType(RelayEvent::class)
 		] public array $events=[],
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 
 	public function getEvent(string $name): ?RelayEvent {

--- a/src/Modules/RELAY_MODULE/RelayEvent.php
+++ b/src/Modules/RELAY_MODULE/RelayEvent.php
@@ -3,23 +3,29 @@
 namespace Nadybot\Modules\RELAY_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'relay_event')]
 class RelayEvent extends DBTable {
+	/** The id of the relay event. Lower id means higher priority */
+
+	#[NCA\JSON\Ignore] #[NCA\DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param int    $relay_id The id of the relay where this layer belongs to
-	 * @param string $event    Which event is this for?
-	 * @param ?int   $id       The id of the relay event. Lower id means higher priority
-	 * @param bool   $incoming Allow sending the event via this relay?
-	 * @param bool   $outgoing Allow receiving the event via this relay?
+	 * @param UuidInterface  $relay_id The id of the relay where this layer belongs to
+	 * @param string         $event    Which event is this for?
+	 * @param ?UuidInterface $id       The id of the relay event. Lower id means higher priority
+	 * @param bool           $incoming Allow sending the event via this relay?
+	 * @param bool           $outgoing Allow receiving the event via this relay?
 	 */
 	public function __construct(
-		#[NCA\JSON\Ignore] public int $relay_id,
+		#[NCA\JSON\Ignore] public UuidInterface $relay_id,
 		public string $event,
-		#[NCA\JSON\Ignore] #[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 		public bool $incoming=false,
 		public bool $outgoing=false,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 
 	public function toString(): string {

--- a/src/Modules/RELAY_MODULE/RelayLayer.php
+++ b/src/Modules/RELAY_MODULE/RelayLayer.php
@@ -4,26 +4,31 @@ namespace Nadybot\Modules\RELAY_MODULE;
 
 use EventSauce\ObjectHydrator\PropertyCasters\CastListToType;
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'relay_layer')]
 class RelayLayer extends DBTable {
+	/** The id of the relay layer. Lower id means higher priority */
+	#[NCA\JSON\Ignore] #[NCA\DB\PK] public UuidInterface $id;
+
 	/**
 	 * @param string               $layer     Which relay stack layer does this represent?
-	 * @param ?int                 $id        The id of the relay layer. Lower id means higher priority
-	 * @param ?int                 $relay_id  The id of the relay where this layer belongs to
+	 * @param UuidInterface        $relay_id  The id of the relay where this layer belongs to
+	 * @param ?UuidInterface       $id        The id of the relay layer. Lower id means higher priority
 	 * @param RelayLayerArgument[] $arguments
 	 *
 	 * @psalm-param list<RelayLayerArgument> $arguments
 	 */
 	public function __construct(
 		public string $layer,
-		#[NCA\JSON\Ignore] #[NCA\DB\AutoInc] public ?int $id=null,
-		#[NCA\JSON\Ignore] public ?int $relay_id=null,
+		#[NCA\JSON\Ignore] public UuidInterface $relay_id,
+		?UuidInterface $id=null,
 		#[
 			NCA\DB\Ignore,
 			CastListToType(RelayLayerArgument::class)
 		] public array $arguments=[],
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 
 	/** @param string[] $secrets */

--- a/src/Modules/RELAY_MODULE/RelayLayerArgument.php
+++ b/src/Modules/RELAY_MODULE/RelayLayerArgument.php
@@ -6,21 +6,26 @@ use function Safe\{json_encode, preg_match};
 
 use Nadybot\Core\Attributes\{DB, JSON};
 use Nadybot\Core\DBTable;
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[DB\Table(name: 'relay_layer_argument')]
 class RelayLayerArgument extends DBTable {
+	/** The id of the argument */
+	#[JSON\Ignore] #[DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param string $name     The name of the argument
-	 * @param string $value    The value of the argument
-	 * @param ?int   $id       The id of the argument
-	 * @param ?int   $layer_id The id of the layer where this argument belongs to
+	 * @param string         $name     The name of the argument
+	 * @param string         $value    The value of the argument
+	 * @param UuidInterface  $layer_id The id of the layer where this argument belongs to
+	 * @param ?UuidInterface $id       The id of the argument
 	 */
 	public function __construct(
 		public string $name,
 		public string $value,
-		#[JSON\Ignore] #[DB\AutoInc] public ?int $id=null,
-		#[JSON\Ignore] public ?int $layer_id=null,
+		#[JSON\Ignore] public UuidInterface $layer_id,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 
 	public function toString(bool $isSecret): string {

--- a/src/Modules/RELAY_MODULE/RelayProperty.php
+++ b/src/Modules/RELAY_MODULE/RelayProperty.php
@@ -4,16 +4,17 @@ namespace Nadybot\Modules\RELAY_MODULE;
 
 use Nadybot\Core\Attributes\DB\PK;
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\UuidInterface;
 
 #[NCA\DB\Table(name: 'relay_property')]
 class RelayProperty extends DBTable {
 	/**
-	 * @param int     $relay_id The id of the relay where this layer belongs to
-	 * @param string  $property Name of the property
-	 * @param ?string $value    The value (in string format)
+	 * @param UuidInterface $relay_id The id of the relay where this layer belongs to
+	 * @param string        $property Name of the property
+	 * @param ?string       $value    The value (in string format)
 	 */
 	public function __construct(
-		#[PK] #[NCA\JSON\Ignore] public int $relay_id,
+		#[PK] #[NCA\JSON\Ignore] public UuidInterface $relay_id,
 		#[PK] public string $property,
 		public ?string $value=null,
 	) {

--- a/src/Modules/SKILLS_MODULE/BuffPerksController.php
+++ b/src/Modules/SKILLS_MODULE/BuffPerksController.php
@@ -551,35 +551,33 @@ class BuffPerksController extends ModuleInstance {
 			$resInserts = [];
 			$buffInserts = [];
 			foreach ($perkInfo as $perk) {
-				$perk->id = $this->db->insert($perk);
+				$this->db->insert($perk);
 
 				foreach ($perk->levels as $level) {
-					$level->perk_id = $perk->id;
-					$level->id = $this->db->insert($level);
+					$this->db->insert($level);
 
 					foreach ($level->professions as $profession) {
 						$profInserts []= [
-							'perk_level_id' => $level->id,
+							'perk_level_id' => $level->id->toString(),
 							'profession' => $profession,
 						];
 					}
 
 					foreach ($level->resistances as $strain => $amount) {
 						$resInserts []= [
-							'perk_level_id' => $level->id,
+							'perk_level_id' => $level->id->toString(),
 							'strain_id' => $strain,
 							'amount' => $amount,
 						];
 					}
 
 					if ($level->action) {
-						$level->action->perk_level_id = $level->id;
 						$this->db->insert($level->action);
 					}
 
 					foreach ($level->buffs as $skillId => $amount) {
 						$buffInserts []= [
-							'perk_level_id' => $level->id,
+							'perk_level_id' => $level->id->toString(),
 							'skill_id' => $skillId,
 							'amount' => $amount,
 						];
@@ -649,7 +647,7 @@ class BuffPerksController extends ModuleInstance {
 			}
 
 			$level = new PerkLevel(
-				perk_id: -1, // Will be filled out by the perk itself
+				perk_id: $perk->id,
 				perk_level: (int)$perkLevel,
 				required_level: (int)$requiredLevel,
 				aoid: (int)$aoid,
@@ -707,6 +705,7 @@ class BuffPerksController extends ModuleInstance {
 					action_id: $actionId,
 					scaling: $count > 0,
 					perk_level: $level->perk_level,
+					perk_level_id: $level->id,
 					aodb: $this->itemsController->getByIDs($actionId)->first(),
 				);
 			}

--- a/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkLevelActionsTable.php
+++ b/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkLevelActionsTable.php
@@ -5,16 +5,17 @@ namespace Nadybot\Modules\SKILLS_MODULE\Migrations\Perks;
 use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\SKILLS_MODULE\PerkLevelAction;
 use Psr\Log\LoggerInterface;
 
-#[NCA\Migration(order: 2021_04_27_14_22_59, shared: true)]
+#[NCA\Migration(order: 2024_08_05_12_55_05, shared: true)]
 class CreatePerkLevelActionsTable implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$table = 'perk_level_actions';
+		$table = PerkLevelAction::getTable();
 		$db->schema()->dropIfExists($table);
 		$db->schema()->create($table, static function (Blueprint $table): void {
-			$table->id();
-			$table->integer('perk_level_id')->index();
+			$table->uuid('id')->primary();
+			$table->uuid('perk_level_id')->index();
 			$table->integer('action_id');
 			$table->boolean('scaling')->default(false);
 		});

--- a/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkLevelBuffsTable.php
+++ b/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkLevelBuffsTable.php
@@ -5,15 +5,16 @@ namespace Nadybot\Modules\SKILLS_MODULE\Migrations\Perks;
 use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\SKILLS_MODULE\PerkLevelBuff;
 use Psr\Log\LoggerInterface;
 
-#[NCA\Migration(order: 2021_04_27_14_22_49, shared: true)]
+#[NCA\Migration(order: 2024_08_05_12_55_04, shared: true)]
 class CreatePerkLevelBuffsTable implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$table = 'perk_level_buffs';
+		$table = PerkLevelBuff::getTable();
 		$db->schema()->dropIfExists($table);
 		$db->schema()->create($table, static function (Blueprint $table): void {
-			$table->integer('perk_level_id')->index();
+			$table->uuid('perk_level_id')->index();
 			$table->integer('skill_id')->index();
 			$table->integer('amount');
 		});

--- a/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkLevelProfTable.php
+++ b/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkLevelProfTable.php
@@ -5,15 +5,16 @@ namespace Nadybot\Modules\SKILLS_MODULE\Migrations\Perks;
 use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\SKILLS_MODULE\PerkLevelProf;
 use Psr\Log\LoggerInterface;
 
-#[NCA\Migration(order: 2021_04_27_14_22_44, shared: true)]
+#[NCA\Migration(order: 2024_08_05_12_55_03, shared: true)]
 class CreatePerkLevelProfTable implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$table = 'perk_level_prof';
+		$table = PerkLevelProf::getTable();
 		$db->schema()->dropIfExists($table);
 		$db->schema()->create($table, static function (Blueprint $table): void {
-			$table->integer('perk_level_id')->index();
+			$table->uuid('perk_level_id')->index();
 			$table->string('profession', 25)->index();
 		});
 	}

--- a/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkLevelResistancesTable.php
+++ b/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkLevelResistancesTable.php
@@ -5,15 +5,16 @@ namespace Nadybot\Modules\SKILLS_MODULE\Migrations\Perks;
 use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\SKILLS_MODULE\PerkLevelResistance;
 use Psr\Log\LoggerInterface;
 
-#[NCA\Migration(order: 2021_04_27_14_23_06, shared: true)]
+#[NCA\Migration(order: 2024_08_05_12_55_02, shared: true)]
 class CreatePerkLevelResistancesTable implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$table = 'perk_level_resistances';
+		$table = PerkLevelResistance::getTable();
 		$db->schema()->dropIfExists($table);
 		$db->schema()->create($table, static function (Blueprint $table): void {
-			$table->integer('perk_level_id')->index();
+			$table->uuid('perk_level_id')->index();
 			$table->integer('strain_id');
 			$table->integer('amount');
 		});

--- a/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkLevelTable.php
+++ b/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkLevelTable.php
@@ -5,17 +5,18 @@ namespace Nadybot\Modules\SKILLS_MODULE\Migrations\Perks;
 use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\SKILLS_MODULE\PerkLevel;
 use Psr\Log\LoggerInterface;
 
-#[NCA\Migration(order: 2021_04_27_14_22_38, shared: true)]
+#[NCA\Migration(order: 2024_08_05_12_55_00, shared: true)]
 class CreatePerkLevelTable implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$table = 'perk_level';
+		$table = PerkLevel::getTable();
 		$db->schema()->dropIfExists($table);
 		$db->schema()->create($table, static function (Blueprint $table): void {
-			$table->id();
+			$table->uuid('id')->primary();
 			$table->integer('aoid')->nullable();
-			$table->integer('perk_id')->index();
+			$table->uuid('perk_id')->index();
 			$table->integer('perk_level')->index();
 			$table->integer('required_level')->index();
 		});

--- a/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkTable.php
+++ b/src/Modules/SKILLS_MODULE/Migrations/Perks/CreatePerkTable.php
@@ -5,15 +5,16 @@ namespace Nadybot\Modules\SKILLS_MODULE\Migrations\Perks;
 use Illuminate\Database\Schema\Blueprint;
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\SKILLS_MODULE\Perk;
 use Psr\Log\LoggerInterface;
 
-#[NCA\Migration(order: 2021_04_27_14_22_33, shared: true)]
+#[NCA\Migration(order: 2024_08_05_12_55_00, shared: true)]
 class CreatePerkTable implements SchemaMigration {
 	public function migrate(LoggerInterface $logger, DB $db): void {
-		$table = 'perk';
+		$table = Perk::getTable();
 		$db->schema()->dropIfExists($table);
 		$db->schema()->create($table, static function (Blueprint $table): void {
-			$table->id();
+			$table->uuid('id')->primary();
 			$table->string('name', 30)->index();
 			$table->string('expansion', 2);
 			$table->text('description')->nullable();

--- a/src/Modules/SKILLS_MODULE/Perk.php
+++ b/src/Modules/SKILLS_MODULE/Perk.php
@@ -3,22 +3,27 @@
 namespace Nadybot\Modules\SKILLS_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'perk', shared: NCA\DB\Shared::Yes)]
 class Perk extends DBTable {
+	/** Internal ID of that perkline */
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/**
 	 * @param string               $name        Name of the perk
 	 * @param string               $expansion   The expansion needed for this perk
 	 * @param ?string              $description A description what a perk does
-	 * @param ?int                 $id          Internal ID of that perkline
+	 * @param ?UuidInterface       $id          Internal ID of that perkline
 	 * @param array<int,PerkLevel> $levels
 	 */
 	public function __construct(
 		public string $name,
 		public string $expansion='sl',
 		public ?string $description=null,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 		#[NCA\DB\Ignore] public array $levels=[],
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Modules/SKILLS_MODULE/PerkLevel.php
+++ b/src/Modules/SKILLS_MODULE/PerkLevel.php
@@ -3,11 +3,14 @@
 namespace Nadybot\Modules\SKILLS_MODULE;
 
 use Nadybot\Core\{Attributes\DB, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[DB\Table(name: 'perk_level', shared: DB\Shared::Yes)]
 class PerkLevel extends DBTable {
+	#[DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param int                       $perk_id          The internal ID of the perk line
+	 * @param UuidInterface             $perk_id          The internal ID of the perk line
 	 * @param int                       $perk_level       Which level of $perk_id does this represent?
 	 * @param int                       $required_level   Required character level to perk this perk level
 	 * @param ?int                      $aoid             The internal ID of the perk level in AO
@@ -18,10 +21,10 @@ class PerkLevel extends DBTable {
 	 * @param list<PerkLevelResistance> $perk_resistances
 	 */
 	public function __construct(
-		public int $perk_id,
+		public UuidInterface $perk_id,
 		public int $perk_level,
 		public int $required_level,
-		#[DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 		public ?int $aoid=null,
 		#[DB\Ignore] public array $professions=[],
 		#[DB\Ignore] public array $buffs=[],
@@ -30,5 +33,6 @@ class PerkLevel extends DBTable {
 		#[DB\Ignore] public array $perk_resistances=[],
 		#[DB\Ignore] public ?PerkLevelAction $action=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Modules/SKILLS_MODULE/PerkLevelAction.php
+++ b/src/Modules/SKILLS_MODULE/PerkLevelAction.php
@@ -4,16 +4,20 @@ namespace Nadybot\Modules\SKILLS_MODULE;
 
 use Nadybot\Core\{Attributes\DB, DBTable};
 use Nadybot\Modules\ITEMS_MODULE\AODBEntry;
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[DB\Table(name: 'perk_level_actions', shared: DB\Shared::Yes)]
 class PerkLevelAction extends DBTable {
+	#[DB\PK] public UuidInterface $id;
+
 	public function __construct(
-		#[DB\Ignore] public ?int $perk_level,
+		#[DB\Ignore] public int $perk_level,
 		public int $action_id,
+		public UuidInterface $perk_level_id,
 		public bool $scaling=false,
 		#[DB\Ignore] public ?AODBEntry $aodb=null,
-		public ?int $perk_level_id=null,
-		#[DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Modules/SKILLS_MODULE/PerkLevelBuff.php
+++ b/src/Modules/SKILLS_MODULE/PerkLevelBuff.php
@@ -4,6 +4,7 @@ namespace Nadybot\Modules\SKILLS_MODULE;
 
 use Nadybot\Core\{Attributes\DB, DBTable};
 use Nadybot\Modules\ITEMS_MODULE\Skill;
+use Ramsey\Uuid\UuidInterface;
 
 #[DB\Table(name: 'perk_level_buffs', shared: DB\Shared::Yes)]
 class PerkLevelBuff extends DBTable {
@@ -11,7 +12,7 @@ class PerkLevelBuff extends DBTable {
 	public ?Skill $skill=null;
 
 	public function __construct(
-		#[DB\PK] public int $perk_level_id,
+		#[DB\PK] public UuidInterface $perk_level_id,
 		#[DB\PK] public int $skill_id,
 		public int $amount,
 	) {

--- a/src/Modules/SKILLS_MODULE/PerkLevelProf.php
+++ b/src/Modules/SKILLS_MODULE/PerkLevelProf.php
@@ -5,11 +5,12 @@ namespace Nadybot\Modules\SKILLS_MODULE;
 use Nadybot\Core\Attributes\DB\{Shared, Table};
 use Nadybot\Core\DBTable;
 use Nadybot\Core\Types\Profession;
+use Ramsey\Uuid\UuidInterface;
 
 #[Table(name: 'perk_level_prof', shared: Shared::Yes)]
 class PerkLevelProf extends DBTable {
 	public function __construct(
-		public int $perk_level_id,
+		public UuidInterface $perk_level_id,
 		public Profession $profession,
 	) {
 	}

--- a/src/Modules/SKILLS_MODULE/PerkLevelResistance.php
+++ b/src/Modules/SKILLS_MODULE/PerkLevelResistance.php
@@ -3,6 +3,7 @@
 namespace Nadybot\Modules\SKILLS_MODULE;
 
 use Nadybot\Core\{Attributes\DB, DBTable};
+use Ramsey\Uuid\UuidInterface;
 
 #[DB\Table(name: 'perk_level_resistances', shared: DB\Shared::Yes)]
 class PerkLevelResistance extends DBTable {
@@ -11,7 +12,7 @@ class PerkLevelResistance extends DBTable {
 	#[DB\Ignore] public ?string $nanoline=null;
 
 	public function __construct(
-		#[DB\PK] public int $perk_level_id,
+		#[DB\PK] public UuidInterface $perk_level_id,
 		#[DB\PK] public int $strain_id,
 		public int $amount,
 	) {

--- a/src/Modules/TIMERS_MODULE/Migrations/MigrateTimersTableToUuids.php
+++ b/src/Modules/TIMERS_MODULE/Migrations/MigrateTimersTableToUuids.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\TIMERS_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\TIMERS_MODULE\{Timer};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_05_14_03_00)]
+class MigrateTimersTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			Timer::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('name', 255);
+				$table->string('owner', 25);
+				$table->string('mode', 50)->nullable(true);
+				$table->integer('endtime')->nullable(true);
+				$table->integer('settime');
+				$table->string('callback', 255);
+				$table->string('data', 255)->nullable(true);
+				$table->text('alerts');
+				$table->string('origin', 100)->nullable(true);
+			},
+			'id',
+			'settime',
+		);
+	}
+}

--- a/src/Modules/TIMERS_MODULE/Migrations/MigrateToRoutes.php
+++ b/src/Modules/TIMERS_MODULE/Migrations/MigrateToRoutes.php
@@ -130,7 +130,7 @@ class MigrateToRoutes implements SchemaMigration {
 			source: Source::SYSTEM . '(timers)',
 			destination: $to,
 		);
-		$route->id = $db->insert($route);
+		$db->insert($route);
 		return $route;
 	}
 }

--- a/src/Modules/TIMERS_MODULE/Migrations/MigrateToRoutes.php
+++ b/src/Modules/TIMERS_MODULE/Migrations/MigrateToRoutes.php
@@ -8,13 +8,12 @@ use Nadybot\Core\{
 	DB,
 	DBSchema\Route,
 	DBSchema\Setting,
-	MessageHub,
 	Modules\DISCORD\DiscordAPIClient,
 	Modules\DISCORD\DiscordChannel,
 	Routing\Source,
 	SchemaMigration,
 };
-use Nadybot\Modules\TIMERS_MODULE\{Timer};
+use Nadybot\Modules\TIMERS_MODULE\Timer;
 use Psr\Log\LoggerInterface;
 use stdClass;
 use Throwable;
@@ -23,9 +22,6 @@ use Throwable;
 class MigrateToRoutes implements SchemaMigration {
 	#[NCA\Inject]
 	private DiscordAPIClient $discordAPIClient;
-
-	#[NCA\Inject]
-	private MessageHub $messageHub;
 
 	public function migrate(LoggerInterface $logger, DB $db): void {
 		$table = Timer::getTable();
@@ -113,24 +109,27 @@ class MigrateToRoutes implements SchemaMigration {
 		if (!in_array('discord', $defaultMode, true)) {
 			return;
 		}
-		$route = $this->addRoute(
+		$this->addRoute(
 			$db,
 			Source::DISCORD_PRIV . "({$channel->name})",
 		);
+		/*
 		try {
 			$msgRoute = $this->messageHub->createMessageRoute($route);
 			$this->messageHub->addRoute($msgRoute);
 		} catch (Throwable) {
 			// Ain't nothing we can do, errors will be given on next restart
 		}
+		*/
 	}
 
-	private function addRoute(DB $db, string $to): Route {
-		$route = new Route(
-			source: Source::SYSTEM . '(timers)',
-			destination: $to,
-		);
-		$db->insert($route);
+	/** @return array<string,mixed> */
+	private function addRoute(DB $db, string $to): array {
+		$route = [
+			'source' => Source::SYSTEM . '(timers)',
+			'destination' => $to,
+		];
+		$db->table(Route::getTable())->insert($route);
 		return $route;
 	}
 }

--- a/src/Modules/TIMERS_MODULE/Timer.php
+++ b/src/Modules/TIMERS_MODULE/Timer.php
@@ -5,21 +5,24 @@ namespace Nadybot\Modules\TIMERS_MODULE;
 use function Safe\json_decode;
 
 use Nadybot\Core\{Attributes\DB, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
+use Safe\DateTimeImmutable;
 
 #[DB\Table(name: 'timers')]
 class Timer extends DBTable {
 	public int $settime;
+	#[DB\PK] public UuidInterface $id;
 
 	/**
-	 * @param string  $name     Name of the timer
-	 * @param string  $owner    Name of the person who created that timer
-	 * @param ?int    $endtime  Timestamp when this timer goes off
-	 * @param string  $callback class.method of the function to call on alerts
-	 * @param ?string $mode     Comma-separated list where to display the alerts (priv,guild,discord)
-	 * @param ?string $data     For repeating timers, this is the repeat interval in seconds
-	 * @param ?int    $id       ID of the timer
-	 * @param Alert[] $alerts   A list of alerts, each calling $callback
-	 * @param ?int    $settime  Timestamp when this timer was set
+	 * @param string         $name     Name of the timer
+	 * @param string         $owner    Name of the person who created that timer
+	 * @param ?int           $endtime  Timestamp when this timer goes off
+	 * @param string         $callback class.method of the function to call on alerts
+	 * @param ?string        $mode     Comma-separated list where to display the alerts (priv,guild,discord)
+	 * @param ?string        $data     For repeating timers, this is the repeat interval in seconds
+	 * @param ?UuidInterface $id       ID of the timer
+	 * @param Alert[]        $alerts   A list of alerts, each calling $callback
+	 * @param ?int           $settime  Timestamp when this timer was set
 	 *
 	 * @psalm-param list<Alert> $alerts
 	 */
@@ -30,12 +33,17 @@ class Timer extends DBTable {
 		public string $callback='timercontroller.timerCallback',
 		public ?string $mode=null,
 		public ?string $data=null,
-		#[DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 		#[DB\MapRead([self::class, 'decodeAlerts'])] #[DB\MapWrite('json_encode')] public array $alerts=[],
 		#[DB\Ignore] public ?string $origin=null,
 		?int $settime=null,
 	) {
 		$this->settime = $settime ?? time();
+		$dt = null;
+		if (isset($settime) && !isset($id)) {
+			$dt = (new DateTimeImmutable())->setTimestamp($settime);
+		}
+		$this->id = $id ?? Uuid::uuid7($dt);
 	}
 
 	/** @return list<Alert> */

--- a/src/Modules/TIMERS_MODULE/TimerController.php
+++ b/src/Modules/TIMERS_MODULE/TimerController.php
@@ -5,6 +5,7 @@ namespace Nadybot\Modules\TIMERS_MODULE;
 use function Safe\{preg_match};
 use Exception;
 use Illuminate\Support\Collection;
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	AccessManager,
 	Attributes as NCA,
@@ -26,8 +27,8 @@ use Nadybot\Core\{
 	Types\MessageEmitter,
 	Util,
 };
-
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\{Uuid, UuidInterface};
 use ReflectionClass;
 
 /**
@@ -200,10 +201,17 @@ class TimerController extends ModuleInstance implements MessageEmitter {
 		}
 		$endTime = (int)$timer->data + $alert->time;
 		$alerts = $this->generateAlerts($timer->owner, $timer->name, $endTime, explode(' ', $this->timerAlertTimes));
-		if (isset($timer->id)) {
-			$this->remove($timer->id);
-		}
-		$this->add($timer->name, $timer->owner, $timer->mode, $alerts, $timer->callback, $timer->data, $timer->origin, $timer->id);
+		$this->remove($timer->id);
+		$this->add(
+			name: $timer->name,
+			owner: $timer->owner,
+			mode: $timer->mode,
+			alerts: $alerts,
+			callback: $timer->callback,
+			data: $timer->data,
+			origin: $timer->origin,
+			id: $timer->id
+		);
 	}
 
 	public function sendAlertMessage(Timer $timer, Alert $alert): void {
@@ -347,7 +355,8 @@ class TimerController extends ModuleInstance implements MessageEmitter {
 	 */
 	#[NCA\HandlesCommand('timers')]
 	#[NCA\Help\Group('timers')]
-	public function timersRemoveCommand(CmdContext $context, PRemove $action, int $id): void {
+	public function timersRemoveCommand(CmdContext $context, PRemove $action, PUuid $id): void {
+		$id = $id();
 		$timer = $this->get($id);
 		if ($timer === null) {
 			$msg = "Could not find timer <highlight>#{$id}<end>.";
@@ -512,7 +521,16 @@ class TimerController extends ModuleInstance implements MessageEmitter {
 	}
 
 	/** @param list<Alert> $alerts */
-	public function add(string $name, string $owner, ?string $mode, array $alerts, string $callback, ?string $data=null, ?string $origin=null, ?int $id=null): int {
+	public function add(
+		string $name,
+		string $owner,
+		?string $mode,
+		array $alerts,
+		string $callback,
+		?string $data=null,
+		?string $origin=null,
+		?UuidInterface $id=null
+	): Timer {
 		usort($alerts, static function (Alert $a, Alert $b): int {
 			return $a->time <=> $b->time;
 		});
@@ -534,15 +552,16 @@ class TimerController extends ModuleInstance implements MessageEmitter {
 
 		$event = new TimerStartEvent(timer: $timer);
 
-		$timer->id = $this->db->insert($timer);
+		$this->db->insert($timer);
 
 		$this->timers[strtolower($name)] = $timer;
 		$this->eventManager->fireEvent($event);
-		return $timer->id;
+		return $timer;
 	}
 
-	public function remove(string|int $name): void {
-		if (is_string($name)) {
+	public function remove(string|\Stringable $name): void {
+		$name = (string)$name;
+		if (!Uuid::isValid($name)) {
 			$this->db->table(Timer::getTable())
 				->whereIlike('name', $name)
 				->delete();
@@ -551,23 +570,20 @@ class TimerController extends ModuleInstance implements MessageEmitter {
 		}
 		$this->db->table(Timer::getTable())->delete($name);
 		foreach ($this->timers as $tName => $timer) {
-			if ($timer->id === $name) {
+			if ($timer->id->toString() === $name) {
 				unset($this->timers[$tName]);
 				return;
 			}
 		}
 	}
 
-	public function get(string|int $name): ?Timer {
+	public function get(\Stringable|string $name): ?Timer {
 		$timer = $this->timers[strtolower((string)$name)] ?? null;
 		if (isset($timer)) {
 			return $timer;
 		}
-		if (!preg_match("/^\d+$/", (string)$name)) {
-			return null;
-		}
 		foreach ($this->timers as $tName => $curTimer) {
-			if ($curTimer->id === (int)$name) {
+			if ($curTimer->id->toString() === (string)$name) {
 				return $curTimer;
 			}
 		}

--- a/src/Modules/TIMERS_MODULE/TimerController.php
+++ b/src/Modules/TIMERS_MODULE/TimerController.php
@@ -330,8 +330,8 @@ class TimerController extends ModuleInstance implements MessageEmitter {
 	public function timersViewCommand(CmdContext $context, #[NCA\Str('view')] string $action, string $id): void {
 		$timer = $this->get($id);
 		if ($timer === null) {
-			if (preg_match("/^\d+$/", $id)) {
-				$msg = "Could not find timer <highlight>#{$id}<end>.";
+			if (!Uuid::isValid($id)) {
+				$msg = "Could not find timer <highlight>{$id}<end>.";
 			} else {
 				$msg = "Could not find a timer named <highlight>{$id}<end>.";
 			}

--- a/src/Modules/TRACKER_MODULE/Migrations/MigrateToRoutes.php
+++ b/src/Modules/TRACKER_MODULE/Migrations/MigrateToRoutes.php
@@ -77,7 +77,7 @@ class MigrateToRoutes implements SchemaMigration {
 			source: $this->trackerController->getChannelName(),
 			destination: Source::DISCORD_PRIV . "({$channel->name})",
 		);
-		$route->id = $db->insert($route);
+		$db->insert($route);
 		try {
 			$msgRoute = $this->messageHub->createMessageRoute($route);
 			$this->messageHub->addRoute($msgRoute);

--- a/src/Modules/TRACKER_MODULE/Migrations/MigrateToRoutes.php
+++ b/src/Modules/TRACKER_MODULE/Migrations/MigrateToRoutes.php
@@ -77,7 +77,10 @@ class MigrateToRoutes implements SchemaMigration {
 			source: $this->trackerController->getChannelName(),
 			destination: Source::DISCORD_PRIV . "({$channel->name})",
 		);
-		$db->insert($route);
+		$db->table(Route::getTable())->insert([
+			'source' => $route->source,
+			'destination' => $route->destination,
+		]);
 		try {
 			$msgRoute = $this->messageHub->createMessageRoute($route);
 			$this->messageHub->addRoute($msgRoute);

--- a/src/Modules/TRADEBOT_MODULE/Migrations/MigrateTradebotColorsTableToUuids.php
+++ b/src/Modules/TRADEBOT_MODULE/Migrations/MigrateTradebotColorsTableToUuids.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\TRADEBOT_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\TRADEBOT_MODULE\{TradebotColors};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_05_16_28_00)]
+class MigrateTradebotColorsTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			TradebotColors::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('tradebot', 12)->index();
+				$table->string('channel', 25)->default('*')->index();
+				$table->string('color', 6);
+				$table->unique(['tradebot', 'channel']);
+			}
+		);
+	}
+}

--- a/src/Modules/TRADEBOT_MODULE/TradebotColors.php
+++ b/src/Modules/TRADEBOT_MODULE/TradebotColors.php
@@ -3,20 +3,25 @@
 namespace Nadybot\Modules\TRADEBOT_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'tradebot_colors')]
 class TradebotColors extends DBTable {
+	/** Internal primary key */
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/**
-	 * @param string $tradebot Name of the tradebnot (Darknet/Lightnet)
-	 * @param string $channel  The channel mask (wtb, *, wt?, ...)
-	 * @param string $color    The 6 hex digits of the color, like FFFFFF
-	 * @param ?int   $id       Internal primary key
+	 * @param string         $tradebot Name of the tradebnot (Darknet/Lightnet)
+	 * @param string         $channel  The channel mask (wtb, *, wt?, ...)
+	 * @param string         $color    The 6 hex digits of the color, like FFFFFF
+	 * @param ?UuidInterface $id       Internal primary key
 	 */
 	public function __construct(
 		public string $tradebot,
 		public string $channel,
 		public string $color,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 }

--- a/src/Modules/TRADEBOT_MODULE/TradebotController.php
+++ b/src/Modules/TRADEBOT_MODULE/TradebotController.php
@@ -5,6 +5,7 @@ namespace Nadybot\Modules\TRADEBOT_MODULE;
 use function Safe\preg_match;
 use AO\Package;
 use Nadybot\Core\Events\{ConnectEvent, ExtJoinPrivRequest, PrivateChannelMsgEvent, RecvMsgEvent};
+use Nadybot\Core\ParamClass\PUuid;
 use Nadybot\Core\{
 	Attributes as NCA,
 	BuddylistManager,
@@ -325,12 +326,13 @@ class TradebotController extends ModuleInstance {
 
 	/** Remove a custom defined color */
 	#[NCA\HandlesCommand('tradecolor')]
-	public function remTradecolorCommand(CmdContext $context, PRemove $action, int $id): void {
+	public function remTradecolorCommand(CmdContext $context, PRemove $action, PUuid $id): void {
+		$id = $id();
 		if (!$this->db->table(TradebotColors::getTable())->delete($id)) {
-			$context->reply("Tradebot color <highlight>#{$id}<end> doesn't exist.");
+			$context->reply("Tradebot color <highlight>{$id}<end> doesn't exist.");
 			return;
 		}
-		$context->reply("Tradebot color <highlight>#{$id}<end> deleted.");
+		$context->reply("Tradebot color <highlight>{$id}<end> deleted.");
 	}
 
 	/** Configure the tag-colors, based on the channel and the tradebot */
@@ -376,7 +378,7 @@ class TradebotController extends ModuleInstance {
 			$colorDef->id = $oldValue->id;
 			$this->db->update($colorDef);
 		} else {
-			$colorDef->id = $this->db->insert($colorDef);
+			$this->db->insert($colorDef);
 		}
 		$context->reply(
 			"Color for <highlight>{$tradeBot} &gt; [{$tag}]<end> set to ".

--- a/src/Modules/VOTE_MODULE/Migrations/MigratePollsTouuids.php
+++ b/src/Modules/VOTE_MODULE/Migrations/MigratePollsTouuids.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\VOTE_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\VOTE_MODULE\{Poll, Vote};
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\UuidInterface;
+
+#[NCA\Migration(order: 2024_08_05_16_42_00)]
+class MigratePollsTouuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$idToUuid = $this->migratePolls($logger, $db);
+		$this->migrateVotes($logger, $db, $idToUuid);
+	}
+
+	/** @return array<int,UuidInterface> */
+	private function migratePolls(LoggerInterface $logger, DB $db): array {
+		$createTable = static function (Blueprint $table): void {
+			$table->uuid('id')->primary();
+			$table->string('author', 20);
+			$table->text('question');
+			$table->text('possible_answers');
+			$table->integer('started');
+			$table->integer('duration');
+			$table->integer('status');
+			$table->boolean('allow_other_answers')->default(true);
+		};
+		$idToUuid = $db->migrateIdToUuid(Poll::getTable(), $createTable, 'id', 'started');
+		return $idToUuid;
+	}
+
+	/** @param array<int,UuidInterface> $idToUuid */
+	private function migrateVotes(LoggerInterface $logger, DB $db, array $idToUuid): void {
+		$createTable = static function (Blueprint $table): void {
+			$table->uuid('poll_id')->index();
+			$table->string('author', 20);
+			$table->text('answer')->nullable();
+			$table->integer('time')->nullable();
+			$table->unique(['poll_id', 'author']);
+		};
+		$table = Vote::getTable();
+		$entries = $db->table($table)->get();
+		$db->schema()->drop($table);
+		$db->schema()->create($table, $createTable);
+
+		/** @return array<string,mixed> */
+		$entries = $entries->map(static function (\stdClass $entry) use ($idToUuid): array {
+			$entry->poll_id = $idToUuid[(int)$entry->poll_id]->toString();
+			return (array)$entry;
+		})->toList();
+		$db->table($table)->chunkInsert($entries);
+	}
+}

--- a/src/Modules/VOTE_MODULE/Poll.php
+++ b/src/Modules/VOTE_MODULE/Poll.php
@@ -3,9 +3,12 @@
 namespace Nadybot\Modules\VOTE_MODULE;
 
 use Nadybot\Core\{Attributes as NCA, DBTable};
+use Ramsey\Uuid\{Uuid, UuidInterface};
 
 #[NCA\DB\Table(name: 'polls')]
 class Poll extends DBTable {
+	#[NCA\DB\PK] public UuidInterface $id;
+
 	/** @param list<string> $answers */
 	public function __construct(
 		public string $author,
@@ -14,10 +17,11 @@ class Poll extends DBTable {
 		public int $started,
 		public int $duration,
 		public int $status,
-		#[NCA\DB\AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 		public bool $allow_other_answers=true,
 		#[NCA\DB\Ignore] public array $answers=[],
 	) {
+		$this->id = $id ?? Uuid::uuid7();
 	}
 
 	public function getTimeLeft(): int {

--- a/src/Modules/VOTE_MODULE/PollsExporter.php
+++ b/src/Modules/VOTE_MODULE/PollsExporter.php
@@ -100,7 +100,7 @@ class PollsExporter extends ModuleInstance implements ExporterInterface, Importe
 
 	/** Import a single poll and its votes */
 	private function importPoll(DB $db, ExportPoll $poll): void {
-		$pollId = $db->insert(new Poll(
+		$dbPoll = new Poll(
 			author: $poll->author?->tryGetName() ?? $this->config->main->character,
 			question: $poll->question,
 			possible_answers: json_encode(
@@ -112,11 +112,12 @@ class PollsExporter extends ModuleInstance implements ExporterInterface, Importe
 			started: $poll->startTime ?? time(),
 			duration: ($poll->endTime ?? time()) - ($poll->startTime ?? time()),
 			status: VoteController::STATUS_STARTED,
-		));
+		);
+		$db->insert($dbPoll);
 		foreach ($poll->answers??[] as $answer) {
 			foreach ($answer->votes??[] as $vote) {
 				$db->insert(new Vote(
-					poll_id: $pollId,
+					poll_id: $dbPoll->id,
 					author: $vote->character?->tryGetName() ?? 'Unknown',
 					answer: $answer->answer,
 					time: $vote->voteTime ?? time(),

--- a/src/Modules/VOTE_MODULE/Vote.php
+++ b/src/Modules/VOTE_MODULE/Vote.php
@@ -4,11 +4,12 @@ namespace Nadybot\Modules\VOTE_MODULE;
 
 use Nadybot\Core\Attributes\DB\{PK, Table};
 use Nadybot\Core\DBTable;
+use Ramsey\Uuid\UuidInterface;
 
 #[Table(name: 'votes')]
 class Vote extends DBTable {
 	public function __construct(
-		#[PK] public int $poll_id,
+		#[PK] public UuidInterface $poll_id,
 		#[PK] public string $author,
 		public ?string $answer=null,
 		public ?int $time=null,

--- a/src/Modules/WEBSERVER_MODULE/ApiController.php
+++ b/src/Modules/WEBSERVER_MODULE/ApiController.php
@@ -159,13 +159,14 @@ class ApiController extends ModuleInstance {
 			token: '',
 		);
 		do {
+			$success = false;
 			$apiKey->token = bin2hex(random_bytes(4));
 			try {
-				$apiKey->id = $this->db->insert($apiKey);
+				$success = $this->db->insert($apiKey) >= 1;
 			} catch (Throwable $e) {
 				// Ignore and retry
 			}
-		} while (!isset($apiKey->id));
+		} while (!$success);
 
 		$blob = "<header2>Your private key<end>\n".
 			'<tab>' . implode("\n<tab>", explode("\n", trim($privKeyPem))) . "\n\n".

--- a/src/Modules/WEBSERVER_MODULE/ApiKey.php
+++ b/src/Modules/WEBSERVER_MODULE/ApiKey.php
@@ -3,22 +3,25 @@
 namespace Nadybot\Modules\WEBSERVER_MODULE;
 
 use DateTimeInterface;
-use Nadybot\Core\Attributes\DB\{AutoInc, Table};
+use Nadybot\Core\Attributes\DB\{PK, Table};
 use Nadybot\Core\DBTable;
+use Ramsey\Uuid\{Uuid, UuidInterface};
 use Safe\DateTimeImmutable;
 
 #[Table(name: 'api_key')]
 class ApiKey extends DBTable {
 	public DateTimeInterface $created;
+	#[PK] public UuidInterface $id;
 
 	public function __construct(
 		public string $character,
 		public string $token,
 		public string $pubkey,
-		#[AutoInc] public ?int $id=null,
+		?UuidInterface $id=null,
 		public int $last_sequence_nr=0,
 		?DateTimeInterface $created=null,
 	) {
 		$this->created = $created ?? new DateTimeImmutable();
+		$this->id = $id ?? Uuid::uuid7($this->created);
 	}
 }

--- a/src/Modules/WEBSERVER_MODULE/Migrations/MigrateApiKeyTableToUuids.php
+++ b/src/Modules/WEBSERVER_MODULE/Migrations/MigrateApiKeyTableToUuids.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Modules\WEBSERVER_MODULE\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Nadybot\Core\Attributes as NCA;
+use Nadybot\Core\{DB, SchemaMigration};
+use Nadybot\Modules\WEBSERVER_MODULE\{ApiKey};
+use Psr\Log\LoggerInterface;
+
+#[NCA\Migration(order: 2024_08_06_07_25_00)]
+class MigrateApiKeyTableToUuids implements SchemaMigration {
+	public function migrate(LoggerInterface $logger, DB $db): void {
+		$db->migrateIdToUuid(
+			ApiKey::getTable(),
+			static function (Blueprint $table): void {
+				$table->uuid('id')->primary();
+				$table->string('character', 12)->index();
+				$table->string('token', 8)->unique();
+				$table->unsignedBigInteger('last_sequence_nr')->default(0);
+				$table->text('pubkey');
+				$table->unsignedInteger('created');
+			},
+			'id',
+			'created'
+		);
+	}
+}

--- a/src/Modules/WEBSERVER_MODULE/Migrations/MigrateUIToRoute.php
+++ b/src/Modules/WEBSERVER_MODULE/Migrations/MigrateUIToRoute.php
@@ -23,9 +23,9 @@ class MigrateUIToRoute implements SchemaMigration {
 		} else {
 			$destination = Source::PRIV . "({$this->config->main->character})";
 		}
-		$db->insert(new Route(
-			source: Source::SYSTEM . '(webui)',
-			destination: $destination,
-		));
+		$db->table(Route::getTable())->insert([
+			'source' => Source::SYSTEM . '(webui)',
+			'destination' => $destination,
+		]);
 	}
 }

--- a/src/Modules/WORLDBOSS_MODULE/GauntletBuffController.php
+++ b/src/Modules/WORLDBOSS_MODULE/GauntletBuffController.php
@@ -247,12 +247,12 @@ class GauntletBuffController extends ModuleInstance implements MessageEmitter {
 
 		$this->timerController->remove("Gaubuff_{$side->lower()}");
 		$this->timerController->add(
-			"Gaubuff_{$side->lower()}",
-			$this->config->main->character,
-			'',
-			$alerts,
-			'GauntletBuffController.gaubuffcallback',
-			json_encode($data)
+			name: "Gaubuff_{$side->lower()}",
+			owner: $this->config->main->character,
+			mode: '',
+			alerts: $alerts,
+			callback: 'GauntletBuffController.gaubuffcallback',
+			data: json_encode($data)
 		);
 	}
 


### PR DESCRIPTION
Auto increasing database columns are problematic when you try to model them in the bot:
1. You need to allow the primary identifier in PHP to be empty, before the entry is inserted into the database. When reading from the database, it will always have a value, which means: in order to satisfy checks like phpstan, you either have to `assert(isset($model->id))` all the time, or constantly check.
2. Restoring from a pure SQL backup won't restore the current auto increase position. You cannot restore without having to manually set the auto increase position. This makes it completely useless for CSV imports

UUIDs in version 1, 6 and 7 have the advantage of being globally unique, plus always generating ascending values. Meaning: 2 consecutively created UUIDs in these versions will always be of ascending order.

UUIDs version 1 and 6 use MAC addresses for global uniqueness, but this also makes them tied to the machine itself, and leaks too much information for my taste. UUID v7 doesn't use any personal or trackable information, which is why the implementation is purely based on UUID v7.

Using UUIDs also solves enumerability attacks: you cannot guess the previous or next id.