### PR TITLE
Hydrator caching

### DIFF
--- a/conf/config.template.toml
+++ b/conf/config.template.toml
@@ -23,6 +23,7 @@ show_aoml_markup = false
 default_module_status = 0
 enable_console_client = true
 enable_package_module = true
+enable_hydrator_cache = true
 auto_org_name = false
 
 [proxy]

--- a/src/Core/BotRunner.php
+++ b/src/Core/BotRunner.php
@@ -217,7 +217,6 @@ class BotRunner {
 			$this->checkRequiredModules();
 			$this->checkRequiredPackages();
 			$this->createMissingDirs();
-			self::setupDBCache($config, self::getFS());
 
 			// these must happen first since the classes that are loaded may be used by processes below
 			$timezone = $config->general->timezone;
@@ -328,21 +327,6 @@ class BotRunner {
 	/** Utility function to check whether the bot is running Linux */
 	public static function isLinux(): bool {
 		return \PHP_OS_FAMILY === 'Linux';
-	}
-
-	/** Setup a directory under cache/db, and make sure it's empty */
-	private static function setupDBCache(BotConfig $config, Filesystem $fs): void {
-		$dbCachePath = $config->paths->cache . '/db';
-		if (!$fs->exists($dbCachePath)) {
-			$fs->createDirectory($dbCachePath);
-			return;
-		}
-		$oldCache = $fs->listFiles($dbCachePath);
-		foreach ($oldCache as $file) {
-			if ($fs->isFile("{$dbCachePath}/{$file}")) {
-				$fs->deleteFile("{$dbCachePath}/{$file}");
-			}
-		}
 	}
 
 	private static function getFS(): Filesystem {

--- a/src/Core/Config/BotConfig.php
+++ b/src/Core/Config/BotConfig.php
@@ -5,9 +5,9 @@ namespace Nadybot\Core\Config;
 use function Safe\json_decode;
 
 use EventSauce\ObjectHydrator\PropertyCasters\CastListToType;
-use EventSauce\ObjectHydrator\{MapFrom, MapperSettings, ObjectMapperUsingReflection};
+use EventSauce\ObjectHydrator\{MapFrom, MapperSettings};
 use Nadybot\Core\Attributes\Instance;
-use Nadybot\Core\Filesystem;
+use Nadybot\Core\{Filesystem, Hydrator};
 use Nadylib\IMEX;
 
 /**
@@ -62,14 +62,13 @@ class BotConfig {
 		}
 		$vars = self::convertOldSettings($vars);
 		$vars['file_path'] = $filePath;
-		$mapper = new ObjectMapperUsingReflection();
 		for ($i = 0; $i < count($vars['worker']??[]); $i++) {
 			$vars['worker'][$i]['dimension'] ??= $vars['main']['dimension'] ?? null;
 			$vars['worker'][$i]['login']     ??= $vars['main']['login'] ?? null;
 			$vars['worker'][$i]['password']  ??= $vars['main']['password'] ?? null;
 		}
 
-		$config = $mapper->hydrateObject(self::class, $vars);
+		$config = Hydrator::hydrate(self::class, $vars);
 		$config->autoUnfreeze ??= new AutoUnfreeze();
 		return $config;
 	}
@@ -81,8 +80,7 @@ class BotConfig {
 
 	/** Saves the config file, creating the file if it doesn't exist yet. */
 	public function save(Filesystem $fs): void {
-		$mapper = new ObjectMapperUsingReflection();
-		$vars = $mapper->serializeObject($this);
+		$vars = Hydrator::serialize($this);
 		unset($vars['file_path']);
 		unset($vars['org_id']);
 		$vars = array_filter($vars, static function (mixed $value): bool {

--- a/src/Core/Config/General.php
+++ b/src/Core/Config/General.php
@@ -19,6 +19,7 @@ class General {
 		#[CastToType('int')] public int $defaultModuleStatus=1,
 		#[CastToType('bool')] public bool $enableConsoleClient=true,
 		#[CastToType('bool')] public bool $enablePackageModule=true,
+		#[CastToType('bool')] public bool $enableHydratorCache=true,
 		#[CastToType('bool')] #[MapFrom('auto_org_name')] public bool $autoOrgName=false,
 		public ?string $timezone=null,
 	) {

--- a/src/Core/Highway/Connection.php
+++ b/src/Core/Highway/Connection.php
@@ -5,12 +5,12 @@ namespace Nadybot\Core\Highway;
 use function Safe\json_encode;
 use Amp\Websocket\Client\WebsocketConnection;
 use Amp\Websocket\{WebsocketCloseCode, WebsocketClosedException};
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToHydrateObject};
+use EventSauce\ObjectHydrator\{UnableToHydrateObject};
 use Exception;
 use Nadybot\Core\Highway\In\InPackage;
 use Nadybot\Core\Highway\Out\OutPackage;
 use Nadybot\Core\Types\LogWrapInterface;
-use Nadybot\Core\{Attributes as NCA, LoggerWrapper, SemanticVersion};
+use Nadybot\Core\{Attributes as NCA, Hydrator, LoggerWrapper, SemanticVersion};
 
 class Connection implements LogWrapInterface {
 	public const SUPPORTED_VERSIONS = ['~0.1.1', '~0.2.0-alpha.1'];
@@ -94,8 +94,7 @@ class Connection implements LogWrapInterface {
 
 	public function send(OutPackage $package): void {
 		$this->logger->info('Sending package {package}', ['package' => $package]);
-		$mapper = new ObjectMapperUsingReflection();
-		$json = $mapper->serializeObject($package);
+		$json = Hydrator::serialize($package);
 		$serverSupportsIds = SemanticVersion::compareUsing($this->getVersion(), '0.2.0-alpha.1', '>=');
 		if (!isset($json['id']) || !$serverSupportsIds) {
 			unset($json['id']);

--- a/src/Core/Highway/Parser.php
+++ b/src/Core/Highway/Parser.php
@@ -3,8 +3,8 @@
 namespace Nadybot\Core\Highway;
 
 use function Safe\json_decode;
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToHydrateObject};
-use Nadybot\Core\{Attributes as NCA, LoggerWrapper};
+use EventSauce\ObjectHydrator\{UnableToHydrateObject};
+use Nadybot\Core\{Attributes as NCA, Hydrator, LoggerWrapper};
 
 use Safe\Exceptions\JsonException;
 
@@ -32,9 +32,8 @@ class Parser {
 		} catch (JsonException $e) {
 			throw new ParserJsonException($e->getMessage(), $e->getCode(), $e);
 		}
-		$mapper = new ObjectMapperUsingReflection();
 		try {
-			$baseInfo = $mapper->hydrateObject(In\InPackage::class, $json);
+			$baseInfo = Hydrator::hydrate(In\InPackage::class, $json);
 		} catch (UnableToHydrateObject $e) {
 			throw new ParserHighwayException($e->getMessage(), $e->getCode(), $e);
 		}
@@ -54,7 +53,7 @@ class Parser {
 
 		try {
 			/** @var In\InPackage */
-			$package = $mapper->hydrateObject($targetClass, $json);
+			$package = Hydrator::hydrate($targetClass, $json);
 		} catch (UnableToHydrateObject $e) {
 			throw new ParserHighwayException($e->getMessage(), $e->getCode(), $e);
 		}

--- a/src/Core/Hydrator.php
+++ b/src/Core/Hydrator.php
@@ -5,8 +5,15 @@ namespace Nadybot\Core;
 use EventSauce\ObjectHydrator\{DefinitionProvider, IterableList, ObjectMapper, ObjectMapperCodeGenerator, ObjectMapperUsingReflection, UnableToHydrateObject, UnableToSerializeObject};
 use Exception;
 use Nadybot\Core\Config\BotConfig;
+use Throwable;
 
 class Hydrator {
+	/** @var array<string,true> */
+	private static $badSerializers = [];
+
+	/** @var array<string,true> */
+	private static $badHydrators = [];
+
 	/**
 	 * @template T of object
 	 *
@@ -24,11 +31,15 @@ class Hydrator {
 	): object {
 		$hydratorClass = self::getHydratorClass($className);
 		self::ensureHydratorExists($hydratorClass, $className, $definitionProvider);
-		if (class_exists($hydratorClass, false)) {
+		if (class_exists($hydratorClass, false) && !isset(self::$badHydrators[$className])) {
 			if (is_subclass_of($hydratorClass, ObjectMapper::class)) {
-				/** @var ObjectMapper */
-				$hydrator = new $hydratorClass();
-				return $hydrator->hydrateObject($className, $data);
+				try {
+					/** @var ObjectMapper */
+					$hydrator = new $hydratorClass();
+					return $hydrator->hydrateObject($className, $data);
+				} catch (Throwable) {
+					self::$badHydrators[$className] = true;
+				}
 			}
 		}
 		$mapper = new ObjectMapperUsingReflection($definitionProvider);
@@ -52,11 +63,15 @@ class Hydrator {
 	): IterableList {
 		$hydratorClass = self::getHydratorClass($className);
 		self::ensureHydratorExists($hydratorClass, $className, $definitionProvider);
-		if (class_exists($hydratorClass, false)) {
+		if (class_exists($hydratorClass, false) && !isset(self::$badHydrators[$className])) {
 			if (is_subclass_of($hydratorClass, ObjectMapper::class)) {
-				/** @var ObjectMapper */
-				$hydrator = new $hydratorClass();
-				return $hydrator->hydrateObjects($className, $data);
+				try {
+					/** @var ObjectMapper */
+					$hydrator = new $hydratorClass();
+					return $hydrator->hydrateObjects($className, $data);
+				} catch (Throwable) {
+					self::$badHydrators[$className] = true;
+				}
 			}
 		}
 		$mapper = new ObjectMapperUsingReflection($definitionProvider);
@@ -70,11 +85,15 @@ class Hydrator {
 		$className = $object::class;
 		$hydratorClass = self::getHydratorClass($className);
 		self::ensureHydratorExists($hydratorClass, $className, $definitionProvider);
-		if (class_exists($hydratorClass, false)) {
+		if (class_exists($hydratorClass, false) && !isset(self::$badSerializers[$className])) {
 			if (is_subclass_of($hydratorClass, ObjectMapper::class)) {
-				/** @var ObjectMapper */
-				$hydrator = new $hydratorClass();
-				return $hydrator->serializeObject($object);
+				try {
+					/** @var ObjectMapper */
+					$hydrator = new $hydratorClass();
+					return $hydrator->serializeObject($object);
+				} catch (Throwable) {
+					self::$badSerializers[$className] = true;
+				}
 			}
 		}
 		$mapper = new ObjectMapperUsingReflection($definitionProvider);
@@ -101,11 +120,15 @@ class Hydrator {
 		$className = get_class($objects[0]);
 		$hydratorClass = self::getHydratorClass($className);
 		self::ensureHydratorExists($hydratorClass, $className, $definitionProvider);
-		if (class_exists($hydratorClass, false)) {
+		if (class_exists($hydratorClass, false) && !isset(self::$badSerializers[$className])) {
 			if (is_subclass_of($hydratorClass, ObjectMapper::class)) {
-				/** @var ObjectMapper */
-				$hydrator = new $hydratorClass();
-				return $hydrator->serializeObjects($objects);
+				try {
+					/** @var ObjectMapper */
+					$hydrator = new $hydratorClass();
+					return $hydrator->serializeObjects($objects);
+				} catch (Throwable) {
+					self::$badSerializers[$className] = true;
+				}
 			}
 		}
 		$mapper = new ObjectMapperUsingReflection($definitionProvider);

--- a/src/Core/Hydrator.php
+++ b/src/Core/Hydrator.php
@@ -1,0 +1,145 @@
+<?php declare(strict_types=1);
+
+namespace Nadybot\Core;
+
+use EventSauce\ObjectHydrator\{DefinitionProvider, IterableList, ObjectMapper, ObjectMapperCodeGenerator, ObjectMapperUsingReflection, UnableToHydrateObject, UnableToSerializeObject};
+use Exception;
+use Nadybot\Core\Config\BotConfig;
+
+class Hydrator {
+	/**
+	 * @template T of object
+	 *
+	 * @param class-string<T>     $className
+	 * @param array<string,mixed> $data
+	 *
+	 * @return T
+	 *
+	 * @throws UnableToHydrateObject
+	 */
+	public static function hydrate(
+		string $className,
+		array $data,
+		?DefinitionProvider $definitionProvider=null
+	): object {
+		$hydratorClass = self::getHydratorClass($className);
+		self::ensureHydratorExists($hydratorClass, $className, $definitionProvider);
+		if (class_exists($hydratorClass, false)) {
+			if (is_subclass_of($hydratorClass, ObjectMapper::class)) {
+				/** @var ObjectMapper */
+				$hydrator = new $hydratorClass();
+				return $hydrator->hydrateObject($className, $data);
+			}
+		}
+		$mapper = new ObjectMapperUsingReflection($definitionProvider);
+		return $mapper->hydrateObject($className, $data);
+	}
+
+	/**
+	 * @template T
+	 *
+	 * @param class-string<T>        $className
+	 * @param iterable<array<mixed>> $data
+	 *
+	 * @return IterableList<T>
+	 *
+	 * @throws UnableToHydrateObject
+	 */
+	public static function hydrateObjects(
+		string $className,
+		iterable $data,
+		?DefinitionProvider $definitionProvider=null
+	): IterableList {
+		$hydratorClass = self::getHydratorClass($className);
+		self::ensureHydratorExists($hydratorClass, $className, $definitionProvider);
+		if (class_exists($hydratorClass, false)) {
+			if (is_subclass_of($hydratorClass, ObjectMapper::class)) {
+				/** @var ObjectMapper */
+				$hydrator = new $hydratorClass();
+				return $hydrator->hydrateObjects($className, $data);
+			}
+		}
+		$mapper = new ObjectMapperUsingReflection($definitionProvider);
+		return $mapper->hydrateObjects($className, $data);
+	}
+
+	public static function serialize(
+		object $object,
+		?DefinitionProvider $definitionProvider=null
+	): mixed {
+		$className = $object::class;
+		$hydratorClass = self::getHydratorClass($className);
+		self::ensureHydratorExists($hydratorClass, $className, $definitionProvider);
+		if (class_exists($hydratorClass, false)) {
+			if (is_subclass_of($hydratorClass, ObjectMapper::class)) {
+				/** @var ObjectMapper */
+				$hydrator = new $hydratorClass();
+				return $hydrator->serializeObject($object);
+			}
+		}
+		$mapper = new ObjectMapperUsingReflection($definitionProvider);
+		return $mapper->serializeObject($object);
+	}
+
+	/**
+	 * @param object[] $objects
+	 *
+	 * @psalm-param list<object> $objects
+	 *
+	 * @return IterableList<array<mixed>>
+	 *
+	 * @throws UnableToSerializeObject
+	 */
+	public static function serializeObjects(
+		array $objects,
+		?DefinitionProvider $definitionProvider=null
+	): IterableList {
+		if (count($objects) === 0) {
+			/** @psalm-suppress TooManyArguments */
+			return new IterableList([]);
+		}
+		$className = get_class($objects[0]);
+		$hydratorClass = self::getHydratorClass($className);
+		self::ensureHydratorExists($hydratorClass, $className, $definitionProvider);
+		if (class_exists($hydratorClass, false)) {
+			if (is_subclass_of($hydratorClass, ObjectMapper::class)) {
+				/** @var ObjectMapper */
+				$hydrator = new $hydratorClass();
+				return $hydrator->serializeObjects($objects);
+			}
+		}
+		$mapper = new ObjectMapperUsingReflection($definitionProvider);
+		return $mapper->serializeObjects($objects);
+	}
+
+	/** @param class-string $className */
+	private static function ensureHydratorExists(
+		string $hydratorClass,
+		string $className,
+		?DefinitionProvider $definitionProvider=null
+	): void {
+		if (class_exists($hydratorClass, false)) {
+			return;
+		}
+
+		try {
+			$fs = Registry::getInstance(Filesystem::class);
+			$config = Registry::getInstance(BotConfig::class);
+		} catch (Exception) {
+			return;
+		}
+		if ($config->general->enableHydratorCache === false) {
+			return;
+		}
+		$dumper = new ObjectMapperCodeGenerator($definitionProvider);
+		$code = $dumper->dump([$className], $hydratorClass);
+		$fileName = $fs->tempnam($config->paths->cache, 'hydrator_');
+		$fs->write($fileName, $code);
+		require_once $fileName;
+		$fs->deleteFile($fileName);
+	}
+
+	private static function getHydratorClass(string $className): string {
+		return "Nadybot\\Cache\Hydrator\\Hyd_" . md5($className);
+	}
+}

--- a/src/Core/Modules/COLORS/ColorsController.php
+++ b/src/Core/Modules/COLORS/ColorsController.php
@@ -3,7 +3,6 @@
 namespace Nadybot\Core\Modules\COLORS;
 
 use function Safe\{json_decode, preg_match};
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Exception;
 use Illuminate\Support\Collection;
 use Nadybot\Core\Filesystem;
@@ -13,6 +12,7 @@ use Nadybot\Core\{
 	CmdContext,
 	DB,
 	DBSchema\RouteHopColor,
+	Hydrator,
 	MessageHub,
 	ModuleInstance,
 	Modules\MESSAGES\MessageHubController,
@@ -207,8 +207,7 @@ class ColorsController extends ModuleInstance {
 			return null;
 		}
 		$data['name'] = basename($filename, '.json');
-		$mapper = new ObjectMapperUsingReflection();
-		return $mapper->hydrateObject(Theme::class, $data);
+		return Hydrator::hydrate(Theme::class, $data);
 	}
 
 	/** Activate all colors of the given theme */

--- a/src/Core/Modules/CONFIG/ConfigApiController.php
+++ b/src/Core/Modules/CONFIG/ConfigApiController.php
@@ -6,7 +6,6 @@ use function Safe\preg_match;
 
 use Amp\Http\HttpStatus;
 use Amp\Http\Server\{Request, Response};
-use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion, ObjectMapper, ObjectMapperUsingReflection};
 use Exception;
 use Illuminate\Support\Collection;
 use Nadybot\Core\{
@@ -20,6 +19,7 @@ use Nadybot\Core\{
 	Exceptions\InsufficientAccessException,
 	Exceptions\SQLException,
 	HelpManager,
+	Hydrator,
 	ModuleInstance,
 	Safe,
 	SettingManager,
@@ -57,15 +57,6 @@ class ConfigApiController extends ModuleInstance {
 
 	#[NCA\Inject]
 	private DB $db;
-
-	public function __construct(
-		private ObjectMapper $mapper=new ObjectMapperUsingReflection(
-			new DefinitionProvider(
-				keyFormatter: new KeyFormatterWithoutConversion(),
-			),
-		)
-	) {
-	}
 
 	/** Get a list of available modules to configure */
 	#[
@@ -468,7 +459,7 @@ class ConfigApiController extends ModuleInstance {
 				throw new Exception('Wrong content body');
 			}
 
-			$permSet = $this->mapper->hydrateObject(CmdPermissionSet::class, $set);
+			$permSet = Hydrator::hydrate(CmdPermissionSet::class, $set);
 		} catch (Throwable) {
 			return new Response(status: HttpStatus::UNPROCESSABLE_ENTITY);
 		}
@@ -500,7 +491,7 @@ class ConfigApiController extends ModuleInstance {
 				throw new Exception('Wrong content body');
 			}
 
-			$permSet = $this->mapper->hydrateObject(CmdPermissionSet::class, $set);
+			$permSet = Hydrator::hydrate(CmdPermissionSet::class, $set);
 		} catch (Throwable) {
 			return new Response(status: HttpStatus::UNPROCESSABLE_ENTITY);
 		}
@@ -658,7 +649,7 @@ class ConfigApiController extends ModuleInstance {
 			}
 			$body['source'] = $source;
 
-			$mapping = $this->mapper->hydrateObject(CmdSourceMapping::class, $body);
+			$mapping = Hydrator::hydrate(CmdSourceMapping::class, $body);
 		} catch (Throwable $e) {
 			return new Response(status: HttpStatus::UNPROCESSABLE_ENTITY);
 		}
@@ -686,7 +677,7 @@ class ConfigApiController extends ModuleInstance {
 
 			$body['source'] = strtolower($source);
 			$body['sub_source'] = null;
-			$mapping = $this->mapper->hydrateObject(CmdSourceMapping::class, $body);
+			$mapping = Hydrator::hydrate(CmdSourceMapping::class, $body);
 		} catch (Throwable) {
 			return new Response(status: HttpStatus::UNPROCESSABLE_ENTITY);
 		}
@@ -714,7 +705,7 @@ class ConfigApiController extends ModuleInstance {
 
 			$body['source'] = strtolower($source);
 			$body['sub_source'] = strtolower($subSource);
-			$mapping = $this->mapper->hydrateObject(CmdSourceMapping::class, $body);
+			$mapping = Hydrator::hydrate(CmdSourceMapping::class, $body);
 		} catch (Throwable) {
 			return new Response(status: HttpStatus::UNPROCESSABLE_ENTITY);
 		}

--- a/src/Core/Modules/DISCORD/DiscordAPIClient.php
+++ b/src/Core/Modules/DISCORD/DiscordAPIClient.php
@@ -6,11 +6,11 @@ use function Amp\delay;
 use function Safe\{json_decode, json_encode};
 use Amp\Http\Client\Interceptor\SetRequestHeaderIfUnset;
 use Amp\Http\Client\{BufferedContent, HttpClient, HttpClientBuilder, Request};
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Exception;
 use Nadybot\Core\{
 	Attributes as NCA,
 	HttpRetryRateLimits,
+	Hydrator,
 	ModuleInstance,
 	Safe,
 };
@@ -70,8 +70,7 @@ class DiscordAPIClient extends ModuleInstance {
 
 	public function getGateway(): DiscordGateway {
 		$body = $this->sendRequest(new Request(self::DISCORD_API . '/gateway/bot'));
-		$mapper = new ObjectMapperUsingReflection();
-		return $mapper->hydrateObject(DiscordGateway::class, json_decode($body, true));
+		return Hydrator::hydrate(DiscordGateway::class, json_decode($body, true));
 	}
 
 	public function modifyGuildMember(string $guildId, string $userId, string $data): stdClass {
@@ -90,8 +89,7 @@ class DiscordAPIClient extends ModuleInstance {
 		$request = new Request($url, 'PUT');
 		$request->setBody(new DiscordBody($message));
 		$json = $this->sendRequest($request);
-		$mapper = new ObjectMapperUsingReflection();
-		return $mapper->hydrateObjects(ApplicationCommand::class, json_decode($json, true))->toArray();
+		return Hydrator::hydrateObjects(ApplicationCommand::class, json_decode($json, true))->toArray();
 	}
 
 	public function deleteGlobalApplicationCommand(
@@ -104,9 +102,8 @@ class DiscordAPIClient extends ModuleInstance {
 
 	/** @return list<ApplicationCommand> */
 	public function getGlobalApplicationCommands(string $applicationId): array {
-		$mapper = new ObjectMapperUsingReflection();
 		$json = $this->sendRequest(new Request(self::DISCORD_API . "/applications/{$applicationId}/commands"));
-		return $mapper->hydrateObjects(ApplicationCommand::class, json_decode($json, true))->toArray();
+		return Hydrator::hydrateObjects(ApplicationCommand::class, json_decode($json, true))->toArray();
 	}
 
 	public function sendInteractionResponse(
@@ -172,8 +169,7 @@ class DiscordAPIClient extends ModuleInstance {
 			'application/json; charset=utf-8'
 		));
 		$json = $this->sendRequest($request);
-		$mapper = new ObjectMapperUsingReflection();
-		$channel = $mapper->hydrateObject(DiscordChannel::class, json_decode($json, true));
+		$channel = Hydrator::hydrate(DiscordChannel::class, json_decode($json, true));
 		$this->queueToChannel($channel->id, $message);
 	}
 
@@ -187,8 +183,7 @@ class DiscordAPIClient extends ModuleInstance {
 		]);
 		$request = new Request(self::DISCORD_API . "/channels/{$channelId}");
 		$json = $this->sendRequest($request);
-		$mapper = new ObjectMapperUsingReflection();
-		return $mapper->hydrateObject(DiscordChannel::class, json_decode($json, true));
+		return Hydrator::hydrate(DiscordChannel::class, json_decode($json, true));
 	}
 
 	public function getUser(string $userId): DiscordUser {
@@ -201,10 +196,9 @@ class DiscordAPIClient extends ModuleInstance {
 			]);
 			return $this->userCache[$userId];
 		}
-		$mapper = new ObjectMapperUsingReflection();
 		$request = new Request(self::DISCORD_API . "/users/{$userId}");
 		$json = $this->sendRequest($request);
-		$user = $mapper->hydrateObject(DiscordUser::class, json_decode($json, true));
+		$user = Hydrator::hydrate(DiscordUser::class, json_decode($json, true));
 		$this->cacheUser($user);
 		return $user;
 	}
@@ -229,8 +223,7 @@ class DiscordAPIClient extends ModuleInstance {
 		}
 		$request = new Request(self::DISCORD_API . "/guilds/{$guildId}/members/{$userId}");
 		$json = $this->sendRequest($request);
-		$mapper = new ObjectMapperUsingReflection();
-		$member = $mapper->hydrateObject(GuildMember::class, json_decode($json, true));
+		$member = Hydrator::hydrate(GuildMember::class, json_decode($json, true));
 		$this->cacheGuildMember($guildId, $member);
 		return $member;
 	}
@@ -247,8 +240,7 @@ class DiscordAPIClient extends ModuleInstance {
 			'application/json; charset=utf-8'
 		));
 		$json = $this->sendRequest($request);
-		$mapper = new ObjectMapperUsingReflection();
-		return $mapper->hydrateObject(DiscordChannelInvite::class, json_decode($json, true));
+		return Hydrator::hydrate(DiscordChannelInvite::class, json_decode($json, true));
 	}
 
 	/**
@@ -259,8 +251,7 @@ class DiscordAPIClient extends ModuleInstance {
 	public function getGuildInvites(string $guildId): array {
 		$request = new Request(self::DISCORD_API . "/guilds/{$guildId}/invites");
 		$json = json_decode($this->sendRequest($request), true);
-		$mapper = new ObjectMapperUsingReflection();
-		return $mapper->hydrateObjects(DiscordChannelInvite::class, $json)->toArray();
+		return Hydrator::hydrateObjects(DiscordChannelInvite::class, $json)->toArray();
 	}
 
 	/**
@@ -271,8 +262,7 @@ class DiscordAPIClient extends ModuleInstance {
 	public function getGuildEvents(string $guildId): array {
 		$request = new Request(self::DISCORD_API . "/guilds/{$guildId}/scheduled-events?with_user_count=true");
 		$json = json_decode($this->sendRequest($request), true);
-		$mapper = new ObjectMapperUsingReflection();
-		return $mapper->hydrateObjects(DiscordScheduledEvent::class, $json)->toArray();
+		return Hydrator::hydrateObjects(DiscordScheduledEvent::class, $json)->toArray();
 	}
 
 	/**
@@ -283,8 +273,7 @@ class DiscordAPIClient extends ModuleInstance {
 	public function getEmojis(string $guildId): array {
 		$request = new Request(self::DISCORD_API . "/guilds/{$guildId}/emojis");
 		$json = json_decode($this->sendRequest($request), true);
-		$mapper = new ObjectMapperUsingReflection();
-		return $mapper->hydrateObjects(Emoji::class, $json)->toArray();
+		return Hydrator::hydrateObjects(Emoji::class, $json)->toArray();
 	}
 
 	/** Register a new Emoji in the $guildId */
@@ -298,9 +287,8 @@ class DiscordAPIClient extends ModuleInstance {
 			]),
 			'application/json; charset=utf-8'
 		));
-		$mapper = new ObjectMapperUsingReflection();
 		$json = json_decode($this->sendRequest($request), true);
-		return $mapper->hydrateObject(Emoji::class, $json);
+		return Hydrator::hydrate(Emoji::class, $json);
 	}
 
 	/** Change the data for an already existing Emoji */
@@ -317,9 +305,8 @@ class DiscordAPIClient extends ModuleInstance {
 			]),
 			'application/json; charset=utf-8'
 		));
-		$mapper = new ObjectMapperUsingReflection();
 		$json = json_decode($this->sendRequest($request), true);
-		return $mapper->hydrateObject(Emoji::class, $json);
+		return Hydrator::hydrate(Emoji::class, $json);
 	}
 
 	/** Delete an already existing emoji */

--- a/src/Core/Modules/PLAYER_LOOKUP/PlayerFeedHandler.php
+++ b/src/Core/Modules/PLAYER_LOOKUP/PlayerFeedHandler.php
@@ -2,12 +2,12 @@
 
 namespace Nadybot\Core\Modules\PLAYER_LOOKUP;
 
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToHydrateObject};
+use EventSauce\ObjectHydrator\{UnableToHydrateObject};
 use Nadybot\Core\Attributes as NCA;
 use Nadybot\Core\Config\BotConfig;
 use Nadybot\Core\Events\SettingEvent;
 use Nadybot\Core\Types\EventFeedHandler;
-use Nadybot\Core\{EventFeed, ModuleInstance, Nadybot};
+use Nadybot\Core\{EventFeed, Hydrator, ModuleInstance, Nadybot};
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -57,9 +57,8 @@ class PlayerFeedHandler extends ModuleInstance implements EventFeedHandler {
 
 	/** @param array<string,mixed> $data */
 	public function handleEventFeedMessage(string $room, array $data): void {
-		$mapper = new ObjectMapperUsingReflection();
 		try {
-			$playerInfo = $mapper->hydrateObject(PlayerInfo::class, $data);
+			$playerInfo = Hydrator::hydrate(PlayerInfo::class, $data);
 			$player = $playerInfo->toPlayer();
 			$this->playerManager->update($player);
 			if ($player->dimension === $this->config->main->dimension) {

--- a/src/Core/Modules/PLAYER_LOOKUP/PlayerHistoryManager.php
+++ b/src/Core/Modules/PLAYER_LOOKUP/PlayerHistoryManager.php
@@ -8,11 +8,11 @@ use Amp\File\FileCache;
 use Amp\Http\Client\{HttpClientBuilder, Request};
 use Amp\Sync\LocalKeyedMutex;
 use Amp\TimeoutCancellation;
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Nadybot\Core\Config\BotConfig;
 use Nadybot\Core\{
 	Attributes as NCA,
 	Filesystem,
+	Hydrator,
 	ModuleInstance,
 };
 use Safe\Exceptions\JsonException;
@@ -89,14 +89,13 @@ class PlayerHistoryManager extends ModuleInstance {
 
 	/** @psalm-param callable(?PlayerHistory, mixed...) $callback */
 	private function parsePlayerHistory(string $data, string $name): ?PlayerHistory {
-		$mapper = new ObjectMapperUsingReflection();
 		try {
 			$history = json_decode($data, true);
 		} catch (JsonException) {
 			return null;
 		}
 
-		$entries = $mapper->hydrateObjects(PlayerHistoryData::class, $history)->toArray();
+		$entries = Hydrator::hydrateObjects(PlayerHistoryData::class, $history)->toArray();
 		return new PlayerHistory(name: $name, data: $entries);
 	}
 }

--- a/src/Core/Modules/SYSTEM/SystemController.php
+++ b/src/Core/Modules/SYSTEM/SystemController.php
@@ -5,7 +5,6 @@ namespace Nadybot\Core\Modules\SYSTEM;
 use function Safe\{ini_get, json_encode};
 
 use Amp\Http\Server\{Request, Response};
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Nadybot\Core\Attributes\Confidential;
 use Nadybot\Core\DBSchema\Player;
 use Nadybot\Core\Events\ConnectEvent;
@@ -24,6 +23,7 @@ use Nadybot\Core\{
 	EventManager,
 	Events\Event,
 	HelpManager,
+	Hydrator,
 	MessageHub,
 	ModuleInstance,
 	Modules\BAN\BanController,
@@ -533,9 +533,8 @@ class SystemController extends ModuleInstance implements MessageEmitter {
 	/** Show your current config file with sensitive information removed */
 	#[NCA\HandlesCommand('showconfig')]
 	public function showConfigCommand(CmdContext $context): void {
-		$mapper = new ObjectMapperUsingReflection();
 		Confidential::$active = true;
-		$config = $mapper->serializeObject($this->config);
+		$config = Hydrator::serialize($this->config);
 		Confidential::$active = false;
 
 		$json = json_encode(
@@ -554,9 +553,8 @@ class SystemController extends ModuleInstance implements MessageEmitter {
 			$context->reply('For security reasons, this command only works in tells');
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
 		Confidential::$active = false;
-		$vars = $mapper->serializeObject($this->config);
+		$vars = Hydrator::serialize($this->config);
 		if (!isset($vars['org_id'])) {
 			unset($vars['org_id']);
 		}

--- a/src/Core/Modules/SYSTEM/UpdateNotificationController.php
+++ b/src/Core/Modules/SYSTEM/UpdateNotificationController.php
@@ -2,10 +2,10 @@
 
 namespace Nadybot\Core\Modules\SYSTEM;
 
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Nadybot\Core\{
 	Attributes as NCA,
 	BotRunner,
+	Hydrator,
 	MessageHub,
 	ModuleInstance,
 	Routing\RoutableMessage,
@@ -26,8 +26,7 @@ class UpdateNotificationController extends ModuleInstance implements EventFeedHa
 
 	/** @param array<string,mixed> $data */
 	public function handleEventFeedMessage(string $room, array $data): void {
-		$mapper = new ObjectMapperUsingReflection();
-		$package = $mapper->hydrateObject(UpdateNotification::class, $data);
+		$package = Hydrator::hydrate(UpdateNotification::class, $data);
 		$myVersion = new SemanticVersion(BotRunner::getVersion(false));
 		if ((isset($package->minVersion) && $package->minVersion->cmp($myVersion) > 0)
 			|| (isset($package->maxVersion) && $package->maxVersion->cmp($myVersion) < 0)) {

--- a/src/Core/QueryBuilder.php
+++ b/src/Core/QueryBuilder.php
@@ -18,6 +18,8 @@ use Safe\{DateTime, DateTimeImmutable};
 use Throwable;
 
 class QueryBuilder extends Builder {
+	private const CLASS_SEP = '⚡️';
+
 	#[NCA\Inject]
 	public BotConfig $config;
 
@@ -225,7 +227,7 @@ class QueryBuilder extends Builder {
 	}
 
 	/** @param class-string $className */
-	private function compileFromClass(string $className): void {
+	private function compileForClass(string $className): void {
 		$cacheLines = [];
 		$colMappings = [];
 		$refClass = new ReflectionClass($className);
@@ -293,15 +295,6 @@ class QueryBuilder extends Builder {
 		$this->compileCache($className, $cacheLines);
 	}
 
-	private function getCacheFile(string $className): string {
-		$safeClassName = Safe::pregReplace(
-			'/[^a-zA-Z0-9]/',
-			'_',
-			$className,
-		);
-		return $this->config->paths->cache . "/db/cmd_{$safeClassName}_compiler.php";
-	}
-
 	/**
 	 * Compile and save the cache
 	 *
@@ -315,17 +308,20 @@ class QueryBuilder extends Builder {
 			\PHP_EOL.
 			"namespace {$nameSpace};" . \PHP_EOL.
 			\PHP_EOL.
-			"class {$classShortName}_compiler {" . \PHP_EOL.
+			"class {$classShortName}" . self::CLASS_SEP . 'compiler {' . \PHP_EOL.
 			"\tpublic static function fromDB(\\stdClass \$data): {$classShortName} {" . \PHP_EOL.
 			"\t\treturn new {$classShortName}(" . \PHP_EOL.
 			"\t\t\t". implode(\PHP_EOL . "\t\t\t", $cacheLines) . \PHP_EOL.
 			"\t\t);" . \PHP_EOL.
 			"\t}" . \PHP_EOL.
 			'}' . \PHP_EOL;
-		$this->fs->write(
-			$this->getCacheFile($className),
-			$code
-		);
+		$fileName = $this->fs->tempnam($this->config->paths->cache . \DIRECTORY_SEPARATOR, 'db_');
+		$this->fs->write($fileName, $code);
+		try {
+			require_once $fileName;
+		} finally {
+			$this->fs->deleteFile($fileName);
+		}
 	}
 
 	/**
@@ -338,8 +334,7 @@ class QueryBuilder extends Builder {
 	 * @return Collection<int,T>
 	 */
 	private function fetchAll(string $className): Collection {
-		$cacheClass = "{$className}_compiler";
-		$cacheFile = $this->getCacheFile($className);
+		$cacheClass = "{$className}" . self::CLASS_SEP . 'compiler';
 
 		$data = $this->get();
 		if ($data->isEmpty()) {
@@ -347,15 +342,12 @@ class QueryBuilder extends Builder {
 		}
 
 		/** @var Collection<int,\stdClass> $data */
-		if (!class_exists($cacheClass)) {
-			if (!$this->fs->exists($cacheFile)) {
-				$this->compileFromClass($className);
-			}
-			require_once $cacheFile;
+		if (!class_exists($cacheClass, false)) {
+			$this->compileForClass($className);
 		}
-		if (class_exists($cacheClass)) {
+		if (class_exists($cacheClass, false)) {
 			return $data->map($cacheClass::fromDB(...));
 		}
-		throw new \Exception('Unable to infer a type from the given SQL result');
+		throw new \Exception("Unable to infer a database mapper for {$className}");
 	}
 }

--- a/src/Core/SyncEventFactory.php
+++ b/src/Core/SyncEventFactory.php
@@ -4,7 +4,7 @@ namespace Nadybot\Core;
 
 use function Safe\{json_decode, json_encode};
 
-use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion, ObjectMapperUsingReflection};
+use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion};
 use InvalidArgumentException;
 use Nadybot\Core\Events\SyncEvent;
 
@@ -32,13 +32,13 @@ class SyncEventFactory {
 		if (!isset($class)) {
 			throw new InvalidArgumentException(__CLASS__  . '::create(): Argument #1 ($data) is an unknown (Sync-)Event');
 		}
-		$mapper = new ObjectMapperUsingReflection(
-			new DefinitionProvider(
+		return Hydrator::hydrate(
+			className: $class,
+			data: $data,
+			definitionProvider: new DefinitionProvider(
 				keyFormatter: new KeyFormatterWithoutConversion(),
 			),
 		);
-		$event = $mapper->hydrateObject($class, $data);
-		return $event;
 	}
 
 	/**

--- a/src/Modules/DEV_MODULE/TestController.php
+++ b/src/Modules/DEV_MODULE/TestController.php
@@ -6,7 +6,6 @@ use function Safe\date;
 use Amp\File\FilesystemException;
 use AO\Client\{SingleClient, WorkerPackage};
 use AO\Package;
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Exception;
 use Nadybot\Core\{
 	Attributes as NCA,
@@ -18,6 +17,7 @@ use Nadybot\Core\{
 	Events\PrivateChannelMsgEvent,
 	Exceptions\UserException,
 	Filesystem,
+	Hydrator,
 	ModuleInstance,
 	Modules\DISCORD\DiscordMessageIn,
 	Nadybot,
@@ -360,7 +360,6 @@ class TestController extends ModuleInstance {
 		PCharacter $nick,
 		string $content
 	): void {
-		$mapper = new ObjectMapperUsingReflection();
 		$payload = [
 			'type' => 0,
 			'tts' => false,
@@ -396,7 +395,7 @@ class TestController extends ModuleInstance {
 			'attachments' => [],
 			'guild_id' => '731552006069551184',
 		];
-		$message = $mapper->hydrateObject(DiscordMessageIn::class, $payload);
+		$message = Hydrator::hydrate(DiscordMessageIn::class, $payload);
 		$event = new DiscordMessageEvent(
 			message: $message->content,
 			sender: $nick(),

--- a/src/Modules/DISCORD_GATEWAY_MODULE/DiscordGatewayController.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/DiscordGatewayController.php
@@ -12,7 +12,7 @@ use Amp\Http\Client\{HttpClientBuilder, HttpException};
 use Amp\Socket\ConnectContext;
 use Amp\Websocket\Client\{Rfc6455Connector, WebsocketConnectException, WebsocketConnection, WebsocketHandshake};
 use Amp\Websocket\{WebsocketCloseCode, WebsocketClosedException, WebsocketCount};
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToHydrateObject};
+use EventSauce\ObjectHydrator\{UnableToHydrateObject};
 use Illuminate\Support\ItemNotFoundException;
 use Nadybot\Core\Events\ConnectEvent;
 use Nadybot\Core\Filesystem;
@@ -40,6 +40,7 @@ use Nadybot\Core\{
 	CommandManager,
 	DB,
 	EventManager,
+	Hydrator,
 	MessageHub,
 	ModuleInstance,
 	Modules\ALTS\AltsController,
@@ -364,12 +365,11 @@ class DiscordGatewayController extends ModuleInstance {
 
 	public function processWebsocketMessage(string $message): void {
 		$this->logger->debug('Received discord message', ['message' => $message]);
-		$mapper = new ObjectMapperUsingReflection();
 		try {
 			if ($message === '') {
 				throw new JsonException('null message received.');
 			}
-			$payload = $mapper->hydrateObject(Payload::class, json_decode($message, true));
+			$payload = Hydrator::hydrate(Payload::class, json_decode($message, true));
 		} catch (JsonException | UnableToHydrateObject $e) {
 			$this->logger->error('Invalid JSON data received from Discord: {error}', [
 				'error' => $e->getMessage(),
@@ -490,8 +490,7 @@ class DiscordGatewayController extends ModuleInstance {
 		if (!isset($event->payload->d) || !is_array($event->payload->d)) {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$chunk = $mapper->hydrateObject(GuildMemberChunk::class, $event->payload->d);
+		$chunk = Hydrator::hydrate(GuildMemberChunk::class, $event->payload->d);
 		$this->logger->debug('Processing incoming discord members chunk {chunk}', [
 			'chunk' => $chunk,
 		]);
@@ -525,8 +524,7 @@ class DiscordGatewayController extends ModuleInstance {
 		if (!isset($event->payload->d) || !is_array($event->payload->d)) {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$message = $mapper->hydrateObject(DiscordMessageIn::class, $event->payload->d);
+		$message = Hydrator::hydrate(DiscordMessageIn::class, $event->payload->d);
 
 		$this->logger->info('Processing incoming discord message {message}', [
 			'message' => $message,
@@ -683,8 +681,7 @@ class DiscordGatewayController extends ModuleInstance {
 		if (!isset($event->payload->d) || !is_array($event->payload->d)) {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$guild = $mapper->hydrateObject(Guild::class, $event->payload->d);
+		$guild = Hydrator::hydrate(Guild::class, $event->payload->d);
 
 		$this->logger->info('Received {event} for {guild}', [
 			'event' => $event->payload->t,
@@ -772,8 +769,7 @@ class DiscordGatewayController extends ModuleInstance {
 		if (!isset($event->payload->d) || !is_array($event->payload->d)) {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$channel = $mapper->hydrateObject(DiscordChannel::class, $event->payload->d);
+		$channel = Hydrator::hydrate(DiscordChannel::class, $event->payload->d);
 
 		$this->logger->info('Received {event} for {channel}', [
 			'event' => $event->payload->t,
@@ -853,8 +849,7 @@ class DiscordGatewayController extends ModuleInstance {
 		if (!isset($payload->d) || !is_array($payload->d) || !isset($payload->d['user'])) {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$user = $mapper->hydrateObject(DiscordUser::class, $payload->d['user']);
+		$user = Hydrator::hydrate(DiscordUser::class, $payload->d['user']);
 
 		$this->sessionId = $payload->d['session_id'] ?? null;
 		$this->me = $user;
@@ -892,8 +887,7 @@ class DiscordGatewayController extends ModuleInstance {
 		if (!isset($payload->d) || !is_array($payload->d)) {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$voiceState = $mapper->hydrateObject(VoiceState::class, $payload->d);
+		$voiceState = Hydrator::hydrate(VoiceState::class, $payload->d);
 		$this->logger->info('Received {event}: {voice_state}', [
 			'event' => 'voice_state_update',
 			'voice_state' => $voiceState,
@@ -1445,8 +1439,7 @@ class DiscordGatewayController extends ModuleInstance {
 		if (!isset($payload->d) || !is_array($payload->d)) {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$event = $mapper->hydrateObject(DiscordScheduledEvent::class, $payload->d);
+		$event = Hydrator::hydrate(DiscordScheduledEvent::class, $payload->d);
 		$guild = $this->guilds[$event->guild_id]??null;
 		if (!isset($guild)) {
 			return;
@@ -1468,8 +1461,7 @@ class DiscordGatewayController extends ModuleInstance {
 		if (!isset($payload->d) || !is_array($payload->d)) {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$event = $mapper->hydrateObject(DiscordScheduledEvent::class, $payload->d);
+		$event = Hydrator::hydrate(DiscordScheduledEvent::class, $payload->d);
 		$guild = $this->guilds[$event->guild_id]??null;
 		if (!isset($guild)) {
 			return;
@@ -1494,8 +1486,7 @@ class DiscordGatewayController extends ModuleInstance {
 		if (!isset($payload->d) || !is_array($payload->d)) {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$event = $mapper->hydrateObject(DiscordScheduledEvent::class, $payload->d);
+		$event = Hydrator::hydrate(DiscordScheduledEvent::class, $payload->d);
 		$guild = $this->guilds[$event->guild_id]??null;
 		if (!isset($guild)) {
 			return;
@@ -1514,8 +1505,7 @@ class DiscordGatewayController extends ModuleInstance {
 		if (!isset($payload->d) || !is_array($payload->d)) {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$event = $mapper->hydrateObject(DiscordScheduledEvent::class, $payload->d);
+		$event = Hydrator::hydrate(DiscordScheduledEvent::class, $payload->d);
 		$guild = $this->guilds[$event->guild_id]??null;
 		if (!isset($guild)) {
 			return;
@@ -2190,8 +2180,7 @@ class DiscordGatewayController extends ModuleInstance {
 		if (!isset($this->client)) {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$serialized = self::stripNull($mapper->serializeObject($login));
+		$serialized = self::stripNull(Hydrator::serialize($login));
 		$this->client->sendText(json_encode($serialized));
 	}
 

--- a/src/Modules/DISCORD_GATEWAY_MODULE/DiscordSlashCommandController.php
+++ b/src/Modules/DISCORD_GATEWAY_MODULE/DiscordSlashCommandController.php
@@ -4,7 +4,6 @@ namespace Nadybot\Modules\DISCORD_GATEWAY_MODULE;
 
 use function Safe\preg_split;
 
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Illuminate\Support\Collection;
 use Nadybot\Core\Modules\DISCORD\{ApplicationCommand, ApplicationCommandOption, DiscordException};
 use Nadybot\Core\{
@@ -14,6 +13,7 @@ use Nadybot\Core\{
 	DB,
 	DBSchema\CmdCfg,
 	Exceptions\UserException,
+	Hydrator,
 	MessageHub,
 	ModuleInstance,
 	Modules\DISCORD\DiscordAPIClient,
@@ -333,8 +333,7 @@ class DiscordSlashCommandController extends ModuleInstance {
 			return;
 		}
 		$this->logger->info('Received interaction on Discord');
-		$mapper = new ObjectMapperUsingReflection();
-		$interaction = $mapper->hydrateObject(Interaction::class, $payload->d);
+		$interaction = Hydrator::hydrate(Interaction::class, $payload->d);
 		$this->logger->debug('Interaction decoded', [
 			'interaction' => $interaction,
 		]);

--- a/src/Modules/EXPORT_MODULE/ExportController.php
+++ b/src/Modules/EXPORT_MODULE/ExportController.php
@@ -5,7 +5,7 @@ namespace Nadybot\Modules\EXPORT_MODULE;
 use function Safe\json_encode;
 
 use Amp\File\FilesystemException;
-use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion, ObjectMapperUsingReflection, UnableToSerializeObject};
+use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion, UnableToSerializeObject};
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
@@ -13,6 +13,7 @@ use Nadybot\Core\{
 	DB,
 	ExporterInterface,
 	Filesystem,
+	Hydrator,
 	ModuleInstance,
 	Registry,
 };
@@ -97,15 +98,13 @@ class ExportController extends ModuleInstance {
 		foreach ($this->exporters as $key => $exporter) {
 			$exports[$key] = $exporter->export($this->db, $this->logger);
 		}
-		$mapper = new ObjectMapperUsingReflection(
-			new DefinitionProvider(
-				keyFormatter: new KeyFormatterWithoutConversion(),
-			),
+		$dp = new DefinitionProvider(
+			keyFormatter: new KeyFormatterWithoutConversion(),
 		);
 		try {
 			$serialized = [];
 			foreach ($exports as $key => $data) {
-				$serialized[$key] = $mapper->serializeObjects($data)->toArray();
+				$serialized[$key] = Hydrator::serializeObjects($data, $dp)->toArray();
 			}
 			$cleaned = self::stripNull($serialized);
 			$output = json_encode($cleaned, \JSON_PRETTY_PRINT|\JSON_UNESCAPED_SLASHES);

--- a/src/Modules/EXPORT_MODULE/ImportController.php
+++ b/src/Modules/EXPORT_MODULE/ImportController.php
@@ -5,7 +5,7 @@ namespace Nadybot\Modules\EXPORT_MODULE;
 use function Safe\json_decode;
 
 use Amp\File\FilesystemException;
-use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion, ObjectMapperUsingReflection, UnableToHydrateObject};
+use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion, UnableToHydrateObject};
 use Exception;
 use Nadybot\Core\{
 	AccessManager,
@@ -14,6 +14,7 @@ use Nadybot\Core\{
 	Config\BotConfig,
 	DB,
 	Filesystem,
+	Hydrator,
 	ImporterInterface,
 	ModuleInstance,
 	ParamClass\PFilename,
@@ -219,15 +220,17 @@ class ImportController extends ModuleInstance {
 		}
 		$this->logger->notice('Loading schema data');
 		$sendto->reply('Validating the import data. This could take a while.');
-		$mapper = new ObjectMapperUsingReflection(
-			new DefinitionProvider(
-				keyFormatter: new KeyFormatterWithoutConversion(),
-			),
+		$defProv = new DefinitionProvider(
+			keyFormatter: new KeyFormatterWithoutConversion(),
 		);
 		$result = [];
 		try {
 			foreach ($import as $key => $importData) {
-				$result[$key] = $mapper->hydrateObjects($this->keyToClass[$key], $importData)->toArray();
+				$result[$key] = Hydrator::hydrateObjects(
+					className: $this->keyToClass[$key],
+					data: $importData,
+					definitionProvider: $defProv,
+				)->toArray();
 			}
 		} catch (UnableToHydrateObject $e) {
 			$sendto->reply('The import data is not valid: <highlight>' . $e->getMessage() . '<end>.');

--- a/src/Modules/GSP_MODULE/GSPController.php
+++ b/src/Modules/GSP_MODULE/GSPController.php
@@ -5,13 +5,13 @@ namespace Nadybot\Modules\GSP_MODULE;
 use function Safe\json_decode;
 use Amp\Http\Client\{HttpClientBuilder, Request, Response};
 use DateTimeZone;
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Exception;
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
 	EventManager,
 	Events\LogonEvent,
+	Hydrator,
 	MessageHub,
 	ModuleInstance,
 	Nadybot,
@@ -105,9 +105,8 @@ class GSPController extends ModuleInstance implements MessageEmitter {
 		if ($response->getStatus() !== 200 || $body === '') {
 			return;
 		}
-		$mapper = new ObjectMapperUsingReflection();
 		try {
-			$show = $mapper->hydrateObject(Show::class, json_decode($body, true));
+			$show = Hydrator::hydrate(Show::class, json_decode($body, true));
 		} catch (\Throwable) {
 			return;
 		}
@@ -227,9 +226,8 @@ class GSPController extends ModuleInstance implements MessageEmitter {
 		if ($body === '' || $response->getStatus() !== 200) {
 			return 'GSP seems to have problems with their service. Please try again later.';
 		}
-		$mapper = new ObjectMapperUsingReflection();
 		try {
-			$show = $mapper->hydrateObject(Show::class, json_decode($body, true));
+			$show = Hydrator::hydrate(Show::class, json_decode($body, true));
 		} catch (\Throwable $e) {
 			return 'GSP seems to have problems with their service. Please try again later.';
 		}
@@ -298,10 +296,9 @@ class GSPController extends ModuleInstance implements MessageEmitter {
 		if ($response->getStatus() !== 200) {
 			throw new Exception('Recdeiced a ' . $response->getStatus() . '.');
 		}
-		$mapper = new ObjectMapperUsingReflection();
 		try {
-			$show = $mapper->hydrateObject(Show::class, json_decode($body, true));
-		} catch (\Throwable $e) {
+			$show = Hydrator::hydrate(Show::class, json_decode($body, true));
+		} catch (\Throwable) {
 			return 'GSP seems to have problems with their service. Please try again later.';
 		}
 		$blob = "<header2>GSP<end>\n<tab>";

--- a/src/Modules/HIGHNET_MODULE/HighnetController.php
+++ b/src/Modules/HIGHNET_MODULE/HighnetController.php
@@ -7,7 +7,7 @@ namespace Nadybot\Modules\HIGHNET_MODULE;
 use function Safe\json_decode;
 
 use Closure;
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToHydrateObject};
+use EventSauce\ObjectHydrator\{UnableToHydrateObject};
 use Exception;
 
 use Illuminate\Support\Collection;
@@ -26,6 +26,7 @@ use Nadybot\Core\{
 	EventManager,
 	Events\LowLevelEventFeedEvent,
 	Highway,
+	Hydrator,
 	MessageHub,
 	ModuleInstance,
 	Nadybot,
@@ -273,9 +274,8 @@ class HighnetController extends ModuleInstance implements EventFeedHandler {
 			$body = json_decode($body, true);
 		}
 
-		$mapper = new ObjectMapperUsingReflection();
 		try {
-			$message = $mapper->hydrateObject(Message::class, $body);
+			$message = Hydrator::hydrate(Message::class, $body);
 			if (!$this->isWantedMessage($message)) {
 				$this->logger->info('Highnet message was filtered away.');
 				return;
@@ -837,8 +837,7 @@ class HighnetController extends ModuleInstance implements EventFeedHandler {
 			channel: $channel,
 			message: $message,
 		);
-		$serializer = new ObjectMapperUsingReflection();
-		$hwBody = $serializer->serializeObject($message);
+		$hwBody = Hydrator::serialize($message);
 		if (!is_array($hwBody)) {
 			$this->logger->warning('Cannot serialize data for Highnet - dropping', [
 				'message' => $message,

--- a/src/Modules/IMPLANT_MODULE/ImplantDesign.php
+++ b/src/Modules/IMPLANT_MODULE/ImplantDesign.php
@@ -28,7 +28,7 @@ class ImplantDesign extends DBTable {
 		return Hydrator::hydrate(ImplantConfig::class, json_decode($design, true));
 	}
 
-	public static function encodeDesign(?object $design): ?string {
+	public static function encodeDesign(?ImplantConfig $design): ?string {
 		if (!isset($design)) {
 			return null;
 		}

--- a/src/Modules/IMPLANT_MODULE/ImplantDesign.php
+++ b/src/Modules/IMPLANT_MODULE/ImplantDesign.php
@@ -4,9 +4,8 @@ namespace Nadybot\Modules\IMPLANT_MODULE;
 
 use function Safe\{json_decode, json_encode};
 
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Nadybot\Core\Attributes\DB\{MapRead, MapWrite, PK, Shared, Table};
-use Nadybot\Core\DBTable;
+use Nadybot\Core\{DBTable, Hydrator};
 
 #[Table(name: 'implant_design', shared: Shared::Yes)]
 class ImplantDesign extends DBTable {
@@ -23,19 +22,17 @@ class ImplantDesign extends DBTable {
 	}
 
 	public static function decodeDesign(?string $design): ?ImplantConfig {
-		if (!isset($design)) {
+		if (!isset($design) || $design === 'null') {
 			return null;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		return $mapper->hydrateObject(ImplantConfig::class, json_decode($design, true));
+		return Hydrator::hydrate(ImplantConfig::class, json_decode($design, true));
 	}
 
 	public static function encodeDesign(?object $design): ?string {
 		if (!isset($design)) {
 			return null;
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$mapped = $mapper->serializeObject($design);
+		$mapped = Hydrator::serialize($design);
 		foreach ($mapped as $key => $value) {
 			if ($value === null) {
 				unset($mapped[$key]);

--- a/src/Modules/IMPLANT_MODULE/ImplantDesign.php
+++ b/src/Modules/IMPLANT_MODULE/ImplantDesign.php
@@ -9,16 +9,18 @@ use Nadybot\Core\{DBTable, Hydrator};
 
 #[Table(name: 'implant_design', shared: Shared::Yes)]
 class ImplantDesign extends DBTable {
+	public int $dt;
+
 	public function __construct(
 		#[PK] public string $name,
 		#[PK] public string $owner,
-		public ?int $dt=null,
+		?int $dt=null,
 		#[
 			MapRead([self::class, 'decodeDesign']),
 			MapWrite([self::class, 'encodeDesign']),
 		] public ?ImplantConfig $design=null,
 	) {
-		$this->dt ??= time();
+		$this->dt = $dt ?? time();
 	}
 
 	public static function decodeDesign(?string $design): ?ImplantConfig {

--- a/src/Modules/ITEMS_MODULE/GmiController.php
+++ b/src/Modules/ITEMS_MODULE/GmiController.php
@@ -4,12 +4,13 @@ namespace Nadybot\Modules\ITEMS_MODULE;
 
 use function Safe\json_decode;
 use Amp\Http\Client\{HttpClientBuilder, Request};
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToHydrateObject};
+use EventSauce\ObjectHydrator\{UnableToHydrateObject};
 use Nadybot\Core\Types\ItemFlag;
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
 	Exceptions\UserException,
+	Hydrator,
 	ModuleInstance,
 	ParamClass\PItem,
 	Text,
@@ -64,11 +65,9 @@ class GmiController extends ModuleInstance {
 				);
 			}
 			$body = $response->getBody()->buffer();
-			$mapper = new ObjectMapperUsingReflection();
 			$json = json_decode($body, true);
 
-			/** @var GmiResult */
-			$gmiResult = $mapper->hydrateObject(GmiResult::class, $json);
+			$gmiResult = Hydrator::hydrate(GmiResult::class, $json);
 		} catch (UserException $e) {
 			throw $e;
 		} catch (JsonException $e) {

--- a/src/Modules/MOB_MODULE/MobController.php
+++ b/src/Modules/MOB_MODULE/MobController.php
@@ -5,11 +5,11 @@ namespace Nadybot\Modules\MOB_MODULE;
 use function Safe\json_decode;
 use Amp\Http\Client\{HttpClientBuilder, Request};
 use Closure;
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToHydrateObject};
+use EventSauce\ObjectHydrator\{UnableToHydrateObject};
 use Illuminate\Support\Collection;
 use Nadybot\Core\Attributes\{Event, HandlesCommand};
 use Nadybot\Core\Routing\{RoutableMessage, Source};
-use Nadybot\Core\{Attributes as NCA, CmdContext, MessageHub, ModuleInstance, Safe, Text, Util};
+use Nadybot\Core\{Attributes as NCA, CmdContext, Hydrator, MessageHub, ModuleInstance, Safe, Text, Util};
 use Nadybot\Modules\WHEREIS_MODULE\{Whereis, WhereisController};
 use Psr\Log\LoggerInterface;
 use Safe\Exceptions\JsonException;
@@ -95,15 +95,14 @@ class MobController extends ModuleInstance {
 		$body = $response->getBody()->buffer();
 
 		try {
-			/** @var array<string,array<mixed>> */
+			/** @var array<string,list<array<string,mixed>>> */
 			$json = json_decode($body, true);
-			$mapper = new ObjectMapperUsingReflection();
 
 			$this->mobs = [];
 			foreach ($json as $type => $entries) {
 				$this->mobs[$type] = [];
 
-				$mobs = $mapper->hydrateObjects(Mob::class, $entries)->getIterator();
+				$mobs = Hydrator::hydrateObjects(Mob::class, $entries)->getIterator();
 				foreach ($mobs as $mob) {
 					$this->mobs[$type][$mob->key] = $mob;
 				}
@@ -136,12 +135,11 @@ class MobController extends ModuleInstance {
 		$body = $response->getBody()->buffer();
 
 		try {
-			/** @var array<string,array<mixed>> */
+			/** @var array<string,list<array<string,mixed>>> */
 			$json = json_decode($body, true);
-			$mapper = new ObjectMapperUsingReflection();
 
 			foreach ($json as $entry) {
-				$mob = $mapper->hydrateObjects(Mob::class, $entry)->getIterator();
+				$mob = Hydrator::hydrateObjects(Mob::class, $entry)->getIterator();
 
 				/** @var Mob $mob */
 				if ($mob->key === $key) {

--- a/src/Modules/MOB_MODULE/MobFeedHandler.php
+++ b/src/Modules/MOB_MODULE/MobFeedHandler.php
@@ -3,9 +3,9 @@
 namespace Nadybot\Modules\MOB_MODULE;
 
 use Closure;
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToHydrateObject};
+use EventSauce\ObjectHydrator\{UnableToHydrateObject};
 use Nadybot\Core\Attributes as NCA;
-use Nadybot\Core\{EventManager, ModuleInstance, Types\EventFeedHandler};
+use Nadybot\Core\{EventManager, Hydrator, ModuleInstance, Types\EventFeedHandler};
 use Nadybot\Modules\MOB_MODULE\FeedMessage\Spawn;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -54,9 +54,8 @@ class MobFeedHandler extends ModuleInstance implements EventFeedHandler {
 			FeedMessage\Base::SPAWN  => FeedMessage\Spawn::class,
 			FeedMessage\Base::OOR    => FeedMessage\OutOfReach::class,
 		];
-		$mapper = new ObjectMapperUsingReflection();
 		try {
-			$baseInfo = $mapper->hydrateObject(FeedMessage\Base::class, $data);
+			$baseInfo = Hydrator::hydrate(FeedMessage\Base::class, $data);
 			$class = $mapping[$baseInfo->event] ?? null;
 			if (!isset($class)) {
 				$this->logger->notice('Unknown mob-event {type}: {data}', [
@@ -67,7 +66,7 @@ class MobFeedHandler extends ModuleInstance implements EventFeedHandler {
 			}
 
 			/** @var FeedMessage\Base */
-			$update = $mapper->hydrateObject($class, $data);
+			$update = Hydrator::hydrate($class, $data);
 			$mob = $this->mobCtrl->mobs[$update->type][$update->key]??null;
 			if (!isset($mob)) {
 				$this->logger->notice('Event for unknown mob: {type}/{key} - reloading from API', [

--- a/src/Modules/NEWS_MODULE/NewsController.php
+++ b/src/Modules/NEWS_MODULE/NewsController.php
@@ -6,7 +6,7 @@ use function Safe\preg_split;
 
 use Amp\Http\HttpStatus;
 use Amp\Http\Server\{Request, Response};
-use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion, ObjectMapperUsingReflection};
+use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion};
 use Exception;
 use Illuminate\Support\Collection;
 use Nadybot\Core\ParamClass\PUuid;
@@ -17,6 +17,7 @@ use Nadybot\Core\{
 	EventManager,
 	Events\JoinMyPrivEvent,
 	Events\LogonEvent,
+	Hydrator,
 	ModuleInstance,
 	Modules\ALTS\AltsController,
 	Nadybot,
@@ -432,11 +433,6 @@ class NewsController extends ModuleInstance {
 		$user = $request->getAttribute(WebserverController::USER) ?? '_';
 		$body = $request->getAttribute(WebserverController::BODY);
 		$this->logger->notice('Body: {body}', ['body' => $body]);
-		$mapper = new ObjectMapperUsingReflection(
-			new DefinitionProvider(
-				keyFormatter: new KeyFormatterWithoutConversion(),
-			),
-		);
 		try {
 			if (!is_array($body)) {
 				throw new Exception('Wrong content body');
@@ -450,7 +446,13 @@ class NewsController extends ModuleInstance {
 			];
 			$data = Util::mergeArraysRecursive($default, $body);
 
-			$news = $mapper->hydrateObject(News::class, $data);
+			$news = Hydrator::hydrate(
+				className: News::class,
+				data: $data,
+				definitionProvider: new DefinitionProvider(
+					keyFormatter: new KeyFormatterWithoutConversion(),
+				),
+			);
 		} catch (Throwable) {
 			return new Response(status: HttpStatus::UNPROCESSABLE_ENTITY);
 		}
@@ -477,18 +479,24 @@ class NewsController extends ModuleInstance {
 		}
 		$user = $request->getAttribute(WebserverController::USER) ?? '_';
 		$body = $request->getAttribute(WebserverController::BODY);
-		$mapper = new ObjectMapperUsingReflection(
-			new DefinitionProvider(
-				keyFormatter: new KeyFormatterWithoutConversion(),
-			),
-		);
 		try {
 			if (!is_array($body)) {
 				throw new Exception('Wrong content body');
 			}
-			$oldData = $mapper->serializeObject($oldItem);
+			$oldData = Hydrator::serialize(
+				object: $oldItem,
+				definitionProvider: new DefinitionProvider(
+					keyFormatter: new KeyFormatterWithoutConversion(),
+				),
+			);
 			$data = Util::mergeArraysRecursive($oldData, $body);
-			$news = $mapper->hydrateObject(News::class, $data);
+			$news = Hydrator::hydrate(
+				className: News::class,
+				data: $data,
+				definitionProvider: new DefinitionProvider(
+					keyFormatter: new KeyFormatterWithoutConversion(),
+				),
+			);
 		} catch (Throwable) {
 			return new Response(status: HttpStatus::UNPROCESSABLE_ENTITY);
 		}

--- a/src/Modules/PACKAGE_MODULE/PackageController.php
+++ b/src/Modules/PACKAGE_MODULE/PackageController.php
@@ -7,7 +7,7 @@ use Amp\File\{FileCache, FilesystemException};
 use Amp\Http\Client\{HttpClientBuilder, Request};
 use Amp\Sync\LocalKeyedMutex;
 use Amp\TimeoutCancellation;
-use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion, ObjectMapperUsingReflection};
+use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion};
 use Illuminate\Support\Collection;
 use Nadybot\Core\{
 	Attributes as NCA,
@@ -18,6 +18,7 @@ use Nadybot\Core\{
 	DB,
 	Exceptions\UserException,
 	Filesystem,
+	Hydrator,
 	ModuleInstance,
 	Nadybot,
 	ParamClass\PWord,
@@ -747,14 +748,14 @@ class PackageController extends ModuleInstance {
 			throw new UserException('Package data was not in the expected format');
 		}
 
-		$mapper = new ObjectMapperUsingReflection(
-			new DefinitionProvider(
-				keyFormatter: new KeyFormatterWithoutConversion(),
-			),
+		/** @var list<array<mixed>> $data */
+
+		$dp = new DefinitionProvider(
+			keyFormatter: new KeyFormatterWithoutConversion(),
 		);
 
 		$packages = new Collection(
-			$mapper->hydrateObjects(Package::class, $data)->toArray()
+			Hydrator::hydrateObjects(Package::class, $data, $dp)->toArray()
 		);
 		$packages = $packages->filter(static function (Package $package): bool {
 			return $package->bot_type === 'Nadybot';

--- a/src/Modules/PVP_MODULE/NotumWarsController.php
+++ b/src/Modules/PVP_MODULE/NotumWarsController.php
@@ -4,7 +4,7 @@ namespace Nadybot\Modules\PVP_MODULE;
 
 use function Safe\json_decode;
 use Amp\Http\Client\{HttpClientBuilder, Request};
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToHydrateObject};
+use EventSauce\ObjectHydrator\{UnableToHydrateObject};
 use Exception;
 use Illuminate\Support\Collection;
 use Nadybot\Core\Modules\PLAYER_LOOKUP\PlayerManager;
@@ -16,6 +16,7 @@ use Nadybot\Core\{
 	Config\BotConfig,
 	DB,
 	EventManager,
+	Hydrator,
 	MessageHub,
 	ModuleInstance,
 	Nadybot,
@@ -414,9 +415,8 @@ class NotumWarsController extends ModuleInstance {
 		$body = $response->getBody()->buffer();
 		try {
 			$json = json_decode($body, true);
-			$mapper = new ObjectMapperUsingReflection();
 
-			$sites = $mapper->hydrateObjects(FeedMessage\SiteUpdate::class, $json)->getIterator();
+			$sites = Hydrator::hydrateObjects(FeedMessage\SiteUpdate::class, $json)->getIterator();
 			foreach ($sites as $site) {
 				$this->updateSiteInfo($site);
 			}
@@ -475,9 +475,8 @@ class NotumWarsController extends ModuleInstance {
 		$body = $response->getBody()->buffer();
 		try {
 			$json = json_decode($body, true);
-			$mapper = new ObjectMapperUsingReflection();
 
-			$attacks = $mapper->hydrateObjects(FeedMessage\TowerAttack::class, $json);
+			$attacks = Hydrator::hydrateObjects(FeedMessage\TowerAttack::class, $json);
 
 			foreach ($attacks as $attack) {
 				$breedRequired = !isset($attack->attacker->breed)
@@ -537,9 +536,8 @@ class NotumWarsController extends ModuleInstance {
 		$body = $response->getBody()->buffer();
 		try {
 			$json = json_decode($body, true);
-			$mapper = new ObjectMapperUsingReflection();
 
-			$outcomes = $mapper->hydrateObjects(FeedMessage\TowerOutcome::class, $json);
+			$outcomes = Hydrator::hydrateObjects(FeedMessage\TowerOutcome::class, $json);
 
 			foreach ($outcomes as $outcome) {
 				$this->db->insert(DBOutcome::fromTowerOutcome($outcome));

--- a/src/Modules/PVP_MODULE/TowerFeedHandler.php
+++ b/src/Modules/PVP_MODULE/TowerFeedHandler.php
@@ -2,9 +2,9 @@
 
 namespace Nadybot\Modules\PVP_MODULE;
 
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToHydrateObject};
+use EventSauce\ObjectHydrator\{UnableToHydrateObject};
 use Nadybot\Core\Attributes as NCA;
-use Nadybot\Core\{EventManager, Events\Event as CoreEvent, ModuleInstance, Types\EventFeedHandler};
+use Nadybot\Core\{EventManager, Events\Event as CoreEvent, Hydrator, ModuleInstance, Types\EventFeedHandler};
 use Nadybot\Modules\PVP_MODULE\Event\{GasUpdateEvent, SiteUpdateEvent, TowerAttackEvent, TowerOutcomeEvent};
 use Psr\Log\LoggerInterface;
 
@@ -61,9 +61,8 @@ class TowerFeedHandler extends ModuleInstance implements EventFeedHandler {
 				Event\TowerOutcomeEvent::class,
 			],
 		];
-		$mapper = new ObjectMapperUsingReflection();
 		try {
-			$baseInfo = $mapper->hydrateObject(FeedMessage\Base::class, $data);
+			$baseInfo = Hydrator::hydrate(FeedMessage\Base::class, $data);
 			$specs = $mapping[$baseInfo->type] ?? null;
 			if (!isset($specs)) {
 				$this->logger->notice('Unknown tower-package {type}', [
@@ -71,7 +70,7 @@ class TowerFeedHandler extends ModuleInstance implements EventFeedHandler {
 				]);
 				return;
 			}
-			$info = $mapper->hydrateObject($specs[0], $data);
+			$info = Hydrator::hydrate($specs[0], $data);
 			$event = new ($specs[1])($info);
 			$this->logger->info('Received tower-feed event {event}', ['event' => $event]);
 			if ($event instanceof CoreEvent) {

--- a/src/Modules/RELAY_MODULE/Layer/Chunker.php
+++ b/src/Modules/RELAY_MODULE/Layer/Chunker.php
@@ -3,10 +3,10 @@
 namespace Nadybot\Modules\RELAY_MODULE\Layer;
 
 use function Safe\{json_decode, json_encode};
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use InvalidArgumentException;
 use Nadybot\Core\{
 	Attributes as NCA,
+	Hydrator,
 	Safe,
 	Util,
 };
@@ -90,11 +90,9 @@ class Chunker implements RelayLayerInterface {
 		foreach ($msg->packages as &$data) {
 			try {
 				$json = json_decode($data, true);
-				$mapper = new ObjectMapperUsingReflection();
 
-				/** @var Chunk */
-				$chunk = $mapper->hydrateObject(Chunk::class, $json);
-			} catch (Throwable $e) {
+				$chunk = Hydrator::hydrate(Chunk::class, $json);
+			} catch (Throwable) {
 				// Chunking is optional
 				continue;
 			}

--- a/src/Modules/RELAY_MODULE/Layer/Highway.php
+++ b/src/Modules/RELAY_MODULE/Layer/Highway.php
@@ -3,10 +3,10 @@
 namespace Nadybot\Modules\RELAY_MODULE\Layer;
 
 use function Safe\json_encode;
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToSerializeObject};
+use EventSauce\ObjectHydrator\{UnableToSerializeObject};
 use Exception;
 use Nadybot\Core\Highway\{In, Out, Parser, ParserHighwayException, ParserJsonException};
-use Nadybot\Core\{Attributes as NCA, Safe};
+use Nadybot\Core\{Attributes as NCA, Hydrator, Safe};
 use Nadybot\Modules\RELAY_MODULE\{
 	Relay,
 	RelayLayerInterface,
@@ -269,8 +269,7 @@ class Highway implements RelayLayerInterface, StatusProvider {
 	}
 
 	private function encodePackage(Out\OutPackage $package): string {
-		$mapper = new ObjectMapperUsingReflection();
-		$json = $mapper->serializeObject($package);
+		$json = Hydrator::serialize($package);
 		unset($json['id']);
 		return json_encode($json, \JSON_UNESCAPED_SLASHES|\JSON_UNESCAPED_UNICODE|\JSON_INVALID_UTF8_SUBSTITUTE);
 	}

--- a/src/Modules/RELAY_MODULE/RelayController.php
+++ b/src/Modules/RELAY_MODULE/RelayController.php
@@ -6,7 +6,6 @@ use function Safe\{json_decode, json_encode, preg_match, preg_split};
 
 use Amp\Http\HttpStatus;
 use Amp\Http\Server\{Request, Response};
-use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion, ObjectMapper, ObjectMapperUsingReflection};
 use Exception;
 use Illuminate\Support\Collection;
 use Nadybot\Core\Events\ConnectEvent;
@@ -22,6 +21,7 @@ use Nadybot\Core\{
 	DB,
 	EventManager,
 	EventType,
+	Hydrator,
 	MessageHub,
 	ModuleInstance,
 	Modules\PROFILE\ProfileCommandReply,
@@ -119,15 +119,6 @@ class RelayController extends ModuleInstance implements AccessLevelProvider {
 
 	#[NCA\Inject]
 	private EventManager $eventManager;
-
-	public function __construct(
-		private ObjectMapper $mapper=new ObjectMapperUsingReflection(
-			new DefinitionProvider(
-				keyFormatter: new KeyFormatterWithoutConversion(),
-			),
-		)
-	) {
-	}
 
 	#[NCA\Event(
 		name: ConnectEvent::EVENT_MASK,
@@ -1142,7 +1133,7 @@ class RelayController extends ModuleInstance implements AccessLevelProvider {
 
 		try {
 			/** @psalm-suppress PossiblyInvalidArgument */
-			$events = $this->mapper->hydrateObjects(RelayEvent::class, $body)->toArray();
+			$events = Hydrator::hydrateObjects(RelayEvent::class, $body)->toArray();
 		} catch (Throwable $e) {
 			return new Response(status: HttpStatus::UNPROCESSABLE_ENTITY);
 		}
@@ -1192,9 +1183,9 @@ class RelayController extends ModuleInstance implements AccessLevelProvider {
 			return new Response(status: HttpStatus::UNPROCESSABLE_ENTITY);
 		}
 		try {
-			$oldData = $this->mapper->serializeObject($relay);
+			$oldData = Hydrator::serialize($relay);
 			$update = Util::mergeArraysRecursive($oldData, $body);
-			$event = $this->mapper->hydrateObject(RelayEvent::class, $update);
+			$event = Hydrator::hydrate(RelayEvent::class, $update);
 		} catch (Throwable $e) {
 			return new Response(
 				status: HttpStatus::UNPROCESSABLE_ENTITY,
@@ -1262,7 +1253,7 @@ class RelayController extends ModuleInstance implements AccessLevelProvider {
 			return new Response(status: HttpStatus::UNPROCESSABLE_ENTITY);
 		}
 		try {
-			$relay = $this->mapper->hydrateObject(RelayConfig::class, $body);
+			$relay = Hydrator::hydrate(RelayConfig::class, $body);
 		} catch (Throwable $e) {
 			return new Response(status: HttpStatus::UNPROCESSABLE_ENTITY);
 		}

--- a/src/Modules/RELAY_MODULE/RelayProtocol/NadyNative.php
+++ b/src/Modules/RELAY_MODULE/RelayProtocol/NadyNative.php
@@ -4,13 +4,14 @@ namespace Nadybot\Modules\RELAY_MODULE\RelayProtocol;
 
 use function Safe\{json_decode, json_encode};
 
-use EventSauce\ObjectHydrator\{ObjectMapperUsingReflection, UnableToSerializeObject};
+use EventSauce\ObjectHydrator\{UnableToSerializeObject};
 use Nadybot\Core\Modules\ALTS\AltsController;
 use Nadybot\Core\{
 	Attributes as NCA,
 	Config\BotConfig,
 	EventManager,
 	Events\SyncEvent,
+	Hydrator,
 	Routing\Character,
 	Routing\Events\Base,
 	Routing\Events\Online,
@@ -90,9 +91,8 @@ class NadyNative implements RelayProtocolInterface {
 		} elseif (is_object($event->data) && !($event->data instanceof SyncEvent) && is_string($event->data->message??null)) {
 			$event->data->message = str_replace('<myname>', $this->config->main->character, $event->data->message??'');
 		}
-		$mapper = new ObjectMapperUsingReflection();
 		try {
-			$serialized = $mapper->serializeObject($event);
+			$serialized = Hydrator::serialize($event);
 			$data = json_encode($serialized, \JSON_UNESCAPED_SLASHES|\JSON_INVALID_UTF8_SUBSTITUTE);
 		} catch (JsonException | UnableToSerializeObject $e) {
 			$this->logger->error('Cannot send event via Nadynative protocol: {error}', [
@@ -128,7 +128,6 @@ class NadyNative implements RelayProtocolInterface {
 		if (!is_array($data)) {
 			return null;
 		}
-		$mapper = new ObjectMapperUsingReflection();
 		$data['type'] ??= RoutableEvent::TYPE_MESSAGE;
 		switch ($data['type']) {
 			case 'online_list_request':
@@ -138,7 +137,7 @@ class NadyNative implements RelayProtocolInterface {
 				return null;
 			case 'online_list':
 				if ($this->syncOnline) {
-					$cmd = $mapper->hydrateObject(OnlineList::class, $data);
+					$cmd = Hydrator::hydrate(OnlineList::class, $data);
 					$this->handleOnlineList($message->sender, $cmd);
 				}
 				return null;
@@ -169,7 +168,7 @@ class NadyNative implements RelayProtocolInterface {
 			&& isset($message->sender)
 			&& $this->syncOnline
 		) {
-			$event->data = $mapper->hydrateObject(Online::class, $eventData);
+			$event->data = Hydrator::hydrate(Online::class, $eventData);
 			$this->logger->debug('Received online event for {relay}: {event}', [
 				'relay' => $this->relay->getName(),
 				'event' => $event,

--- a/src/Modules/RELAY_MODULE/RelayProtocol/Tyrbot.php
+++ b/src/Modules/RELAY_MODULE/RelayProtocol/Tyrbot.php
@@ -3,11 +3,11 @@
 namespace Nadybot\Modules\RELAY_MODULE\RelayProtocol;
 
 use function Safe\{json_decode, json_encode};
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Nadybot\Core\{
 	Attributes as NCA,
 	Blob,
 	Config\BotConfig,
+	Hydrator,
 	Nadybot,
 	Routing\Character,
 	Routing\Events\Online,
@@ -101,10 +101,8 @@ class Tyrbot implements RelayProtocolInterface {
 		$serialized = array_shift($message->packages);
 		try {
 			$data = json_decode($serialized, true, 10, \JSON_UNESCAPED_SLASHES|\JSON_INVALID_UTF8_SUBSTITUTE);
-			$mapper = new ObjectMapperUsingReflection();
 
-			/** @var BasePacket */
-			$identify = $mapper->hydrateObject(BasePacket::class, $data);
+			$identify = Hydrator::hydrate(BasePacket::class, $data);
 			return $this->decodeAndHandlePacket($message->sender, $identify, $data);
 		} catch (JsonException $e) {
 			$this->logger->error('Invalid data received via Tyrbot protocol: {data}', [
@@ -159,10 +157,9 @@ class Tyrbot implements RelayProtocolInterface {
 			],
 			'source' => $this->nadyPathToTyr($r),
 		];
-		$mapper = new ObjectMapperUsingReflection();
 		$statePacket = $event->online
-			? $mapper->hydrateObject(Logon::class, $packet)
-			: $mapper->hydrateObject(Logoff::class, $packet);
+			? Hydrator::hydrate(Logon::class, $packet)
+			: Hydrator::hydrate(Logoff::class, $packet);
 		$data = $this->jsonEncode($statePacket);
 		return [$data];
 	}
@@ -238,19 +235,16 @@ class Tyrbot implements RelayProtocolInterface {
 
 	/** @param array<mixed> $data */
 	protected function decodeAndHandlePacket(?string $sender, BasePacket $identify, array $data): ?RoutableEvent {
-		$mapper = new ObjectMapperUsingReflection();
 		switch ($identify->type) {
 			case $identify::MESSAGE:
-				/** @var Message */
-				$message = $mapper->hydrateObject(Message::class, $data);
+				$message = Hydrator::hydrate(Message::class, $data);
 				return $this->receiveMessage($message);
 			case $identify::LOGON:
 				$this->logger->debug('Logon event received on {relay}', [
 					'relay' => $this->relay->getName(),
 				]);
 
-				/** @var Logon */
-				$logon = $mapper->hydrateObject(Logon::class, $data);
+				$logon = Hydrator::hydrate(Logon::class, $data);
 				$this->handleLogon($sender, $logon);
 				return null;
 			case $identify::LOGOFF:
@@ -258,8 +252,7 @@ class Tyrbot implements RelayProtocolInterface {
 					'relay' => $this->relay->getName(),
 				]);
 
-				/** @var Logoff */
-				$logoff = $mapper->hydrateObject(Logoff::class, $data);
+				$logoff = Hydrator::hydrate(Logoff::class, $data);
 				$this->handleLogoff($sender, $logoff);
 				return null;
 			case $identify::ONLINE_LIST_REQUEST:
@@ -273,8 +266,7 @@ class Tyrbot implements RelayProtocolInterface {
 					'relay' => $this->relay->getName(),
 				]);
 
-				/** @var OnlineList */
-				$onlineList = $mapper->hydrateObject(OnlineList::class, $data);
+				$onlineList = Hydrator::hydrate(OnlineList::class, $data);
 				$this->handleOnlineList($sender, $onlineList);
 				return null;
 			default:
@@ -376,10 +368,8 @@ class Tyrbot implements RelayProtocolInterface {
 			'source' => $privSource,
 			'users' => $privUsers,
 		];
-		$mapper = new ObjectMapperUsingReflection();
 
-		/** @var OnlineList */
-		$result = $mapper->hydrateObject(OnlineList::class, $onlineList);
+		$result = Hydrator::hydrate(OnlineList::class, $onlineList);
 		return $result;
 	}
 

--- a/src/Modules/WEATHER_MODULE/WeatherController.php
+++ b/src/Modules/WEATHER_MODULE/WeatherController.php
@@ -6,11 +6,12 @@ use function Safe\{json_decode, preg_match};
 use Amp\Cache\LocalCache;
 use Amp\Http\Client\Interceptor\AddRequestHeader;
 use Amp\Http\Client\{HttpClientBuilder, Request};
-use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion, ObjectMapperUsingReflection};
+use EventSauce\ObjectHydrator\{DefinitionProvider, KeyFormatterWithoutConversion};
 use Nadybot\Core\{
 	Attributes as NCA,
 	CmdContext,
 	Exceptions\UserException,
+	Hydrator,
 	ModuleInstance,
 	Safe,
 	Text,
@@ -320,8 +321,7 @@ class WeatherController extends ModuleInstance {
 		if (!count($data)) {
 			throw new UserException('Location not found');
 		}
-		$mapper = new ObjectMapperUsingReflection();
-		$nominatim = $mapper->hydrateObject(Nominatim::class, $data[0]);
+		$nominatim = Hydrator::hydrate(Nominatim::class, $data[0]);
 		return $nominatim;
 	}
 
@@ -342,12 +342,10 @@ class WeatherController extends ModuleInstance {
 				'<highlight>' . print_r($data, true) . '<end>.'
 			);
 		}
-		$mapper = new ObjectMapperUsingReflection(
-			new DefinitionProvider(
-				keyFormatter: new KeyFormatterWithoutConversion(),
-			)
+		$dp =  new DefinitionProvider(
+			keyFormatter: new KeyFormatterWithoutConversion(),
 		);
-		$weather = $mapper->hydrateObject(Weather::class, $data);
+		$weather = Hydrator::hydrate(Weather::class, $data, $dp);
 		return $weather;
 	}
 }

--- a/src/Modules/WEBSOCKET_MODULE/WebsocketController.php
+++ b/src/Modules/WEBSOCKET_MODULE/WebsocketController.php
@@ -7,7 +7,6 @@ use function Safe\json_decode;
 use Amp\Http\Server\{Request, Response};
 use Amp\Websocket\Server\{AllowOriginAcceptor, Websocket, WebsocketClientGateway, WebsocketClientHandler, WebsocketGateway};
 use Amp\Websocket\{WebsocketClient, WebsocketMessage};
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Exception;
 use Nadybot\Core\{
 	Attributes as NCA,
@@ -15,6 +14,7 @@ use Nadybot\Core\{
 	EventManager,
 	Events\Event,
 	Events\PackageEvent,
+	Hydrator,
 	MessageHub,
 	ModuleInstance,
 	Registry,
@@ -212,8 +212,7 @@ class WebsocketController extends ModuleInstance implements WebsocketClientHandl
 		$this->logger->info('[Data inc.] {data}', ['data' => $body]);
 		try {
 			$data = json_decode($body, true);
-			$mapper = new ObjectMapperUsingReflection();
-			$command = $mapper->hydrateObject(WebsocketCommand::class, $data);
+			$command = Hydrator::hydrate(WebsocketCommand::class, $data);
 			if (!in_array($command->command, $command::ALLOWED_COMMANDS, true)) {
 				throw new Exception();
 			}
@@ -223,11 +222,11 @@ class WebsocketController extends ModuleInstance implements WebsocketClientHandl
 		}
 		if ($command->command === $command::SUBSCRIBE) {
 			$newEvent = new WebsocketSubscribeEvent(
-				data: $mapper->hydrateObject(NadySubscribe::class, $command->data),
+				data: Hydrator::hydrate(NadySubscribe::class, $command->data),
 			);
 		} elseif ($command->command === $command::REQUEST) {
 			$newEvent = new WebsocketRequestEvent(
-				data: $mapper->hydrateObject(NadyRequest::class, $command->data),
+				data: Hydrator::hydrate(NadyRequest::class, $command->data),
 			);
 		} else {
 			// Unknown command received is just silently ignored in case another handler deals with it

--- a/src/Modules/WORLDBOSS_MODULE/GauntletBuffController.php
+++ b/src/Modules/WORLDBOSS_MODULE/GauntletBuffController.php
@@ -5,7 +5,6 @@ namespace Nadybot\Modules\WORLDBOSS_MODULE;
 use function Amp\delay;
 use function Safe\{json_decode, json_encode};
 use Amp\Http\Client\{HttpClientBuilder, Request};
-use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 use Exception;
 use Nadybot\Core\{
 	Attributes as NCA,
@@ -15,6 +14,7 @@ use Nadybot\Core\{
 	Events\ConnectEvent,
 	Events\JoinMyPrivEvent,
 	Events\LogonEvent,
+	Hydrator,
 	MessageHub,
 	ModuleInstance,
 	Nadybot,
@@ -496,14 +496,13 @@ class GauntletBuffController extends ModuleInstance implements MessageEmitter {
 
 		/** @var list<ApiGauntletBuff> */
 		$buffs = [];
-		$mapper = new ObjectMapperUsingReflection();
 		try {
 			$data = json_decode($body, true);
 			if (!is_array($data)) {
 				throw new JsonException();
 			}
 			foreach ($data as $gauntletData) {
-				$buffs []= $mapper->hydrateObject(ApiGauntletBuff::class, $gauntletData);
+				$buffs []= Hydrator::hydrate(ApiGauntletBuff::class, $gauntletData);
 			}
 		} catch (JsonException) {
 			$this->logger->error('Gauntlet buff API sent invalid json.');


### PR DESCRIPTION
By default, the bot will now compile hydrators and serializers for improved speed and reduced CPU.
This introduces a wrapper that is to be used instead of the low-level eventsauce/hydration library, so we're independent of them.